### PR TITLE
feat: remove polling interval from cli auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ const blobs = ydoc.getMap('blobs');  // hash -> content metadata
 ```
 1. uspark auth login → Generate device code
 2. Open browser → User authenticates with Clerk  
-3. CLI polls for token → Receive JWT token
+3. CLI exchanges code for token → Receive JWT token
 4. Store in keychain → Future requests authenticated
 ```
 

--- a/spec/cli-auth.md
+++ b/spec/cli-auth.md
@@ -111,7 +111,7 @@ src/
 │   ├── auth.service.ts # Authentication logic
 │   │   - getAuthToken()     # Check env var first, then stored credentials
 │   │   - requestDeviceCode()
-│   │   - pollForToken()
+│   │   - exchangeToken()
 │   │   - storeCredentials()
 │   │   - getStoredToken()
 ```
@@ -223,7 +223,7 @@ app/
 **Acceptance Criteria**:
 
 - [ ] `requestDeviceCode()` calls device API and returns code
-- [ ] `pollForToken()` polls every 5 seconds with timeout
+- [ ] `exchangeToken()` exchanges device code for access token
 - [ ] `storeToken()` saves to config file
 - [ ] `getStoredToken()` reads from config file
 - [ ] Basic retry logic for network errors

--- a/turbo/apps/cli/src/test/handlers.ts
+++ b/turbo/apps/cli/src/test/handlers.ts
@@ -11,11 +11,10 @@ export const handlers = [
       user_code: "WDJB-MJHT",
       verification_url: `${API_BASE_URL}/cli-auth`,
       expires_in: 900, // 15 minutes
-      interval: 5,
     });
   }),
 
-  // Token polling - returns pending by default
+  // Token exchange - returns pending by default
   http.post(`${API_BASE_URL}/api/cli/auth/token`, () => {
     return HttpResponse.json({
       pending: true,

--- a/turbo/apps/docs/content/docs/api/cli-auth.mdx
+++ b/turbo/apps/docs/content/docs/api/cli-auth.mdx
@@ -359,20 +359,20 @@ async function authenticateCLI() {
     });
 
     const tokenData = await tokenResponse.json();
-    
+
     if (tokenData.access_token) {
       console.log("Authentication successful!");
       return tokenData.access_token;
     }
-    
+
     if (tokenData.error === "authorization_pending") {
       // User hasn't authenticated yet, retry later
       return null;
     }
-    
+
     throw new Error(`Authentication failed: ${tokenData.error}`);
   };
-  
+
   // Call exchangeToken with your own retry strategy
   return await exchangeToken();
 }

--- a/turbo/apps/docs/content/docs/api/cli-auth.mdx
+++ b/turbo/apps/docs/content/docs/api/cli-auth.mdx
@@ -13,7 +13,7 @@ This API implements a device authorization flow similar to GitHub CLI, where:
 
 1. CLI requests a device code
 2. User enters the code in their browser to authenticate
-3. CLI polls for the authentication result
+3. CLI exchanges code for token after user authentication
 4. CLI receives an access token for API calls
 
 ## Endpoints
@@ -37,8 +37,7 @@ _Note: This endpoint accepts an empty request body._
   "device_code": "WDJB-MJHT",
   "user_code": "WDJB-MJHT",
   "verification_url": "https://app.uspark.com/cli-auth",
-  "expires_in": 900,
-  "interval": 5
+  "expires_in": 900
 }
 ```
 
@@ -48,7 +47,6 @@ _Note: This endpoint accepts an empty request body._
 - **user_code**: User-friendly verification code (same as device_code)
 - **verification_url**: URL where user should enter the device code
 - **expires_in**: Code lifetime in seconds (15 minutes)
-- **interval**: Minimum polling interval in seconds (5 seconds)
 
 #### Example Request
 
@@ -60,7 +58,7 @@ curl -X POST https://app.uspark.com/api/cli/auth/device \
 
 ### POST /api/cli/auth/token
 
-Exchanges device code for access token. CLI should poll this endpoint until authentication is complete.
+Exchanges device code for access token after user has authenticated.
 
 #### Request Body
 
@@ -222,8 +220,8 @@ uspark auth login
 # 3. CLI displays instructions
 echo "Visit https://app.uspark.com/cli-auth and enter code: WDJB-MJHT"
 
-# 4. CLI polls for token
-# POST /api/cli/auth/token (every 5 seconds)
+# 4. CLI exchanges code for token
+# POST /api/cli/auth/token
 
 # 5. Store token securely
 # CLI stores token in system keychain
@@ -258,7 +256,6 @@ type DeviceAuthResponse = {
   user_code: string; // Same as device_code
   verification_url: string; // https://app.uspark.com/cli-auth
   expires_in: number; // 900 (15 minutes)
-  interval: number; // 5 (seconds)
 };
 
 // Token exchange request
@@ -352,12 +349,9 @@ async function authenticateCLI() {
     `Visit ${deviceData.verification_url} and enter: ${deviceData.device_code}`,
   );
 
-  // Step 2: Poll for token
-  while (true) {
-    await new Promise((resolve) =>
-      setTimeout(resolve, deviceData.interval * 1000),
-    );
-
+  // Step 2: Exchange token (implement your own retry logic)
+  // Note: You should implement your own retry/wait strategy
+  const exchangeToken = async () => {
     const tokenResponse = await fetch("/api/cli/auth/token", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -365,16 +359,22 @@ async function authenticateCLI() {
     });
 
     const tokenData = await tokenResponse.json();
-
+    
     if (tokenData.access_token) {
       console.log("Authentication successful!");
       return tokenData.access_token;
     }
-
-    if (tokenData.error !== "authorization_pending") {
-      throw new Error(`Authentication failed: ${tokenData.error}`);
+    
+    if (tokenData.error === "authorization_pending") {
+      // User hasn't authenticated yet, retry later
+      return null;
     }
-  }
+    
+    throw new Error(`Authentication failed: ${tokenData.error}`);
+  };
+  
+  // Call exchangeToken with your own retry strategy
+  return await exchangeToken();
 }
 ```
 

--- a/turbo/apps/web/app/api/cli/auth/device/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.test.ts
@@ -33,7 +33,6 @@ describe("/api/cli/auth/device", () => {
         "https://app.uspark.com/cli-auth",
       );
       expect(validData.expires_in).toBe(900); // 15 minutes
-      expect(validData.interval).toBe(5); // 5 seconds
     }
   });
 

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -60,7 +60,6 @@ export async function POST() {
     user_code: deviceCode, // Same as device_code for simplicity
     verification_url: "https://app.uspark.com/cli-auth",
     expires_in: expiresIn,
-    interval: 5, // Poll every 5 seconds
   };
 
   // TODO: Implement rate limiting

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -12,8 +12,7 @@ import { DEVICE_CODES_TBL } from "../../../../../src/db/schema/device-codes";
 /**
  * POST /api/cli/auth/token
  *
- * Exchange a device code for an access token.
- * This endpoint should be polled by the CLI until the user completes authentication.
+ * Exchange a device code for an access token after the user has authenticated.
  *
  * @param request - Contains device_code in the body
  * @returns TokenExchangeSuccess if authenticated, TokenExchangePending if waiting, or error

--- a/turbo/packages/core/src/contracts/cli-auth.contract.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.contract.ts
@@ -38,13 +38,6 @@ export const DeviceAuthResponseSchema = z.object({
     .int()
     .positive()
     .describe("The lifetime in seconds of the device code"),
-  interval: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .default(5)
-    .describe("The minimum polling interval in seconds"),
 });
 
 /**
@@ -161,7 +154,6 @@ export const cliAuthContract = c.router({
 
   /**
    * Exchange device code for access token
-   * This endpoint should be polled until authentication is complete
    */
   exchangeToken: {
     method: "POST",
@@ -178,7 +170,7 @@ export const cliAuthContract = c.router({
     },
     summary: "Exchange device code for access token",
     description:
-      "Polls for the result of the device authorization. Returns a token when the user has successfully authenticated, or an error if the code has expired or been denied",
+      "Exchanges a device code for an access token. Returns a token when the user has successfully authenticated, or an error if the code has expired or been denied",
   },
 
   /**


### PR DESCRIPTION
## Summary

- Remove `interval` field from device authentication API response 
- Update CLI auth contract schema to remove interval requirement
- Update test handlers and documentation to reflect polling → exchange terminology changes
- Simplify authentication flow by allowing clients to implement their own retry strategies

## Changes Made

- **API Response**: Removed `interval` field from `/api/cli/auth/device` endpoint
- **Contract Schema**: Updated `DeviceAuthResponseSchema` to remove interval field and validation
- **Tests**: Updated test handlers and assertions to remove interval field expectations  
- **Documentation**: Updated API docs to change from polling terminology to exchange terminology
- **Comments**: Changed all "poll" related comments to "exchange" throughout codebase

## Impact

This change simplifies the CLI authentication flow by:
- Removing the server-imposed polling interval constraint
- Allowing CLI clients to implement their own retry strategies
- Reducing the API response payload size
- Making the flow more flexible for different client implementations

All existing tests pass and type checking succeeds for affected packages.

## Test Plan

- [x] All existing tests pass with updated expectations
- [x] TypeScript compilation succeeds for all affected packages
- [x] API contract validation works correctly without interval field
- [x] Documentation examples updated to reflect new flow

🤖 Generated with [Claude Code](https://claude.ai/code)