### PR TITLE
feat(cli): implement pull --all command for batch file downloads

### DIFF
--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -28,6 +28,12 @@ describe("pull command", () => {
 
     // Reset mock server state
     mockServer.reset();
+
+    // Reset config mocks and ensure they return valid values
+    vi.clearAllMocks();
+    const { getToken, getApiUrl } = await import("../config");
+    vi.mocked(getToken).mockResolvedValue("test_token");
+    vi.mocked(getApiUrl).mockResolvedValue("http://localhost:3000");
   });
 
   afterEach(async () => {
@@ -118,8 +124,11 @@ describe("pull --all command", () => {
     // Reset mock server state
     mockServer.reset();
 
-    // Reset config mocks
+    // Reset config mocks and ensure they return valid values
     vi.clearAllMocks();
+    const { getToken, getApiUrl } = await import("../config");
+    vi.mocked(getToken).mockResolvedValue("test_token");
+    vi.mocked(getApiUrl).mockResolvedValue("http://localhost:3000");
   });
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -126,7 +126,7 @@ describe("pull --all command", () => {
 
   it("should pull all files from a project", async () => {
     const projectId = "multi-file-project";
-    
+
     // Setup mock server with multiple test files
     const files = {
       "src/index.ts": "export const main = () => console.log('main');",
@@ -155,15 +155,15 @@ describe("pull --all command", () => {
 
   it("should handle empty project gracefully", async () => {
     const projectId = "empty-project";
-    
+
     // Don't add any files to the project
-    
+
     // Execute pull --all command - should not throw
     await pullAllCommand({
       projectId,
       output: tempDir,
     });
-    
+
     // Verify no files were created
     const { readdirSync } = await import("fs");
     const files = readdirSync(tempDir);

--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -117,7 +117,7 @@ describe("pull --all command", () => {
 
     // Reset mock server state
     mockServer.reset();
-    
+
     // Reset config mocks
     vi.clearAllMocks();
   });

--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -117,6 +117,9 @@ describe("pull --all command", () => {
 
     // Reset mock server state
     mockServer.reset();
+    
+    // Reset config mocks
+    vi.clearAllMocks();
   });
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -20,6 +20,17 @@ export async function pullCommand(
   console.log(chalk.green(`✓ Successfully pulled to ${outputPath}`));
 }
 
+export async function pullAllCommand(
+  options: { projectId: string; output?: string },
+): Promise<void> {
+  const { token, apiUrl, sync } = await requireAuth();
+
+  await sync.pullAll(options.projectId, options.output, {
+    token,
+    apiUrl,
+  });
+}
+
 export async function pushCommand(
   filePath: string,
   options: { projectId: string; source?: string },

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -20,9 +20,10 @@ export async function pullCommand(
   console.log(chalk.green(`✓ Successfully pulled to ${outputPath}`));
 }
 
-export async function pullAllCommand(
-  options: { projectId: string; output?: string },
-): Promise<void> {
+export async function pullAllCommand(options: {
+  projectId: string;
+  output?: string;
+}): Promise<void> {
   const { token, apiUrl, sync } = await requireAuth();
 
   await sync.pullAll(options.projectId, options.output, {

--- a/turbo/apps/cli/src/fs.ts
+++ b/turbo/apps/cli/src/fs.ts
@@ -70,6 +70,14 @@ export class FileSystem {
     this.blobStore.set(hash, content);
   }
 
+  getAllFiles(): string[] {
+    const files: string[] = [];
+    this.files.forEach((_fileNode, path) => {
+      files.push(path);
+    });
+    return files.sort(); // Sort for consistent ordering
+  }
+
   applyUpdate(update: Uint8Array): void {
     Y.applyUpdate(this.ydoc, update);
   }

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -2,7 +2,7 @@ import { FOO } from "@uspark/core";
 import { Command } from "commander";
 import chalk from "chalk";
 import { authenticate, logout, checkAuthStatus } from "./auth";
-import { pullCommand, pushCommand } from "./commands/sync";
+import { pullCommand, pullAllCommand, pushCommand } from "./commands/sync";
 import { watchClaudeCommand } from "./commands/watch-claude";
 
 const API_HOST = process.env.API_HOST || "https://api.uspark.com";
@@ -61,19 +61,29 @@ authCommand
 
 program
   .command("pull")
-  .description("Pull a file from remote project")
-  .argument("<filePath>", "File path to pull")
+  .description("Pull file(s) from remote project")
+  .argument("[filePath]", "File path to pull (omit with --all to pull entire project)")
   .requiredOption("--project-id <projectId>", "Project ID")
   .option(
     "--output <outputPath>",
     "Local output path (defaults to same as remote path)",
   )
+  .option("--all", "Pull all files from the project")
   .action(
     async (
-      filePath: string,
-      options: { projectId: string; output?: string },
+      filePath: string | undefined,
+      options: { projectId: string; output?: string; all?: boolean },
     ) => {
-      await pullCommand(filePath, options);
+      if (options.all) {
+        // Pull all files
+        await pullAllCommand({ projectId: options.projectId, output: options.output });
+      } else if (filePath) {
+        // Pull single file
+        await pullCommand(filePath, options);
+      } else {
+        console.error(chalk.red("Error: Either provide a file path or use --all flag"));
+        process.exit(1);
+      }
     },
   );
 

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -62,7 +62,10 @@ authCommand
 program
   .command("pull")
   .description("Pull file(s) from remote project")
-  .argument("[filePath]", "File path to pull (omit with --all to pull entire project)")
+  .argument(
+    "[filePath]",
+    "File path to pull (omit with --all to pull entire project)",
+  )
   .requiredOption("--project-id <projectId>", "Project ID")
   .option(
     "--output <outputPath>",
@@ -76,12 +79,17 @@ program
     ) => {
       if (options.all) {
         // Pull all files
-        await pullAllCommand({ projectId: options.projectId, output: options.output });
+        await pullAllCommand({
+          projectId: options.projectId,
+          output: options.output,
+        });
       } else if (filePath) {
         // Pull single file
         await pullCommand(filePath, options);
       } else {
-        console.error(chalk.red("Error: Either provide a file path or use --all flag"));
+        console.error(
+          chalk.red("Error: Either provide a file path or use --all flag"),
+        );
         process.exit(1);
       }
     },

--- a/turbo/apps/cli/src/project-sync.ts
+++ b/turbo/apps/cli/src/project-sync.ts
@@ -1,6 +1,6 @@
 import { FileSystem } from "./fs";
 import { writeFile, readFile, mkdir } from "fs/promises";
-import { dirname } from "path";
+import { dirname, join } from "path";
 
 export interface SyncOptions {
   token?: string;
@@ -116,5 +116,54 @@ export class ProjectSync {
 
     // 3. Sync to remote
     await this.syncToRemote(projectId, options);
+  }
+
+  async pullAll(
+    projectId: string,
+    outputDir?: string,
+    options?: SyncOptions,
+  ): Promise<void> {
+    const apiUrl = options?.apiUrl || "http://localhost:3000";
+    const token = options?.token || "test_token";
+    
+    // 1. Sync from remote to get latest state
+    await this.syncFromRemote(projectId, options);
+    
+    // 2. Get all files from the YJS document
+    const allFiles = this.fs.getAllFiles();
+    
+    if (allFiles.length === 0) {
+      return;
+    }
+    
+    // 3. Download all files - fail fast on any error
+    for (const filePath of allFiles) {
+      const fileNode = this.fs.getFileNode(filePath);
+      if (!fileNode) {
+        throw new Error(`File metadata not found: ${filePath}`);
+      }
+      
+      // Get blob content from FileSystem or fetch from remote
+      let content = this.fs.getBlob(fileNode.hash);
+      if (!content) {
+        const response = await fetch(`${apiUrl}/api/blobs/${fileNode.hash}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        
+        if (!response.ok) {
+          throw new Error(`Failed to fetch blob: ${response.statusText}`);
+        }
+        
+        content = await response.text();
+        this.fs.setBlob(fileNode.hash, content);
+      }
+      
+      // Write to local filesystem
+      const localPath = outputDir ? join(outputDir, filePath) : filePath;
+      await mkdir(dirname(localPath), { recursive: true });
+      await writeFile(localPath, content, "utf8");
+    }
   }
 }

--- a/turbo/apps/cli/src/project-sync.ts
+++ b/turbo/apps/cli/src/project-sync.ts
@@ -125,24 +125,24 @@ export class ProjectSync {
   ): Promise<void> {
     const apiUrl = options?.apiUrl || "http://localhost:3000";
     const token = options?.token || "test_token";
-    
+
     // 1. Sync from remote to get latest state
     await this.syncFromRemote(projectId, options);
-    
+
     // 2. Get all files from the YJS document
     const allFiles = this.fs.getAllFiles();
-    
+
     if (allFiles.length === 0) {
       return;
     }
-    
+
     // 3. Download all files - fail fast on any error
     for (const filePath of allFiles) {
       const fileNode = this.fs.getFileNode(filePath);
       if (!fileNode) {
         throw new Error(`File metadata not found: ${filePath}`);
       }
-      
+
       // Get blob content from FileSystem or fetch from remote
       let content = this.fs.getBlob(fileNode.hash);
       if (!content) {
@@ -151,15 +151,15 @@ export class ProjectSync {
             Authorization: `Bearer ${token}`,
           },
         });
-        
+
         if (!response.ok) {
           throw new Error(`Failed to fetch blob: ${response.statusText}`);
         }
-        
+
         content = await response.text();
         this.fs.setBlob(fileNode.hash, content);
       }
-      
+
       // Write to local filesystem
       const localPath = outputDir ? join(outputDir, filePath) : filePath;
       await mkdir(dirname(localPath), { recursive: true });

--- a/turbo/apps/cli/src/test/mock-server.ts
+++ b/turbo/apps/cli/src/test/mock-server.ts
@@ -81,13 +81,13 @@ const originalFetch = global.fetch;
 
 global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
   const urlStr = url.toString();
-  
+
   // Handle project GET/PATCH requests
   if (urlStr.includes("/api/projects/")) {
     const match = urlStr.match(/\/api\/projects\/([^/]+)/);
     if (match && match[1]) {
       const projectId = match[1];
-      
+
       if (init?.method === "PATCH") {
         // Handle project update
         const body = init.body;
@@ -102,30 +102,33 @@ global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
         const data = mockServer.getProject(projectId);
         return new Response(data, {
           status: 200,
-          headers: { "Content-Type": "application/octet-stream" }
+          headers: { "Content-Type": "application/octet-stream" },
         });
       }
     }
   }
-  
+
   // Handle blob requests
   if (urlStr.includes("/api/blobs/")) {
     const match = urlStr.match(/\/api\/blobs\/([^/]+)/);
     if (match && match[1]) {
       const hash = match[1];
       const content = mockServer.getBlobContent(hash);
-      
+
       if (content !== undefined) {
         return new Response(content, {
           status: 200,
-          headers: { "Content-Type": "text/plain" }
+          headers: { "Content-Type": "text/plain" },
         });
       } else {
-        return new Response("Blob not found", { status: 404, statusText: "Not Found" });
+        return new Response("Blob not found", {
+          status: 404,
+          statusText: "Not Found",
+        });
       }
     }
   }
-  
+
   // Fallback to original fetch for other requests
   return originalFetch(url, init);
 };

--- a/turbo/apps/cli/src/test/mock-server.ts
+++ b/turbo/apps/cli/src/test/mock-server.ts
@@ -77,7 +77,7 @@ export class MockYjsServer {
 export const mockServer = new MockYjsServer();
 
 // Mock fetch for tests
-const originalFetch = global.fetch;
+const originalFetch = global.fetch || (() => Promise.reject(new Error("Fetch not available")));
 
 global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
   const urlStr = url.toString();

--- a/turbo/apps/cli/src/test/mock-server.ts
+++ b/turbo/apps/cli/src/test/mock-server.ts
@@ -77,7 +77,8 @@ export class MockYjsServer {
 export const mockServer = new MockYjsServer();
 
 // Mock fetch for tests
-const originalFetch = global.fetch || (() => Promise.reject(new Error("Fetch not available")));
+const originalFetch =
+  global.fetch || (() => Promise.reject(new Error("Fetch not available")));
 
 global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
   const urlStr = url.toString();

--- a/turbo/apps/cli/src/test/mock-server.ts
+++ b/turbo/apps/cli/src/test/mock-server.ts
@@ -1,5 +1,6 @@
 import { Doc, encodeStateAsUpdate, applyUpdate } from "yjs";
 import type { FileNode, BlobInfo } from "@uspark/core";
+import { createHash } from "crypto";
 
 export class MockYjsServer {
   private projects = new Map<string, Doc>();
@@ -37,7 +38,7 @@ export class MockYjsServer {
     const files = project.getMap("files");
     const blobs = project.getMap("blobs");
 
-    // Compute hash (simple for testing)
+    // Compute hash (using real SHA256 to match FileSystem)
     const hash = this.computeHash(content);
 
     // Store file metadata
@@ -67,10 +68,64 @@ export class MockYjsServer {
   }
 
   private computeHash(content: string): string {
-    // Simple hash for testing - in real implementation would use crypto
-    return `hash_${content.length}_${content.slice(0, 10)}`;
+    // Use real SHA256 hash to match the FileSystem implementation
+    return createHash("sha256").update(Buffer.from(content)).digest("hex");
   }
 }
 
 // Global instance for tests
 export const mockServer = new MockYjsServer();
+
+// Mock fetch for tests
+const originalFetch = global.fetch;
+
+global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+  const urlStr = url.toString();
+  
+  // Handle project GET/PATCH requests
+  if (urlStr.includes("/api/projects/")) {
+    const match = urlStr.match(/\/api\/projects\/([^/]+)/);
+    if (match && match[1]) {
+      const projectId = match[1];
+      
+      if (init?.method === "PATCH") {
+        // Handle project update
+        const body = init.body;
+        if (body instanceof Buffer) {
+          mockServer.patchProject(projectId, new Uint8Array(body));
+        } else if (body instanceof Uint8Array) {
+          mockServer.patchProject(projectId, body);
+        }
+        return new Response(null, { status: 200 });
+      } else {
+        // Handle project fetch
+        const data = mockServer.getProject(projectId);
+        return new Response(data, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" }
+        });
+      }
+    }
+  }
+  
+  // Handle blob requests
+  if (urlStr.includes("/api/blobs/")) {
+    const match = urlStr.match(/\/api\/blobs\/([^/]+)/);
+    if (match && match[1]) {
+      const hash = match[1];
+      const content = mockServer.getBlobContent(hash);
+      
+      if (content !== undefined) {
+        return new Response(content, {
+          status: 200,
+          headers: { "Content-Type": "text/plain" }
+        });
+      } else {
+        return new Response("Blob not found", { status: 404, statusText: "Not Found" });
+      }
+    }
+  }
+  
+  // Fallback to original fetch for other requests
+  return originalFetch(url, init);
+};


### PR DESCRIPTION
## Summary
Implements task #4 from daily task list - CLI pull --all batch download functionality.

## Changes
- Added `pullAll` method in ProjectSync class for batch downloads
- Added `getAllFiles` method in FileSystem class to list all files
- Modified CLI pull command to support `--all` flag
- Implemented fail-fast behavior - any error stops entire operation
- Added comprehensive test coverage

## Implementation Details
- Minimal MVP implementation (31 lines of core logic)
- No progress bars or file comparison - just download everything
- Fails immediately on any error
- Preserves directory structure when downloading

## Usage
```bash
uspark pull --all --project-id <id>
uspark pull --all --project-id <id> --output <dir>
```

## Testing
- ✅ All tests passing (8/8)
- ✅ Lint checks pass
- ✅ TypeScript type checks pass

Completes: spec/issues/20250905.md Task #4