### PR TITLE
feat: add docker toolchain with layered build and github registry integration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,36 +1,16 @@
 {
-  "name": "Node.js & TypeScript",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "22"
-    },
-    "ghcr.io/devcontainers-extra/features/pnpm:2": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-extra/features/lefthook-asdf:1": {},
-    "ghcr.io/itsmechlark/features/postgresql:1": {},
-    "ghcr.io/guiyomh/features/vim:0": {},
-    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
-  },
-  "forwardPorts": [4983],
-  "remoteEnv": {
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",
-    "HISTFILE": "/home/vscode/.cache/.zsh_history",
-    "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/postgres"
-  },
-  "mounts": [
-    "source=config,target=/home/vscode/.config",
-    "source=cache,target=/home/vscode/.cache",
-    "source=vercel,target=/home/vscode/.local/share/com.vercel.cli"
-  ],
-  "postCreateCommand": "sudo mkdir -p /home/vscode/.local/bin && sudo chown -R vscode:vscode /home/vscode/.config /home/vscode/.cache /home/vscode/.local && npm install -g vercel",
+  "name": "USpark Development",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [4983, 5432],
   "customizations": {
     "vscode": {
       "settings": {
         "sqltools.connections": [
           {
             "previewLimit": 50,
-            "server": "localhost",
+            "server": "db",
             "port": 5432,
             "driver": "PostgreSQL",
             "name": "local",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,13 +5,13 @@ services:
     image: ghcr.io/uspark-hq/uspark-dev:latest
     volumes:
       - ..:/workspace:cached
-      - config:/home/vscode/.config
-      - cache:/home/vscode/.cache
-      - vercel:/home/vscode/.local/share/com.vercel.cli
+      - config:/home/uspark/.config
+      - cache:/home/uspark/.cache
+      - vercel:/home/uspark/.local/share/com.vercel.cli
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
-      CLAUDE_CONFIG_DIR: /home/vscode/.config/claude
-      HISTFILE: /home/vscode/.cache/.zsh_history
+      CLAUDE_CONFIG_DIR: /home/uspark/.config/claude
+      HISTFILE: /home/uspark/.cache/.zsh_history
     command: sleep infinity
     networks:
       - uspark-network

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/uspark-hq/uspark-dev:latest
+    volumes:
+      - ..:/workspace:cached
+      - config:/home/vscode/.config
+      - cache:/home/vscode/.cache
+      - vercel:/home/vscode/.local/share/com.vercel.cli
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
+      CLAUDE_CONFIG_DIR: /home/vscode/.config/claude
+      HISTFILE: /home/vscode/.cache/.zsh_history
+    command: sleep infinity
+    networks:
+      - uspark-network
+
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - uspark-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  config:
+  cache:
+  vercel:
+  postgres-data:
+
+networks:
+  uspark-network:
+    driver: bridge

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - vercel:/home/uspark/.local/share/com.vercel.cli
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/postgres
-      CLAUDE_CONFIG_DIR: /home/uspark/.config/claude
-      HISTFILE: /home/uspark/.cache/.zsh_history
     command: sleep infinity
     networks:
       - uspark-network

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,42 @@
+name: Docker Build
+
+on:
+  pull_request:
+    paths:
+      - 'toolchain/**'
+      - '.github/workflows/docker-*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build toolchain image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./toolchain
+          file: ./toolchain/Dockerfile
+          target: toolchain
+          push: false
+          tags: uspark-toolchain:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build development image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./toolchain
+          file: ./toolchain/Dockerfile
+          target: development
+          push: false
+          tags: uspark-dev:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'toolchain/**'
-      - '.devcontainer/**'
       - '.github/workflows/docker-*.yml'
 
 permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'toolchain/**'
+      - '.devcontainer/**'
       - '.github/workflows/docker-*.yml'
 
 permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,73 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'toolchain/**'
+      - '.github/workflows/docker-*.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Build and push toolchain image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./toolchain
+          file: ./toolchain/Dockerfile
+          target: toolchain
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/uspark-hq/uspark-toolchain:latest
+            ${{ env.REGISTRY }}/uspark-hq/uspark-toolchain:${{ steps.meta.outputs.sha_short }}
+            ${{ env.REGISTRY }}/uspark-hq/uspark-toolchain:${{ steps.meta.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push development image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./toolchain
+          file: ./toolchain/Dockerfile
+          target: development
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/uspark-hq/uspark-dev:latest
+            ${{ env.REGISTRY }}/uspark-hq/uspark-dev:${{ steps.meta.outputs.sha_short }}
+            ${{ env.REGISTRY }}/uspark-hq/uspark-dev:${{ steps.meta.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'toolchain/**'
-      - '.devcontainer/**'
       - '.github/workflows/docker-*.yml'
 
 permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'toolchain/**'
+      - '.devcontainer/**'
       - '.github/workflows/docker-*.yml'
 
 permissions:

--- a/toolchain/.dockerignore
+++ b/toolchain/.dockerignore
@@ -1,0 +1,58 @@
+# Git
+.git
+.gitignore
+
+# Node modules
+node_modules
+**/node_modules
+
+# Build outputs
+dist
+build
+.next
+out
+
+# Cache and temp files
+.cache
+tmp
+temp
+*.tmp
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+.env.*
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Test coverage
+coverage
+.nyc_output
+
+# Documentation
+*.md
+docs
+
+# CI/CD
+.github
+.circleci
+.gitlab-ci.yml
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -1,0 +1,81 @@
+# Stage 1: Base toolchain for CI/CD and minimal development
+FROM ubuntu:22.04 AS toolchain
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install base dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    gnupg \
+    lsb-release \
+    ca-certificates \
+    sudo \
+    zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pnpm 10
+RUN npm install -g pnpm@10.0.0
+
+# Install lefthook for git hooks
+RUN curl -fsSL https://raw.githubusercontent.com/evilmartians/lefthook/master/install.sh | bash \
+    && mv lefthook /usr/local/bin/
+
+# Create non-root user
+RUN useradd -m -s /usr/bin/zsh vscode \
+    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Switch to non-root user
+USER vscode
+WORKDIR /home/vscode
+
+# Set up shell environment
+RUN touch ~/.zshrc
+
+# Stage 2: Development environment with additional tools
+FROM toolchain AS development
+
+# Switch back to root for installations
+USER root
+
+# Install development tools
+RUN apt-get update && apt-get install -y \
+    vim \
+    ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Vercel CLI globally
+RUN npm install -g vercel
+
+# Create directories that will be mounted as volumes
+RUN mkdir -p /home/vscode/.config \
+    && mkdir -p /home/vscode/.cache \
+    && mkdir -p /home/vscode/.local/share/com.vercel.cli \
+    && mkdir -p /home/vscode/.local/bin \
+    && chown -R vscode:vscode /home/vscode/.config \
+    && chown -R vscode:vscode /home/vscode/.cache \
+    && chown -R vscode:vscode /home/vscode/.local
+
+# Switch back to non-root user
+USER vscode
+
+# Set environment variables for development
+ENV CLAUDE_CONFIG_DIR=/home/vscode/.config/claude
+ENV HISTFILE=/home/vscode/.cache/.zsh_history
+
+# Default command
+CMD ["/usr/bin/zsh"]

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     lsb-release \
     ca-certificates \
-    sudo \
-    zsh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 22
@@ -36,8 +34,10 @@ WORKDIR /workspace
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development
 
-# Install development tools
+# Install development tools and user requirements
 RUN apt-get update && apt-get install -y \
+    sudo \
+    zsh \
     vim \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -50,8 +50,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Vercel CLI globally
-RUN npm install -g vercel
+# Install Vercel CLI globally (locked version)
+RUN npm install -g vercel@46.1.1
 
 # Create non-root user
 RUN useradd -m -s /usr/bin/zsh uspark \

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -20,12 +20,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm 10
-RUN npm install -g pnpm@10.0.0
+# Install pnpm 10.15.0 and set up
+RUN npm install -g pnpm@10.15.0 \
+    && pnpm setup \
+    && echo 'export PNPM_HOME="/root/.local/share/pnpm"' >> /etc/profile.d/pnpm.sh \
+    && echo 'export PATH="$PNPM_HOME:$PATH"' >> /etc/profile.d/pnpm.sh
 
-# Install lefthook for git hooks
-RUN curl -fsSL https://raw.githubusercontent.com/evilmartians/lefthook/master/install.sh | bash \
-    && mv lefthook /usr/local/bin/
+# Install lefthook using pnpm
+RUN /root/.local/share/pnpm/pnpm install -g lefthook@1.12.3
 
 # Create non-root user
 RUN useradd -m -s /usr/bin/zsh vscode \
@@ -35,8 +37,10 @@ RUN useradd -m -s /usr/bin/zsh vscode \
 USER vscode
 WORKDIR /home/vscode
 
-# Set up shell environment
-RUN touch ~/.zshrc
+# Set up shell environment and pnpm for vscode user
+RUN pnpm setup \
+    && echo 'export PNPM_HOME="/home/vscode/.local/share/pnpm"' >> ~/.zshrc \
+    && echo 'export PATH="$PNPM_HOME:$PATH"' >> ~/.zshrc
 
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -30,24 +30,11 @@ RUN npm install -g pnpm@10.15.0 \
 # Install lefthook using pnpm
 RUN . /etc/profile.d/pnpm.sh && pnpm install -g lefthook@1.12.3
 
-# Create non-root user
-RUN useradd -m -s /usr/bin/zsh uspark \
-    && echo "uspark ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# Switch to non-root user
-USER uspark
-WORKDIR /home/uspark
-
-# Set up shell environment and pnpm for uspark user
-RUN SHELL=/usr/bin/zsh pnpm setup \
-    && echo 'export PNPM_HOME="/home/uspark/.local/share/pnpm"' >> ~/.zshrc \
-    && echo 'export PATH="$PNPM_HOME:$PATH"' >> ~/.zshrc
+# Keep as root user for CI/CD usage
+WORKDIR /workspace
 
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development
-
-# Switch back to root for installations
-USER root
 
 # Install development tools
 RUN apt-get update && apt-get install -y \
@@ -66,6 +53,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # Install Vercel CLI globally
 RUN npm install -g vercel
 
+# Create non-root user
+RUN useradd -m -s /usr/bin/zsh uspark \
+    && echo "uspark ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 # Create directories that will be mounted as volumes
 RUN mkdir -p /home/uspark/.config \
     && mkdir -p /home/uspark/.cache \
@@ -75,8 +66,14 @@ RUN mkdir -p /home/uspark/.config \
     && chown -R uspark:uspark /home/uspark/.cache \
     && chown -R uspark:uspark /home/uspark/.local
 
-# Switch back to non-root user
+# Switch to non-root user and set up pnpm
 USER uspark
+WORKDIR /home/uspark
+
+# Set up shell environment and pnpm for uspark user
+RUN SHELL=/usr/bin/zsh pnpm setup \
+    && echo 'export PNPM_HOME="/home/uspark/.local/share/pnpm"' >> ~/.zshrc \
+    && echo 'export PATH="$PNPM_HOME:$PATH"' >> ~/.zshrc
 
 # Set environment variables for development
 ENV CLAUDE_CONFIG_DIR=/home/uspark/.config/claude

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -21,25 +21,26 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm 10.15.0 and set up
+ENV SHELL=/bin/bash
 RUN npm install -g pnpm@10.15.0 \
-    && pnpm setup \
+    && SHELL=/bin/bash pnpm setup \
     && echo 'export PNPM_HOME="/root/.local/share/pnpm"' >> /etc/profile.d/pnpm.sh \
     && echo 'export PATH="$PNPM_HOME:$PATH"' >> /etc/profile.d/pnpm.sh
 
 # Install lefthook using pnpm
-RUN /root/.local/share/pnpm/pnpm install -g lefthook@1.12.3
+RUN . /etc/profile.d/pnpm.sh && pnpm install -g lefthook@1.12.3
 
 # Create non-root user
-RUN useradd -m -s /usr/bin/zsh vscode \
-    && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN useradd -m -s /usr/bin/zsh uspark \
+    && echo "uspark ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Switch to non-root user
-USER vscode
-WORKDIR /home/vscode
+USER uspark
+WORKDIR /home/uspark
 
-# Set up shell environment and pnpm for vscode user
-RUN pnpm setup \
-    && echo 'export PNPM_HOME="/home/vscode/.local/share/pnpm"' >> ~/.zshrc \
+# Set up shell environment and pnpm for uspark user
+RUN SHELL=/usr/bin/zsh pnpm setup \
+    && echo 'export PNPM_HOME="/home/uspark/.local/share/pnpm"' >> ~/.zshrc \
     && echo 'export PATH="$PNPM_HOME:$PATH"' >> ~/.zshrc
 
 # Stage 2: Development environment with additional tools
@@ -66,20 +67,20 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 RUN npm install -g vercel
 
 # Create directories that will be mounted as volumes
-RUN mkdir -p /home/vscode/.config \
-    && mkdir -p /home/vscode/.cache \
-    && mkdir -p /home/vscode/.local/share/com.vercel.cli \
-    && mkdir -p /home/vscode/.local/bin \
-    && chown -R vscode:vscode /home/vscode/.config \
-    && chown -R vscode:vscode /home/vscode/.cache \
-    && chown -R vscode:vscode /home/vscode/.local
+RUN mkdir -p /home/uspark/.config \
+    && mkdir -p /home/uspark/.cache \
+    && mkdir -p /home/uspark/.local/share/com.vercel.cli \
+    && mkdir -p /home/uspark/.local/bin \
+    && chown -R uspark:uspark /home/uspark/.config \
+    && chown -R uspark:uspark /home/uspark/.cache \
+    && chown -R uspark:uspark /home/uspark/.local
 
 # Switch back to non-root user
-USER vscode
+USER uspark
 
 # Set environment variables for development
-ENV CLAUDE_CONFIG_DIR=/home/vscode/.config/claude
-ENV HISTFILE=/home/vscode/.cache/.zsh_history
+ENV CLAUDE_CONFIG_DIR=/home/uspark/.config/claude
+ENV HISTFILE=/home/uspark/.cache/.zsh_history
 
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary
- Convert devcontainer setup to layered Dockerfile approach
- Set up CI/CD for building and publishing Docker images to GitHub Container Registry
- Implement two-stage build: base toolchain for CI/CD and full dev environment

## Changes
- Created multi-stage Dockerfile with `toolchain` (minimal) and `development` (full) stages
- Added docker-compose.yml for PostgreSQL service (matching GitHub Actions setup)
- Created GitHub workflows for PR validation and main branch publishing
- Updated devcontainer to use docker-compose with registry images
- Removed devcontainer features in favor of explicit Dockerfile commands

## Docker Images
Two images will be published to GitHub Container Registry:
- `ghcr.io/uspark-hq/uspark-toolchain`: Minimal toolchain for CI/CD (Node.js, PNPM, Lefthook)
- `ghcr.io/uspark-hq/uspark-dev`: Full development environment (includes Vim, Ripgrep, GitHub CLI, Vercel)

## Benefits
- Faster builds with better layer caching
- Consistent environments across dev/CI/prod
- PostgreSQL as external service (not bundled in image)
- Automatic image updates on main branch commits