### PR TITLE
feat: implement cli token generation api endpoint

### DIFF
--- a/spec/cli-auth.md
+++ b/spec/cli-auth.md
@@ -152,11 +152,11 @@ app/
 **Task**: Implement `/api/cli/auth/generate-token` endpoint
 **Acceptance Criteria**:
 
-- [ ] Requires authenticated user (Clerk JWT)
-- [ ] Generates long-lived CLI token (30-90 days)
-- [ ] Stores token metadata (name, created_at, last_used)
-- [ ] Returns token and expiration date
-- [ ] Limits number of active tokens per user (e.g., 10)
+- [x] Requires authenticated user (Clerk JWT)
+- [x] Generates long-lived CLI token (30-90 days)
+- [x] Stores token metadata (name, created_at, last_used)
+- [x] Returns token and expiration date
+- [x] Limits number of active tokens per user (e.g., 10)
 
 ### Phase 2: Web UI Implementation
 

--- a/turbo/apps/web/app/api/cli/auth/device/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.test.ts
@@ -55,6 +55,10 @@ describe("/api/cli/auth/device", () => {
     const storedCode = storedCodes[0];
     expect(storedCode).toBeDefined();
 
+    if (!storedCode) {
+      throw new Error("Device code was not stored in database");
+    }
+
     // Verify all fields are correctly stored
     expect(storedCode.code).toBe(deviceCode);
     expect(storedCode.status).toBe("pending");

--- a/turbo/apps/web/app/api/cli/auth/generate-token/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/generate-token/route.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "./route";
+import { NextRequest } from "next/server";
+import {
+  GenerateTokenResponseSchema,
+  GenerateTokenErrorSchema,
+} from "@uspark/core";
+import { CLI_TOKENS_TBL } from "../../../../../src/db/schema/cli-tokens";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+
+// Mock Clerk auth
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+
+describe("/api/cli/auth/generate-token", () => {
+  beforeEach(async () => {
+    // Clean up any existing tokens before each test
+    initServices();
+    await globalThis.services.db.delete(CLI_TOKENS_TBL);
+  });
+
+  it("should generate a new CLI token for authenticated user", async () => {
+    // Mock authenticated user
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "GitHub Actions CI",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenResponseSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      const validData = validationResult.data;
+
+      // Check token format
+      expect(validData.token).toMatch(/^usp_live_[A-Za-z0-9_-]+$/);
+      expect(validData.name).toBe("GitHub Actions CI");
+
+      // Check expiration is approximately 30 days from now
+      const expiresAt = new Date(validData.expires_at);
+      const now = new Date();
+      const diffInDays =
+        (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diffInDays).toBeGreaterThan(29);
+      expect(diffInDays).toBeLessThanOrEqual(30);
+    }
+
+    // Verify token was stored in database
+    const storedTokens = await globalThis.services.db
+      .select()
+      .from(CLI_TOKENS_TBL)
+      .where(eq(CLI_TOKENS_TBL.userId, "user_123"));
+
+    const storedToken = storedTokens[0];
+    expect(storedToken).toBeDefined();
+    expect(storedToken.name).toBe("GitHub Actions CI");
+    expect(storedToken.token).toMatch(/^usp_live_/);
+  });
+
+  it("should use default expiration of 90 days when not specified", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Default Token",
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    const data = await response.json();
+    const expiresAt = new Date(data.expires_at);
+    const now = new Date();
+    const diffInDays =
+      (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diffInDays).toBeGreaterThan(89);
+    expect(diffInDays).toBeLessThanOrEqual(90);
+  });
+
+  it("should return unauthorized error when user is not authenticated", async () => {
+    // Mock unauthenticated user
+    vi.mocked(auth).mockResolvedValue({ userId: null } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Test Token",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenErrorSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      expect(validationResult.data.error).toBe("unauthorized");
+      expect(validationResult.data.error_description).toContain(
+        "Authentication required",
+      );
+    }
+  });
+
+  it("should enforce token limit per user", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    // Create 10 tokens (the max limit)
+    const now = new Date();
+    const futureDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    for (let i = 0; i < 10; i++) {
+      await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+        token: `usp_live_existing_${i}`,
+        userId: "user_123",
+        name: `Existing Token ${i}`,
+        expiresAt: futureDate,
+        createdAt: now,
+      });
+    }
+
+    // Try to create an 11th token
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "One Too Many",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenErrorSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      expect(validationResult.data.error).toBe("token_limit_exceeded");
+      expect(validationResult.data.error_description).toContain(
+        "Maximum number of active tokens",
+      );
+      expect(validationResult.data.max_tokens).toBe(10);
+    }
+  });
+
+  it("should not count expired tokens towards the limit", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const now = new Date();
+    const pastDate = new Date(now.getTime() - 24 * 60 * 60 * 1000); // Yesterday
+    const futureDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    // Create 5 expired tokens
+    for (let i = 0; i < 5; i++) {
+      await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+        token: `usp_live_expired_${i}`,
+        userId: "user_123",
+        name: `Expired Token ${i}`,
+        expiresAt: pastDate,
+        createdAt: pastDate,
+      });
+    }
+
+    // Create 9 active tokens
+    for (let i = 0; i < 9; i++) {
+      await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+        token: `usp_live_active_${i}`,
+        userId: "user_123",
+        name: `Active Token ${i}`,
+        expiresAt: futureDate,
+        createdAt: now,
+      });
+    }
+
+    // Should be able to create one more token (total 10 active)
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New Token",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    // But not an 11th active token
+    const request2 = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Too Many",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response2 = await POST(request2);
+    expect(response2.status).toBe(403);
+  });
+
+  it("should return invalid request error for missing name", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenErrorSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      expect(validationResult.data.error).toBe("invalid_request");
+    }
+  });
+
+  it("should return invalid request error for invalid expires_in_days", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Test Token",
+          expires_in_days: 400, // More than 365 max
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenErrorSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      expect(validationResult.data.error).toBe("invalid_request");
+    }
+  });
+
+  it("should return invalid request error for malformed JSON", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: "not-json",
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    const validationResult = GenerateTokenErrorSchema.safeParse(data);
+    expect(validationResult.success).toBe(true);
+
+    if (validationResult.success) {
+      expect(validationResult.data.error).toBe("invalid_request");
+      expect(validationResult.data.error_description).toBe(
+        "Invalid JSON in request body",
+      );
+    }
+  });
+
+  it("should allow different users to have their own token limits", async () => {
+    const now = new Date();
+    const futureDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    // Create 10 tokens for user_123
+    for (let i = 0; i < 10; i++) {
+      await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+        token: `usp_live_user123_${i}`,
+        userId: "user_123",
+        name: `User123 Token ${i}`,
+        expiresAt: futureDate,
+        createdAt: now,
+      });
+    }
+
+    // User_456 should still be able to create tokens
+    vi.mocked(auth).mockResolvedValue({ userId: "user_456" } as ReturnType<
+      typeof auth
+    >);
+
+    const request = new NextRequest(
+      "http://localhost/api/cli/auth/generate-token",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "User 456 Token",
+          expires_in_days: 30,
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    const data = await response.json();
+    expect(data.name).toBe("User 456 Token");
+  });
+});

--- a/turbo/apps/web/app/api/cli/auth/generate-token/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/generate-token/route.test.ts
@@ -25,8 +25,8 @@ describe("/api/cli/auth/generate-token", () => {
 
   it("should generate a new CLI token for authenticated user", async () => {
     // Mock authenticated user
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -71,13 +71,18 @@ describe("/api/cli/auth/generate-token", () => {
 
     const storedToken = storedTokens[0];
     expect(storedToken).toBeDefined();
+
+    if (!storedToken) {
+      throw new Error("Token was not stored in database");
+    }
+
     expect(storedToken.name).toBe("GitHub Actions CI");
     expect(storedToken.token).toMatch(/^usp_live_/);
   });
 
   it("should use default expiration of 90 days when not specified", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -104,8 +109,8 @@ describe("/api/cli/auth/generate-token", () => {
 
   it("should return unauthorized error when user is not authenticated", async () => {
     // Mock unauthenticated user
-    vi.mocked(auth).mockResolvedValue({ userId: null } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: null } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -135,8 +140,8 @@ describe("/api/cli/auth/generate-token", () => {
   });
 
   it("should enforce token limit per user", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     // Create 10 tokens (the max limit)
@@ -182,8 +187,8 @@ describe("/api/cli/auth/generate-token", () => {
   });
 
   it("should not count expired tokens towards the limit", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const now = new Date();
@@ -244,8 +249,8 @@ describe("/api/cli/auth/generate-token", () => {
   });
 
   it("should return invalid request error for missing name", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -271,8 +276,8 @@ describe("/api/cli/auth/generate-token", () => {
   });
 
   it("should return invalid request error for invalid expires_in_days", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -299,8 +304,8 @@ describe("/api/cli/auth/generate-token", () => {
   });
 
   it("should return invalid request error for malformed JSON", async () => {
-    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(
@@ -342,8 +347,8 @@ describe("/api/cli/auth/generate-token", () => {
     }
 
     // User_456 should still be able to create tokens
-    vi.mocked(auth).mockResolvedValue({ userId: "user_456" } as ReturnType<
-      typeof auth
+    vi.mocked(auth).mockResolvedValue({ userId: "user_456" } as Awaited<
+      ReturnType<typeof auth>
     >);
 
     const request = new NextRequest(

--- a/turbo/apps/web/app/api/cli/auth/generate-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/generate-token/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
   const validationResult = GenerateTokenRequestSchema.safeParse(body);
 
   if (!validationResult.success) {
-    const errors = validationResult.error?.errors || [];
+    const errors = validationResult.error?.issues || [];
     const firstError = errors[0];
     const errorResponse: GenerateTokenError = {
       error: "invalid_request",

--- a/turbo/apps/web/app/api/cli/auth/generate-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/generate-token/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import {
+  type GenerateTokenResponse,
+  type GenerateTokenError,
+  GenerateTokenRequestSchema,
+} from "@uspark/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { CLI_TOKENS_TBL } from "../../../../../src/db/schema/cli-tokens";
+import { eq, and, gt } from "drizzle-orm";
+import crypto from "crypto";
+
+const MAX_TOKENS_PER_USER = 10;
+
+/**
+ * Generate a secure CLI token with prefix
+ */
+function generateCliToken(): string {
+  // Generate 32 bytes of random data and encode as base64url
+  const randomBytes = crypto.randomBytes(32);
+  const token = randomBytes.toString("base64url");
+  // Add a prefix to make it identifiable
+  return `usp_live_${token}`;
+}
+
+/**
+ * POST /api/cli/auth/generate-token
+ *
+ * Generate a long-lived CLI token for CI/CD or programmatic access.
+ * Requires authentication via Clerk JWT.
+ *
+ * @param request - Contains name and expires_in_days in the body
+ * @returns GenerateTokenResponse with token details or error
+ */
+export async function POST(request: NextRequest) {
+  // Check if user is authenticated
+  const { userId } = await auth();
+
+  if (!userId) {
+    const errorResponse: GenerateTokenError = {
+      error: "unauthorized",
+      error_description:
+        "Authentication required. Please log in to generate a CLI token.",
+    };
+    return NextResponse.json(errorResponse, { status: 401 });
+  }
+
+  // Initialize services for database access
+  initServices();
+
+  // Parse and validate the request body
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    const errorResponse: GenerateTokenError = {
+      error: "invalid_request",
+      error_description: "Invalid JSON in request body",
+    };
+    return NextResponse.json(errorResponse, { status: 400 });
+  }
+
+  const validationResult = GenerateTokenRequestSchema.safeParse(body);
+
+  if (!validationResult.success) {
+    const errors = validationResult.error?.errors || [];
+    const firstError = errors[0];
+    const errorResponse: GenerateTokenError = {
+      error: "invalid_request",
+      error_description: firstError
+        ? `${firstError.path?.join(".") || "field"}: ${firstError.message}`
+        : "Invalid request format",
+    };
+    return NextResponse.json(errorResponse, { status: 400 });
+  }
+
+  const { name, expires_in_days = 90 } = validationResult.data;
+
+  // Check current number of active tokens for this user
+  const now = new Date();
+  const activeTokens = await globalThis.services.db
+    .select()
+    .from(CLI_TOKENS_TBL)
+    .where(
+      and(eq(CLI_TOKENS_TBL.userId, userId), gt(CLI_TOKENS_TBL.expiresAt, now)),
+    );
+
+  if (activeTokens.length >= MAX_TOKENS_PER_USER) {
+    const errorResponse: GenerateTokenError = {
+      error: "token_limit_exceeded",
+      error_description: `Maximum number of active tokens (${MAX_TOKENS_PER_USER}) reached. Please revoke an existing token before creating a new one.`,
+      max_tokens: MAX_TOKENS_PER_USER,
+    };
+    return NextResponse.json(errorResponse, { status: 403 });
+  }
+
+  // Generate new token
+  const token = generateCliToken();
+  const expiresAt = new Date(
+    now.getTime() + expires_in_days * 24 * 60 * 60 * 1000,
+  );
+
+  // Store token in database
+  await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+    token,
+    userId,
+    name,
+    expiresAt,
+    createdAt: now,
+  });
+
+  // Prepare the response
+  const response: GenerateTokenResponse = {
+    token,
+    name,
+    expires_at: expiresAt.toISOString(),
+    created_at: now.toISOString(),
+  };
+
+  return NextResponse.json(response, { status: 201 });
+}

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -1,7 +1,9 @@
 import * as userSchema from "./schema/user";
 import * as deviceCodesSchema from "./schema/device-codes";
+import * as cliTokensSchema from "./schema/cli-tokens";
 
 export const schema = {
   ...userSchema,
   ...deviceCodesSchema,
+  ...cliTokensSchema,
 };

--- a/turbo/apps/web/src/db/migrations/0002_mighty_amazoness.sql
+++ b/turbo/apps/web/src/db/migrations/0002_mighty_amazoness.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "cli_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token" text NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"last_used_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "cli_tokens_token_unique" UNIQUE("token")
+);

--- a/turbo/apps/web/src/db/migrations/meta/0002_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,174 @@
+{
+  "id": "e8b9bcec-08f6-419c-8dd1-4431aa0e2a8f",
+  "prevId": "057148fb-e136-440d-8ddf-46434a30dd6e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1756804196812,
       "tag": "0001_dark_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1756815502373,
+      "tag": "0002_mighty_amazoness",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -1,0 +1,21 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Schema for CLI access tokens
+ * Stores long-lived tokens for CLI/CI usage
+ */
+export const CLI_TOKENS_TBL = pgTable("cli_tokens", {
+  id: text("id")
+    .primaryKey()
+    .notNull()
+    .$defaultFn(() => crypto.randomUUID()),
+  token: text("token").notNull().unique(), // The actual token value (e.g., usp_live_xxx)
+  userId: text("user_id").notNull(), // Clerk user ID
+  name: text("name").notNull(), // User-provided name for the token
+  expiresAt: timestamp("expires_at").notNull(),
+  lastUsedAt: timestamp("last_used_at"), // Track when token was last used
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+export type CliToken = typeof CLI_TOKENS_TBL.$inferSelect;
+export type NewCliToken = typeof CLI_TOKENS_TBL.$inferInsert;

--- a/turbo/packages/core/src/contracts/cli-auth.contract.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.contract.ts
@@ -93,6 +93,33 @@ export const TokenExchangeErrorSchema = z.object({
   error_description: z.string(),
 });
 
+/**
+ * Generate Token Request Schema
+ */
+export const GenerateTokenRequestSchema = z.object({
+  name: z.string().min(1).max(100),
+  expires_in_days: z.number().min(1).max(365).default(90),
+});
+
+/**
+ * Generate Token Response Schema
+ */
+export const GenerateTokenResponseSchema = z.object({
+  token: z.string(), // e.g., "usp_live_abc123..."
+  name: z.string(),
+  expires_at: z.string(), // ISO date string
+  created_at: z.string(), // ISO date string
+});
+
+/**
+ * Generate Token Error Schema
+ */
+export const GenerateTokenErrorSchema = z.object({
+  error: z.enum(["unauthorized", "token_limit_exceeded", "invalid_request"]),
+  error_description: z.string(),
+  max_tokens: z.number().optional(),
+});
+
 // Type exports
 export type DeviceAuthRequest = z.infer<typeof DeviceAuthRequestSchema>;
 export type DeviceAuthResponse = z.infer<typeof DeviceAuthResponseSchema>;
@@ -100,6 +127,9 @@ export type TokenExchangeRequest = z.infer<typeof TokenExchangeRequestSchema>;
 export type TokenExchangeSuccess = z.infer<typeof TokenExchangeSuccessSchema>;
 export type TokenExchangePending = z.infer<typeof TokenExchangePendingSchema>;
 export type TokenExchangeError = z.infer<typeof TokenExchangeErrorSchema>;
+export type GenerateTokenRequest = z.infer<typeof GenerateTokenRequestSchema>;
+export type GenerateTokenResponse = z.infer<typeof GenerateTokenResponseSchema>;
+export type GenerateTokenError = z.infer<typeof GenerateTokenErrorSchema>;
 
 /**
  * CLI Authentication API Contract


### PR DESCRIPTION
## Summary
Implements the `/api/cli/auth/generate-token` endpoint for creating long-lived CLI access tokens with proper authentication and limits.

## Changes
- ✅ Add database schema for CLI tokens with metadata tracking
- ✅ Implement POST `/api/cli/auth/generate-token` endpoint
- ✅ Add Clerk authentication requirement for token generation
- ✅ Enforce max 10 active tokens per user limit
- ✅ Support configurable expiration (1-365 days, default 90)
- ✅ Generate secure tokens with `usp_live_` prefix
- ✅ Add comprehensive test coverage (9 tests)
- ✅ Update API contracts in @uspark/core package

## Technical Details
- Tokens generated using `crypto.randomBytes(32)` with base64url encoding
- Expired tokens don't count towards user limit
- Database migration included for `cli_tokens` table
- Full TypeScript type safety with Zod schemas

## Test Coverage
All 20 CLI auth tests passing:
- 3 tests for `/api/cli/auth/device`
- 8 tests for `/api/cli/auth/token`
- 9 tests for `/api/cli/auth/generate-token` (new)

Tests use real PostgreSQL database (only Clerk API is mocked).

## Acceptance Criteria Met
- [x] Requires authenticated user (Clerk JWT)
- [x] Generates long-lived CLI token (30-90 days)
- [x] Stores token metadata (name, created_at, last_used)
- [x] Returns token and expiration date
- [x] Limits number of active tokens per user (10)