### PR TITLE
fix: replace hardcoded userId with Clerk authentication in project API

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
@@ -31,7 +31,9 @@ describe("/api/projects/:projectId", () => {
 
   describe("GET /api/projects/:projectId", () => {
     it("should return 401 when not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const mockRequest = new NextRequest("http://localhost:3000");
       const context = { params: Promise.resolve({ projectId }) };
@@ -113,7 +115,9 @@ describe("/api/projects/:projectId", () => {
 
   describe("PATCH /api/projects/:projectId", () => {
     it("should return 401 when not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const update = new Uint8Array([1, 2, 3]);
       const mockRequest = new NextRequest("http://localhost:3000", {

--- a/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET, PATCH } from "./route";
 import * as Y from "yjs";
@@ -6,11 +6,22 @@ import { initServices } from "../../../../src/lib/init-services";
 import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
 import { eq, and } from "drizzle-orm";
 
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
 describe("/api/projects/:projectId", () => {
   const projectId = `test-project-${Date.now()}`;
   const userId = "test-user";
 
   beforeEach(async () => {
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
     // Clean up any existing test project
     initServices();
     await globalThis.services.db
@@ -19,6 +30,19 @@ describe("/api/projects/:projectId", () => {
   });
 
   describe("GET /api/projects/:projectId", () => {
+    it("should return 401 when not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+
+      const mockRequest = new NextRequest("http://localhost:3000");
+      const context = { params: Promise.resolve({ projectId }) };
+
+      const response = await GET(mockRequest, context);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data).toHaveProperty("error", "unauthorized");
+    });
+
     it("should create new project with empty YDoc when project doesn't exist", async () => {
       const mockRequest = new NextRequest("http://localhost:3000");
       const context = { params: Promise.resolve({ projectId }) };
@@ -88,6 +112,23 @@ describe("/api/projects/:projectId", () => {
   });
 
   describe("PATCH /api/projects/:projectId", () => {
+    it("should return 401 when not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+
+      const update = new Uint8Array([1, 2, 3]);
+      const mockRequest = new NextRequest("http://localhost:3000", {
+        method: "PATCH",
+        body: update,
+      });
+      const context = { params: Promise.resolve({ projectId }) };
+
+      const response = await PATCH(mockRequest, context);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data).toHaveProperty("error", "unauthorized");
+    });
+
     it("should apply YDoc updates to existing project", async () => {
       // Create initial project
       const ydoc = new Y.Doc();

--- a/turbo/apps/web/app/api/projects/[projectId]/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
 import * as Y from "yjs";
 import { initServices } from "../../../../src/lib/init-services";
 import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
@@ -12,12 +13,17 @@ export async function GET(
   _request: NextRequest,
   context: { params: Promise<{ projectId: string }> },
 ) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
   initServices();
   const { projectId } = await context.params;
-
-  // For now, we'll use a hardcoded userId (no auth check)
-  // In production, this should come from auth
-  const userId = "test-user";
 
   // Try to fetch existing project
   const [project] = await globalThis.services.db
@@ -68,11 +74,17 @@ export async function PATCH(
   request: NextRequest,
   context: { params: Promise<{ projectId: string }> },
 ) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
   initServices();
   const { projectId } = await context.params;
-
-  // For now, hardcoded userId
-  const userId = "test-user";
 
   // Get the update from request body
   const updateBuffer = await request.arrayBuffer();

--- a/turbo/apps/web/app/api/projects/[projectId]/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.ts
@@ -16,10 +16,7 @@ export async function GET(
   const { userId } = await auth();
 
   if (!userId) {
-    return NextResponse.json(
-      { error: "unauthorized" },
-      { status: 401 }
-    );
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   initServices();
@@ -77,10 +74,7 @@ export async function PATCH(
   const { userId } = await auth();
 
   if (!userId) {
-    return NextResponse.json(
-      { error: "unauthorized" },
-      { status: 401 }
-    );
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   initServices();

--- a/turbo/apps/web/app/api/projects/route.test.ts
+++ b/turbo/apps/web/app/api/projects/route.test.ts
@@ -48,7 +48,9 @@ describe("/api/projects", () => {
 
   describe("GET /api/projects", () => {
     it("should return 401 when not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const response = await GET();
 
@@ -135,7 +137,9 @@ describe("/api/projects", () => {
 
   describe("POST /api/projects", () => {
     it("should return 401 when not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const mockRequest = new NextRequest("http://localhost:3000", {
         method: "POST",

--- a/turbo/apps/web/app/api/projects/route.ts
+++ b/turbo/apps/web/app/api/projects/route.ts
@@ -19,10 +19,7 @@ export async function GET() {
   const { userId } = await auth();
 
   if (!userId) {
-    return NextResponse.json(
-      { error: "unauthorized" },
-      { status: 401 }
-    );
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   initServices();
@@ -57,10 +54,7 @@ export async function POST(request: NextRequest) {
   const { userId } = await auth();
 
   if (!userId) {
-    return NextResponse.json(
-      { error: "unauthorized" },
-      { status: 401 }
-    );
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   initServices();

--- a/turbo/apps/web/app/api/projects/route.ts
+++ b/turbo/apps/web/app/api/projects/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
 import * as Y from "yjs";
 import { initServices } from "../../../src/lib/init-services";
 import { PROJECTS_TBL } from "../../../src/db/schema/projects";
@@ -15,11 +16,16 @@ import {
  * Returns list of user's projects
  */
 export async function GET() {
-  initServices();
+  const { userId } = await auth();
 
-  // For now, we'll use a hardcoded userId (no auth check)
-  // In production, this should come from auth
-  const userId = "test-user";
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
 
   const projectsData = await globalThis.services.db
     .select({
@@ -48,10 +54,16 @@ export async function GET() {
  * Creates a new project
  */
 export async function POST(request: NextRequest) {
-  initServices();
+  const { userId } = await auth();
 
-  // For now, hardcoded userId
-  const userId = "test-user";
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
 
   const body = await request.json();
 


### PR DESCRIPTION
## Summary
- Fixes hardcoded `userId = "test-user"` in project API endpoints
- Implements proper Clerk authentication for all project operations
- Addresses critical security issue from spec/issues/20250904.md (Task 1 from 20250905.md)

## Changes
- ✅ Added Clerk authentication to `/api/projects` GET and POST endpoints
- ✅ Added Clerk authentication to `/api/projects/[projectId]` GET and PATCH endpoints  
- ✅ Return 401 unauthorized for non-authenticated requests
- ✅ Updated test files with proper Clerk mocking
- ✅ Added tests for unauthorized access scenarios

## Test Plan
- [x] All 20 tests passing
- [x] Lint checks pass
- [x] Type checks complete

🤖 Generated with [Claude Code](https://claude.ai/code)