### PR TITLE
fix: resolve artifact download issues in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           name: turbo-build-${{ github.event.workflow_run.head_sha }}-cli
           path: turbo/apps/cli/dist
 
@@ -62,11 +63,14 @@ jobs:
       - name: Push database schema
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         run: cd turbo/apps/web && pnpm db:migrate
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           name: turbo-build-${{ github.event.workflow_run.head_sha }}-web
           path: .vercel/output
 
@@ -95,8 +99,9 @@ jobs:
       - uses: ./.github/actions/init
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           name: turbo-build-${{ github.event.workflow_run.head_sha }}-docs
           path: .vercel/output
 


### PR DESCRIPTION
This PR fixes the artifact download issues in the release-please workflow that were causing deployment failures.

## 🐛 Problem
The release-please workflow was failing to download artifacts from the triggering Turbo workflow due to GitHub Actions limitations:
- Standard  cannot access artifacts from other workflow runs
- This caused failures in CLI publishing and production deployments
- Missing Clerk environment variables in database migration step

## 🔧 Solution
- **Replace artifact download action**: Use  with  parameter
- **Cross-workflow support**: Properly reference the triggering workflow run ID
- **Environment variables**: Add missing Clerk vars to database migration step

## 🎯 Impact
- ✅ CLI publishing will work when release PR is merged
- ✅ Production web deployment will work
- ✅ Production docs deployment will work  
- ✅ Database migrations will have proper environment variables

## 🧪 Test Plan
- [x] Verify workflow syntax is valid
- [ ] Test with actual release PR merge
- [ ] Confirm artifacts are downloaded successfully
- [ ] Verify production deployments complete