### PR TITLE
chore: complete knip cleanup - achieve zero unused exports

### DIFF
--- a/turbo/apps/web/app/components/file-explorer/index.ts
+++ b/turbo/apps/web/app/components/file-explorer/index.ts
@@ -1,2 +1,1 @@
-export { FileExplorer } from "./file-explorer";
 export { YjsFileExplorer } from "./yjs-file-explorer";

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -3,15 +3,12 @@
   "workspaces": {
     ".": {
       "entry": [],
-      "project": ["vitest.*.{js,ts,mjs}", "*.config.{js,ts,mjs}"]
+      "project": ["*.config.{js,ts,mjs}"]
     },
     "apps/web": {
       "entry": [
         "app/**/page.{ts,tsx}",
         "app/**/layout.{ts,tsx}",
-        "app/**/error.{ts,tsx}",
-        "app/**/loading.{ts,tsx}",
-        "app/**/not-found.{ts,tsx}",
         "app/api/**/route.{ts,tsx}",
         "middleware.{ts,tsx}",
         "scripts/*.ts"
@@ -26,18 +23,16 @@
       "project": ["src/**/*.ts"],
       "tsup": {
         "config": ["tsup.config.ts"]
-      },
-      "ignoreBinaries": ["eslint"]
+      }
     },
     "apps/docs": {
       "entry": ["source.config.ts"],
       "project": ["**/*.{ts,tsx,mdx,js,mjs}"],
-      "ignoreDependencies": ["fumadocs-mdx"]
+      "ignoreDependencies": []
     },
     "packages/core": {
       "entry": [],
-      "project": ["src/**/*.ts"],
-      "ignoreBinaries": ["eslint"]
+      "project": ["src/**/*.ts"]
     },
     "packages/ui": {
       "entry": [],


### PR DESCRIPTION
## Summary
Final cleanup to achieve **zero unused function exports** in the codebase! 🎉

## Changes
1. **Removed last unused export**
   - Removed `FileExplorer` from `apps/web/app/components/file-explorer/index.ts`
   - This component is only used internally, not through the barrel export

2. **Cleaned up knip configuration**
   - Removed non-existent entry patterns (error.tsx, loading.tsx, not-found.tsx)
   - Cleaned up unnecessary ignoreBinaries and ignoreDependencies
   - Removed unmatched vitest pattern

## Results
- **Unused function exports: 0** ✅ (reduced from initial 16 to 0!)
- **Configuration hints: reduced from 6 to 1**
- All tests passing
- No lint errors

## Test Plan
- [x] Run lint: `pnpm turbo run lint --filter=web`
- [x] Run tests: `pnpm vitest --run apps/web/app/components/file-explorer`
- [x] Verify with knip: `pnpm knip`

## Impact
This completes the knip cleanup effort:
- PR #167: Reduced from 16 → 1 unused export
- This PR: Reduced from 1 → 0 unused exports

The codebase now has **zero unused function exports**, making it cleaner and more maintainable.

🤖 Generated with [Claude Code](https://claude.ai/code)