### PR TITLE
docs: update task 6 completion status in daily development list

### DIFF
--- a/spec/issues/20250904.md
+++ b/spec/issues/20250904.md
@@ -114,7 +114,7 @@
 
 ---
 
-### 6. CLI - uspark watch-claude 命令
+### 6. CLI - uspark watch-claude 命令 ✅
 
 **负责模块**: `turbo/apps/cli/src/commands`
 
@@ -125,10 +125,16 @@
 - 后台执行 `uspark push` 同步文件
 
 **验收标准**:
-- [ ] 正确解析 Claude 的 JSON 格式输出
-- [ ] 检测到文件写入立即触发同步
-- [ ] 原始输出完整传递不受影响
-- [ ] 错误处理不中断主流程
+- [x] 正确解析 Claude 的 JSON 格式输出
+- [x] 检测到文件写入立即触发同步
+- [x] 原始输出完整传递不受影响
+- [x] 错误处理不中断主流程
+
+**完成情况**:
+- ✅ PR #100 已合并：`feat(cli): implement uspark watch-claude command for real-time sync`
+- ✅ 实现了完整的 watch-claude 命令，支持实时监控和同步
+- ✅ 包含测试用例覆盖各种场景
+- ✅ 与 Claude Code 输出格式完美集成
 
 **相关文档**: `spec/issues/e2b-runtime-container.md`
 


### PR DESCRIPTION
## Summary
- Mark CLI task #6 (uspark watch-claude command) as completed
- Add details about merged PR #100 and implementation status
- Update completion checkboxes and add completion information

## Test plan
- [x] Documentation changes only - no code changes to test
- [x] Verified task #6 information matches PR #100 details

🤖 Generated with [Claude Code](https://claude.ai/code)