### PR TITLE
fix: set remoteUser to uspark in devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
+  "remoteUser": "uspark",
   "forwardPorts": [4983, 5432],
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary
- Sets remoteUser to 'uspark' in devcontainer.json to match the Docker image's user configuration
- Fixes pnpm permission errors where it was trying to use /root/.local/share/pnpm instead of /home/uspark/.local/share/pnpm

## Problem
The devcontainer was running as 'vscode' user but the Docker image configures pnpm for the 'uspark' user, causing permission errors when running pnpm commands.

## Solution
Added `remoteUser: "uspark"` to ensure VS Code runs as the correct user with proper pnpm configuration.