### PR TITLE
ci: use unified toolchain container for all workflows

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Ensure type is in lowercase
+    'type-case': [2, 'always', 'lower-case'],
+    // Ensure subject is in lowercase
+    'subject-case': [2, 'always', 'lower-case'],
+    // Ensure subject doesn't end with period
+    'subject-full-stop': [2, 'never', '.'],
+    // Ensure header max length is 100
+    'header-max-length': [2, 'always', 100],
+    // Type must be one of the following
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'test',
+        'chore',
+        'ci',
+        'perf',
+        'build',
+        'revert'
+      ]
+    ]
+  }
+};

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -20,7 +20,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 
 RUN node --version
 
-RUN npm install -g pnpm@10.15.0 lefthook@1.12.3
+# Install jq for JSON processing
+RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/local/bin/jq \
+    && chmod +x /usr/local/bin/jq
+
+# Install global npm packages for CI/CD
+RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@46.1.1 neonctl@2.2.0
 
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development
@@ -40,9 +45,6 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get update \
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Vercel CLI globally (locked version)
-RUN npm install -g vercel@46.1.1
 
 # Create vscode user with standard UID/GID for devcontainer compatibility
 RUN groupadd --gid 1000 vscode \


### PR DESCRIPTION
## Summary
- Replace ubuntu-latest with ghcr.io/uspark-hq/uspark-toolchain:8767eed container
- Remove redundant tool installations and init action usage  
- Move commitlint to turbo devDependencies for better dependency management

## Changes
This PR updates all GitHub Actions workflows to use our custom toolchain container, ensuring consistent environment across all CI/CD runs:

### Workflow Updates
- **turbo.yml**: All jobs (lint, test, deploy-web, deploy-docs) now use toolchain container
- **release-please.yml**: All jobs including release-please itself use toolchain container
- Removed `./.github/actions/init` usage, replaced with direct `pnpm install`

### Tool Management
- **commitlint**: Moved from npx to turbo devDependencies
- **vercel**: Using pre-installed version from toolchain (v46.1.1)
- **neonctl**: Using npx since not in toolchain yet
- **npm publish**: Direct npm config instead of setup-node action

### Benefits
- ✅ Consistent Node.js, pnpm, and tool versions across all CI runs
- ✅ Faster CI execution (no need to install tools)
- ✅ Better dependency management (commitlint as project dependency)
- ✅ Single source of truth for CI environment (toolchain/Dockerfile)

## Test Plan
- [ ] CI workflows run successfully
- [ ] Commit message validation works
- [ ] Deployments work correctly
- [ ] Release process functions properly

🤖 Generated with [Claude Code](https://claude.ai/code)