### PR TITLE
chore: add mailmap to unify author display in git history

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# Map all author variations to canonical name and email
+# Format: Proper Name <proper@email> Current Name <current@email>
+<ethan@uspark.ai> <perfectworks@gmail.com>
+<ethan@uspark.ai> <ethan@paraflow.com>
+Ethan Zhang <ethan@uspark.ai> Yuchen <ethan@uspark.ai>
+Ethan Zhang <ethan@uspark.ai> e7h4n <perfectworks@gmail.com>


### PR DESCRIPTION
## Summary
- Added `.mailmap` file to unify author names and emails in git history
- Maps all variations of author identities to canonical `Ethan Zhang <ethan@uspark.ai>`

## Benefits
- GitHub will automatically apply these mappings when displaying commits
- No history rewriting required - all commit SHAs remain unchanged
- Provides consistent author attribution across the project
- Works with `git shortlog` and GitHub's contributor statistics

## Mapped Identities
- `Yuchen <ethan@uspark.ai>` → `Ethan Zhang <ethan@uspark.ai>`
- `e7h4n <perfectworks@gmail.com>` → `Ethan Zhang <ethan@uspark.ai>`
- `<perfectworks@gmail.com>` → `<ethan@uspark.ai>`
- `<ethan@paraflow.com>` → `<ethan@uspark.ai>`