### PR TITLE
fix: replace hardcoded delay with dynamic polling interval in cli auth

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@uspark/core": "workspace:*",
     "chalk": "^5.6.0",
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "signal-timers": "^1.0.4"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/turbo/apps/cli/src/auth.ts
+++ b/turbo/apps/cli/src/auth.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { delay } from "signal-timers";
 import { saveConfig, clearConfig, loadConfig } from "./config";
 
 const API_BASE_URL = "https://app.uspark.com";
@@ -8,6 +9,7 @@ async function requestDeviceCode(apiUrl: string): Promise<{
   user_code: string;
   verification_url: string;
   expires_in: number;
+  interval: number;
 }> {
   const response = await fetch(`${apiUrl}/api/cli/auth/device`, {
     method: "POST",
@@ -24,6 +26,7 @@ async function requestDeviceCode(apiUrl: string): Promise<{
     user_code: string;
     verification_url: string;
     expires_in: number;
+    interval: number;
   }>;
 }
 
@@ -80,9 +83,10 @@ export async function authenticate(
   // Poll for token
   const startTime = Date.now();
   const maxWaitTime = deviceAuth.expires_in * 1000; // Convert to milliseconds
+  const pollInterval = (deviceAuth.interval || 5) * 1000; // Use server-specified interval or default to 5 seconds
 
   while (Date.now() - startTime < maxWaitTime) {
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait 5 seconds
+    await delay(pollInterval); // Use dynamic polling interval
 
     const tokenResult = await exchangeToken(apiUrl, deviceAuth.device_code);
 

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -44,6 +44,7 @@ export async function POST() {
   // Generate a unique device code
   const deviceCode = generateDeviceCode();
   const expiresIn = 900; // 15 minutes in seconds
+  const interval = 5; // 5 seconds polling interval
 
   // Store device code in database with TTL
   await globalThis.services.db.insert(DEVICE_CODES_TBL).values({
@@ -60,6 +61,7 @@ export async function POST() {
     user_code: deviceCode, // Same as device_code for simplicity
     verification_url: "https://app.uspark.com/cli-auth",
     expires_in: expiresIn,
+    interval: interval,
   };
 
   // TODO: Implement rate limiting

--- a/turbo/packages/core/src/contracts/cli-auth.contract.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.contract.ts
@@ -38,6 +38,12 @@ export const DeviceAuthResponseSchema = z.object({
     .int()
     .positive()
     .describe("The lifetime in seconds of the device code"),
+  interval: z
+    .number()
+    .int()
+    .positive()
+    .default(5)
+    .describe("The minimum interval in seconds between polling requests"),
 });
 
 /**

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      signal-timers:
+        specifier: ^1.0.4
+        version: 1.0.4
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -4199,6 +4202,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  signal-timers@1.0.4:
+    resolution: {integrity: sha512-aIqj6BTlnA2G48GTfTFqkEn5MJBtfx4bHCjqzdRLdkhvCRhH8kEDFsX6yUbX0qYXLvV4bI1PRgAw+C9DrgskGg==}
+    engines: {node: '>=10'}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -9084,6 +9091,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  signal-timers@1.0.4: {}
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixes hardcoded 5 second delay in CLI authentication polling (Issue #2 from spec/issues/20250905.md)
- Add `interval` field to DeviceAuthResponse schema per OAuth 2.0 Device Flow RFC 8628
- Update device API route to return 5s polling interval
- Use signal-timers `delay()` function for cleaner async delays
- CLI now respects server-specified polling interval

## Changes
- Added `interval` field to DeviceAuthResponse schema in `cli-auth.contract.ts`
- Updated device auth API route to return interval value
- Added signal-timers dependency to CLI package
- Replaced hardcoded setTimeout with dynamic interval using signal-timers

## Test Plan
- [x] Lint checks pass
- [x] Type checks pass  
- [x] CLI builds successfully
- [ ] Manual test of CLI authentication flow

This implements Task 2 from spec/issues/20250905.md