### PR TITLE
feat: add playwright system dependencies to development dockerfile

### DIFF
--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -38,6 +38,38 @@ RUN apt-get update && apt-get install -y \
     ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Playwright dependencies
+# These are required for running browser automation tests
+RUN apt-get update && apt-get install -y \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxshmfence1 \
+    xvfb \
+    fonts-liberation \
+    libu2f-udev \
+    libvulkan1 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
Add Playwright browser automation dependencies to the development Docker image.

## Why
Enable running Playwright e2e tests inside the development container without needing to install dependencies manually.

## Changes
- Added all required system libraries for Chromium, Firefox, and WebKit browsers
- Included fonts-liberation for proper text rendering
- Added xvfb for headless display server
- Included additional dependencies like libu2f-udev and libvulkan1

## Dependencies Added
- Display: libx11-6, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxrandr2, xvfb
- GTK/Cairo: libgtk-3-0, libcairo2, libpango-1.0-0, libatk1.0-0, libatk-bridge2.0-0
- Audio/Video: libasound2, libdrm2, libgbm1
- System: libdbus-1-3, libglib2.0-0, libnspr4, libnss3, libcups2
- Additional: libxkbcommon0, libxshmfence1, libatspi2.0-0, libu2f-udev, libvulkan1

## Testing
After rebuilding the image, you can test with:
```bash
npx playwright install chromium firefox webkit
npx playwright test
```

## Note
This only adds system dependencies. Playwright browsers still need to be installed separately using `npx playwright install`.