### PR TITLE
fix: correct neon env from main to production in release action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,7 +78,7 @@ jobs:
           npm install -g neonctl@latest
 
           # Get the main branch database URL (production)
-          DATABASE_URL=$(neonctl connection-string main --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
+          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
           echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## Summary
- Fixes the neon environment configuration in the release workflow
- Changes `neonctl connection-string main` to `neonctl connection-string production` in the deploy-web-production job

## Context
As reported in #91, the release action was incorrectly using the `main` environment when it should use `production` for the neon database connection in the production deployment.

## Changes
- Updated line 81 in `.github/workflows/release-please.yml` to use the correct `production` environment

Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/code)