### PR TITLE
docs: remove non-MVP tasks from technical specifications

### DIFF
--- a/spec/issues/document-sharing.md
+++ b/spec/issues/document-sharing.md
@@ -123,8 +123,6 @@ Features:
 **Acceptance Criteria**:
 - [x] POST /api/share - Generate share link (✅ PR #101)
 - [x] GET /api/share/:token - Retrieve shared content (✅ PR #101, ⚠️ 需要 Blob 集成)
-- [ ] GET /api/share - List user's shares (延期到下个迭代)
-- [ ] DELETE /api/share/:id - Revoke share link (延期到下个迭代)
 
 #### 2. Database Setup
 **Acceptance Criteria**:
@@ -135,7 +133,6 @@ Features:
 **Acceptance Criteria**:
 - [x] Share button in document viewer (✅ PR #106)
 - [x] Share modal with copy functionality (✅ PR #106)
-- [ ] Share management page at /settings/shares (延期到下个迭代)
 
 #### 4. Public View Page
 **Acceptance Criteria**:


### PR DESCRIPTION
## Summary
- Remove deferred share management features from document-sharing.md  
- Clean up tasks explicitly marked as postponed to next iteration
- Keep only MVP-required functionality in specifications

## Changes
- Removed GET /api/share (list user's shares) - deferred to next iteration
- Removed DELETE /api/share/:id (revoke share link) - deferred to next iteration  
- Removed share management page at /settings/shares - deferred to next iteration

## Test plan
- [x] Review spec/issues/mvp.md to verify removed items are not MVP requirements
- [x] Confirm remaining tasks align with MVP scope

🤖 Generated with [Claude Code](https://claude.ai/code)