### PR TITLE
fix(cli): correct npm bin path for npx execution

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@uspark/core\"]; this.bin[\"uspark\"]=\"index.js\"; this.files=[\".\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@uspark/core\"]; this.bin[\"uspark\"]=\"./index.js\"; this.files=[\".\"]'",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Fixes the npm/npx execution issue by correcting the bin path from "index.js" to "./index.js" in the postbuild script
- Ensures that `npx @uspark/cli` commands work correctly by setting the proper relative path in the package.json bin field

## Test plan
- [ ] Build the CLI package: `cd turbo/apps/cli && pnpm build`
- [ ] Verify the generated dist/package.json has the correct bin path: `./index.js`
- [ ] Test npx execution after publishing

🤖 Generated with [Claude Code](https://claude.ai/code)