### PR TITLE
test: add content-type headers to cli auth token route tests

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/token/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.test.ts
@@ -54,6 +54,9 @@ describe("/api/cli/auth/token", () => {
 
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: deviceCode,
       }),
@@ -80,6 +83,9 @@ describe("/api/cli/auth/token", () => {
 
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: deviceCode,
       }),
@@ -114,6 +120,9 @@ describe("/api/cli/auth/token", () => {
 
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: deviceCode,
       }),
@@ -138,6 +147,9 @@ describe("/api/cli/auth/token", () => {
 
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: deviceCode,
       }),
@@ -159,6 +171,9 @@ describe("/api/cli/auth/token", () => {
   it("should return invalid request error for malformed device code", async () => {
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: "invalid-code-format",
       }),
@@ -180,6 +195,9 @@ describe("/api/cli/auth/token", () => {
   it("should return invalid request error for missing device code", async () => {
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({}),
     });
 
@@ -201,6 +219,9 @@ describe("/api/cli/auth/token", () => {
 
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: deviceCode,
       }),
@@ -222,6 +243,9 @@ describe("/api/cli/auth/token", () => {
   it("should return invalid request error for non-existent device code", async () => {
     const request = new NextRequest("http://localhost/api/cli/auth/token", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
         device_code: "NONE-XIST",
       }),


### PR DESCRIPTION
## Summary
Added missing Content-Type headers to all test requests in the CLI auth token route test file to ensure proper request formatting.

## Changes
- Added `Content-Type: application/json` headers to all NextRequest instances in route.test.ts

## Test Plan
- [x] All tests pass with the added headers
- [x] Linting and formatting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)