### PR TITLE
docs: align spec documents with MVP polling strategy

### DIFF
--- a/spec/issues/mvp.md
+++ b/spec/issues/mvp.md
@@ -39,14 +39,14 @@ This document defines the mid-term goals and user stories for the MVP release of
 - [ ] Document explorer showing project file tree
 - [ ] Document viewer/editor for selected files
 - [ ] Chat interface for entering Claude Code prompts
-- [ ] Real-time execution status indicators
-- [ ] Live document updates as Claude makes changes
+- [ ] Execution status indicators (via polling)
+- [ ] Document updates as Claude makes changes (via YJS polling)
 
 #### Technical Requirements
 
 - E2B container runtime for Claude Code execution
-- WebSocket or SSE for real-time updates
-- YJS for real-time document synchronization
+- Polling API for status updates
+- YJS for document synchronization (polling-based)
 - Queue system for managing Claude tasks
 - Audit logging for all AI operations
 
@@ -104,8 +104,8 @@ This document defines the mid-term goals and user stories for the MVP release of
 3. ✅ uspark watch-claude command implementation
 4. [ ] Claude Code runtime integration
 5. ⏳ Chat interface component (UI only, no backend)
-6. [ ] WebSocket/SSE for real-time updates
-7. [ ] Document change streaming
+6. [ ] Polling system for status updates
+7. [ ] Document change detection via YJS polling
 
 ### Phase 5: Sharing Features (Story 3)
 

--- a/spec/issues/web-ui.md
+++ b/spec/issues/web-ui.md
@@ -83,10 +83,10 @@ Returns: {
 }
 ```
 
-**Real-time Updates**:
-- WebSocket connection for live updates
-- Show file changes as they happen
-- Display execution logs
+**Status Updates (Polling-based)**:
+- Polling connection for live updates
+- Show file changes via YJS polling
+- Display execution logs via status polling
 
 ## Implementation Todos
 
@@ -103,7 +103,7 @@ Returns: {
 **Acceptance Criteria**:
 - [ ] POST /api/claude/execute - Start Claude task
 - [ ] GET /api/claude/status/:taskId - Get task status
-- [ ] WebSocket endpoint for real-time updates
+- [ ] Polling endpoints for status updates
 
 ### Frontend Pages
 
@@ -118,13 +118,13 @@ Returns: {
 - [x] File explorer component (✅ PR #107)
 - [x] Document viewer with syntax highlighting (✅ PR #106)
 - [ ] Chat input component (待实现)
-- [ ] Real-time update display (待实现)
+- [ ] Polling-based update display (待实现)
 
-#### 5. Real-time Integration
+#### 5. Polling Integration
 **Acceptance Criteria**:
-- [ ] WebSocket client setup
-- [ ] Live file change updates
-- [ ] Execution status updates
+- [ ] Polling client setup (useSessionPolling hook)
+- [ ] File change updates via YJS polling
+- [ ] Execution status updates via API polling
 
 ## Database Schema
 
@@ -150,4 +150,4 @@ CREATE TABLE claude_tasks (
 - Tailwind CSS for styling
 - shadcn/ui for components
 - Monaco Editor or CodeMirror for syntax highlighting
-- Socket.io or native WebSocket for real-time updates
+- Polling-based updates using existing API endpoints


### PR DESCRIPTION
Align specification documents to consistently use polling instead of real-time WebSocket/SSE streaming for MVP implementation.

Updated 3 key documents:
- mvp.md: Polling API instead of WebSocket/SSE
- web-ui.md: useSessionPolling hook approach
- e2b-runtime-container.md: Status monitoring instead of streaming

Closes #189

Generated with [Claude Code](https://claude.ai/code)