### PR TITLE
fix: update auto approve workflow to support app/github-actions author

### DIFF
--- a/.github/workflows/auto-approve-release.yml
+++ b/.github/workflows/auto-approve-release.yml
@@ -16,7 +16,8 @@ jobs:
       github.event_name == 'schedule' || 
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && 
-       github.event.pull_request.user.login == 'release-please[bot]')
+       (github.event.pull_request.user.login == 'release-please[bot]' || 
+        github.event.pull_request.user.login == 'app/github-actions'))
     permissions:
       pull-requests: write
       contents: write
@@ -37,7 +38,7 @@ jobs:
             # Otherwise, find the release PR
             PR_NUMBER=$(gh pr list \
               --json number,author,title \
-              --jq '.[] | select(.author.login == "release-please[bot]" or (.title | startswith("chore: release")) or (.title | startswith("chore(main): release"))) | .number' \
+              --jq '.[] | select((.author.login == "release-please[bot]" or .author.login == "app/github-actions") or (.title | startswith("chore: release")) or (.title | startswith("chore(main): release"))) | .number' \
               --limit 1)
           fi
           


### PR DESCRIPTION
The auto approve workflow was being skipped because it only checked for 'release-please[bot]' as the PR author, but release PRs created by the googleapis/release-please-action@v4 using GITHUB_TOKEN show up with 'app/github-actions' as the author.

This PR updates the workflow conditions and PR search logic to support both author types:
- release-please[bot] (for PAT-based release-please setups)  
- app/github-actions (for GITHUB_TOKEN-based setups like ours)

Now the auto approve workflow will correctly run for release PRs instead of being skipped.