### PR TITLE
docs: add comprehensive CLI authentication API documentation

### DIFF
--- a/turbo/apps/docs/content/docs/api/cli-auth.mdx
+++ b/turbo/apps/docs/content/docs/api/cli-auth.mdx
@@ -1,0 +1,389 @@
+---
+title: CLI Authentication API
+description: Device authorization flow for CLI authentication
+---
+
+# CLI Authentication API
+
+The CLI Authentication API provides secure device authorization flow for authenticating CLI clients using a browser-based authentication process.
+
+## Overview
+
+This API implements a device authorization flow similar to GitHub CLI, where:
+1. CLI requests a device code
+2. User enters the code in their browser to authenticate
+3. CLI polls for the authentication result
+4. CLI receives an access token for API calls
+
+## Endpoints
+
+### POST /api/cli/auth/device
+
+Initiates the device authorization flow by generating a unique device code.
+
+#### Request Body
+
+```json
+{}
+```
+
+*Note: This endpoint accepts an empty request body.*
+
+#### Response
+
+```json
+{
+  "device_code": "WDJB-MJHT",
+  "user_code": "WDJB-MJHT", 
+  "verification_url": "https://app.uspark.com/cli-auth",
+  "expires_in": 900,
+  "interval": 5
+}
+```
+
+#### Response Fields
+
+- **device_code**: The device verification code (8 characters in XXXX-XXXX format)
+- **user_code**: User-friendly verification code (same as device_code)
+- **verification_url**: URL where user should enter the device code
+- **expires_in**: Code lifetime in seconds (15 minutes)
+- **interval**: Minimum polling interval in seconds (5 seconds)
+
+#### Example Request
+
+```bash
+curl -X POST https://app.uspark.com/api/cli/auth/device \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+#### Error Responses
+
+**429 Rate Limit Exceeded**
+```json
+{
+  "error": "rate_limit_exceeded",
+  "error_description": "Too many device code requests",
+  "retry_after": 60
+}
+```
+
+### POST /api/cli/auth/token
+
+Exchanges device code for access token. CLI should poll this endpoint until authentication is complete.
+
+#### Request Body
+
+```json
+{
+  "device_code": "WDJB-MJHT"
+}
+```
+
+#### Successful Response (200)
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "optional_refresh_token",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+#### Pending Response (202)
+
+Returned when user hasn't completed authentication yet:
+
+```json
+{
+  "error": "authorization_pending",
+  "error_description": "The user has not yet completed authorization"
+}
+```
+
+#### Error Responses
+
+**400 Bad Request**
+```json
+{
+  "error": "expired_token",
+  "error_description": "The device code has expired"
+}
+```
+
+**404 Not Found**
+```json
+{
+  "error": "invalid_grant", 
+  "error_description": "Invalid or unknown device code"
+}
+```
+
+#### Example Polling Logic
+
+```bash
+# Request device code
+RESPONSE=$(curl -X POST https://app.uspark.com/api/cli/auth/device)
+DEVICE_CODE=$(echo $RESPONSE | jq -r '.device_code')
+
+# Poll for token
+while true; do
+  TOKEN_RESPONSE=$(curl -X POST https://app.uspark.com/api/cli/auth/token \
+    -H "Content-Type: application/json" \
+    -d "{\"device_code\": \"$DEVICE_CODE\"}")
+  
+  if echo $TOKEN_RESPONSE | jq -e '.access_token' > /dev/null; then
+    echo "Authentication successful!"
+    break
+  fi
+  
+  sleep 5
+done
+```
+
+### POST /api/cli/auth/generate-token
+
+Generates long-lived CLI tokens for CI/CD usage. Requires authentication via Bearer token.
+
+#### Headers
+
+```json
+{
+  "Authorization": "Bearer <jwt_token>"
+}
+```
+
+#### Request Body
+
+```json
+{
+  "name": "GitHub Actions CI",
+  "expires_in_days": 90
+}
+```
+
+#### Response
+
+```json
+{
+  "token": "usp_live_abc123...",
+  "name": "GitHub Actions CI",
+  "expires_at": "2024-04-15T10:30:00.000Z",
+  "created_at": "2024-01-15T10:30:00.000Z"
+}
+```
+
+#### Error Responses
+
+**401 Unauthorized**
+```json
+{
+  "error": "unauthorized",
+  "error_description": "Invalid or missing Bearer token"
+}
+```
+
+**403 Token Limit Exceeded**
+```json
+{
+  "error": "token_limit_exceeded", 
+  "error_description": "Maximum number of active tokens reached",
+  "max_tokens": 10
+}
+```
+
+#### Example Request
+
+```bash
+curl -X POST https://app.uspark.com/api/cli/auth/generate-token \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production CI/CD",
+    "expires_in_days": 30
+  }'
+```
+
+## Device Code Format
+
+Device codes follow the pattern `XXXX-XXXX` where:
+- Each character is uppercase letter or number  
+- Excludes confusing characters (0, O, 1, I, L)
+- Total of 8 characters with a dash separator
+- Example: `WDJB-MJHT`, `P3R4-N8M9`
+
+## Authentication Flow
+
+### CLI Interactive Login
+
+```bash
+# 1. User runs login command
+uspark auth login
+
+# 2. CLI requests device code
+# POST /api/cli/auth/device
+
+# 3. CLI displays instructions
+echo "Visit https://app.uspark.com/cli-auth and enter code: WDJB-MJHT"
+
+# 4. CLI polls for token
+# POST /api/cli/auth/token (every 5 seconds)
+
+# 5. Store token securely
+# CLI stores token in system keychain
+```
+
+### Environment Variable Authentication
+
+```bash
+# Direct token usage (useful for CI/CD)
+USPARK_TOKEN=usp_live_abc123... uspark sync
+```
+
+## TypeScript Types
+
+The API contracts are defined in `@uspark/core`:
+
+```typescript
+import { 
+  DeviceAuthRequest, 
+  DeviceAuthResponse,
+  TokenExchangeRequest,
+  TokenExchangeSuccess,
+  TokenExchangePending
+} from "@uspark/core";
+
+// Device authorization request (empty object)
+type DeviceAuthRequest = {};
+
+// Device authorization response
+type DeviceAuthResponse = {
+  device_code: string;      // XXXX-XXXX format
+  user_code: string;        // Same as device_code
+  verification_url: string; // https://app.uspark.com/cli-auth
+  expires_in: number;       // 900 (15 minutes)
+  interval: number;         // 5 (seconds)
+};
+
+// Token exchange request
+type TokenExchangeRequest = {
+  device_code: string;
+};
+
+// Token exchange success response  
+type TokenExchangeSuccess = {
+  access_token: string;
+  refresh_token?: string;
+  token_type: "Bearer";
+  expires_in: number;
+};
+
+// Token exchange pending response
+type TokenExchangePending = {
+  error: "authorization_pending";
+  error_description: string;
+};
+```
+
+## Security Considerations
+
+### Token Security
+- **Storage**: CLI tokens stored in system keychain (using `keytar`)
+- **Transmission**: All API calls use HTTPS
+- **Expiration**: Device codes expire in 15 minutes
+- **Scope**: Tokens have limited scope for CLI operations
+
+### Rate Limiting
+- Device code requests are rate limited to prevent abuse
+- Failed authentication attempts are tracked
+- Slow down requests if polling too frequently
+
+### Token Management
+- Users can view and revoke tokens from web UI
+- Maximum number of active tokens per user (typically 10)
+- Tokens include metadata (name, creation date, last used)
+
+## Testing Examples
+
+### Using cURL
+
+```bash
+# Complete authentication flow
+echo "=== Step 1: Request device code ==="
+RESPONSE=$(curl -s -X POST https://app.uspark.com/api/cli/auth/device \
+  -H "Content-Type: application/json" -d '{}')
+
+DEVICE_CODE=$(echo $RESPONSE | jq -r '.device_code')
+VERIFICATION_URL=$(echo $RESPONSE | jq -r '.verification_url')
+
+echo "Visit $VERIFICATION_URL and enter code: $DEVICE_CODE"
+
+echo "=== Step 2: Poll for token ==="
+while true; do
+  TOKEN_RESPONSE=$(curl -s -X POST https://app.uspark.com/api/cli/auth/token \
+    -H "Content-Type: application/json" \
+    -d "{\"device_code\": \"$DEVICE_CODE\"}")
+  
+  if echo $TOKEN_RESPONSE | jq -e '.access_token' > /dev/null; then
+    ACCESS_TOKEN=$(echo $TOKEN_RESPONSE | jq -r '.access_token')
+    echo "Got access token: ${ACCESS_TOKEN:0:20}..."
+    break
+  fi
+  
+  ERROR=$(echo $TOKEN_RESPONSE | jq -r '.error // empty')
+  if [[ "$ERROR" != "authorization_pending" && "$ERROR" != "" ]]; then
+    echo "Error: $ERROR"
+    break
+  fi
+  
+  echo "Waiting for authentication..."
+  sleep 5
+done
+```
+
+### Using TypeScript/Node.js
+
+```typescript
+import { cliAuthContract } from "@uspark/core";
+
+async function authenticateCLI() {
+  // Step 1: Request device code
+  const deviceResponse = await fetch("/api/cli/auth/device", {
+    method: "POST", 
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  
+  const deviceData = await deviceResponse.json();
+  console.log(`Visit ${deviceData.verification_url} and enter: ${deviceData.device_code}`);
+  
+  // Step 2: Poll for token
+  while (true) {
+    await new Promise(resolve => setTimeout(resolve, deviceData.interval * 1000));
+    
+    const tokenResponse = await fetch("/api/cli/auth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ device_code: deviceData.device_code })
+    });
+    
+    const tokenData = await tokenResponse.json();
+    
+    if (tokenData.access_token) {
+      console.log("Authentication successful!");
+      return tokenData.access_token;
+    }
+    
+    if (tokenData.error !== "authorization_pending") {
+      throw new Error(`Authentication failed: ${tokenData.error}`);
+    }
+  }
+}
+```
+
+## Related Resources
+
+- [CLI Authentication Specification](/spec/cli-auth.md) - Detailed implementation spec
+- [Hello API](/api/hello) - Example API endpoint documentation
+- [Web Authentication Flow](/cli-auth) - Browser-based auth page

--- a/turbo/apps/docs/content/docs/api/meta.json
+++ b/turbo/apps/docs/content/docs/api/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "API Reference",
-  "pages": ["hello"]
+  "title": "API Reference", 
+  "pages": ["hello", "cli-auth"]
 }


### PR DESCRIPTION
Addresses ##36

Adds complete CLI authentication API documentation covering all auth-related endpoints:

- `POST /api/cli/auth/device` - Device authorization flow initiation
- `POST /api/cli/auth/token` - Token exchange and polling endpoint
- `POST /api/cli/auth/generate-token` - Long-lived token generation for CI/CD

The documentation includes TypeScript types, error handling, security considerations, and practical examples in both cURL and TypeScript/Node.js.

Generated with [Claude Code](https://claude.ai/code)