### PR TITLE
fix: add toolchain container to neon cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   cleanup-database:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Fix Neon branch cleanup failure in GitHub Actions by adding toolchain container
- Resolves "neonctl: command not found" error that was preventing proper cleanup

## Problem
The cleanup-database job in `.github/workflows/cleanup.yml` was failing because it runs on a standard Ubuntu runner that doesn't have `neonctl` installed. The Neon branch cleanup action requires the Neon CLI to delete branches when PRs are closed.

## Solution
Added the toolchain container configuration to the cleanup-database job, matching the pattern used in other workflows that need access to our development tools. The container includes all necessary tools including `neonctl`.

## Test Plan
The fix will be validated when:
1. This PR is created (should create a Neon branch successfully)
2. This PR is closed (should delete the Neon branch successfully)
3. Monitor the cleanup workflow execution to ensure it completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)