### PR TITLE
chore: update devcontainer image to latest toolchain build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "USpark Development",
-  "image": "ghcr.io/uspark-hq/uspark-dev:8767eed",
+  "image": "ghcr.io/uspark-hq/uspark-dev:bd056ee",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {}
   },


### PR DESCRIPTION
## Summary
- Update Docker image version from `8767eed` to `bd056ee` in devcontainer configuration
- Includes Playwright system dependencies added in the latest toolchain build

## Test plan
- [ ] Verify devcontainer rebuilds successfully with new image
- [ ] Confirm all development tools are available in the updated container

🤖 Generated with [Claude Code](https://claude.ai/code)