### PR TITLE
feat: update claude workflow to use project toolchain container

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
     permissions:
       contents: read
       pull-requests: read
@@ -29,6 +31,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Initialize toolchain
+        uses: ./.github/actions/toolchain-init
 
       - name: Run Claude Code
         id: claude

--- a/turbo/apps/web/drizzle.config.ts
+++ b/turbo/apps/web/drizzle.config.ts
@@ -3,15 +3,9 @@ import { defineConfig } from "drizzle-kit";
 export const DRIZZLE_MIGRATE_OUT = "./src/db/migrations";
 
 // Allow missing DATABASE_URL for static analysis tools like knip
-const databaseUrl =
-  process.env.DATABASE_URL ||
-  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
+const databaseUrl = process.env.DATABASE_URL || "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
-if (
-  !process.env.DATABASE_URL &&
-  process.env.NODE_ENV !== "test" &&
-  !process.env.CI
-) {
+if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "test" && !process.env.CI) {
   console.warn("WARNING: DATABASE_URL is not set, using placeholder value");
 }
 

--- a/turbo/apps/web/drizzle.config.ts
+++ b/turbo/apps/web/drizzle.config.ts
@@ -2,11 +2,8 @@ import { defineConfig } from "drizzle-kit";
 
 export const DRIZZLE_MIGRATE_OUT = "./src/db/migrations";
 
-// Allow missing DATABASE_URL for static analysis tools like knip
-const databaseUrl = process.env.DATABASE_URL || "postgresql://placeholder:placeholder@localhost:5432/placeholder";
-
-if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "test" && !process.env.CI) {
-  console.warn("WARNING: DATABASE_URL is not set, using placeholder value");
+if (!process.env.DATABASE_URL) {
+  throw new Error("invalid DATABASE_URL");
 }
 
 export default defineConfig({
@@ -14,7 +11,7 @@ export default defineConfig({
   out: DRIZZLE_MIGRATE_OUT,
   dialect: "postgresql",
   dbCredentials: {
-    url: databaseUrl,
+    url: process.env.DATABASE_URL,
   },
   verbose: true,
   strict: false,

--- a/turbo/apps/web/drizzle.config.ts
+++ b/turbo/apps/web/drizzle.config.ts
@@ -3,9 +3,15 @@ import { defineConfig } from "drizzle-kit";
 export const DRIZZLE_MIGRATE_OUT = "./src/db/migrations";
 
 // Allow missing DATABASE_URL for static analysis tools like knip
-const databaseUrl = process.env.DATABASE_URL || "postgresql://placeholder:placeholder@localhost:5432/placeholder";
+const databaseUrl =
+  process.env.DATABASE_URL ||
+  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
-if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "test" && !process.env.CI) {
+if (
+  !process.env.DATABASE_URL &&
+  process.env.NODE_ENV !== "test" &&
+  !process.env.CI
+) {
   console.warn("WARNING: DATABASE_URL is not set, using placeholder value");
 }
 

--- a/turbo/apps/web/drizzle.config.ts
+++ b/turbo/apps/web/drizzle.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from "drizzle-kit";
 
 export const DRIZZLE_MIGRATE_OUT = "./src/db/migrations";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("invalid DATABASE_URL");
+// Allow missing DATABASE_URL for static analysis tools like knip
+const databaseUrl = process.env.DATABASE_URL || "postgresql://placeholder:placeholder@localhost:5432/placeholder";
+
+if (!process.env.DATABASE_URL && process.env.NODE_ENV !== "test" && !process.env.CI) {
+  console.warn("WARNING: DATABASE_URL is not set, using placeholder value");
 }
 
 export default defineConfig({
@@ -11,7 +14,7 @@ export default defineConfig({
   out: DRIZZLE_MIGRATE_OUT,
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: databaseUrl,
   },
   verbose: true,
   strict: false,

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -48,6 +48,6 @@
       "ignoreUnresolved": ["next"]
     }
   },
-  "ignore": ["**/*.d.ts", ".next/**", "dist/**", "build/**", "coverage/**"],
+  "ignore": ["**/*.d.ts", ".next/**", "dist/**", "build/**", "coverage/**", "**/drizzle.config.ts"],
   "ignoreWorkspaces": []
 }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -13,7 +13,7 @@
         "middleware.{ts,tsx}",
         "scripts/*.ts"
       ],
-      "project": ["**/*.{ts,tsx}", "scripts/**/*.ts", "!drizzle.config.ts"],
+      "project": ["**/*.{ts,tsx}", "scripts/**/*.ts"],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]
       }

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -13,7 +13,7 @@
         "middleware.{ts,tsx}",
         "scripts/*.ts"
       ],
-      "project": ["**/*.{ts,tsx}", "scripts/**/*.ts"],
+      "project": ["**/*.{ts,tsx}", "scripts/**/*.ts", "!drizzle.config.ts"],
       "next": {
         "entry": ["next.config.{js,ts,mjs}"]
       }


### PR DESCRIPTION
## Summary
- Updates Claude Code GitHub Action to use the same toolchain container as other CI jobs
- Adds toolchain initialization step for proper environment setup
- Ensures Claude has access to all project tools (pnpm, lefthook, vercel, neonctl, etc.)

## Changes
- Added `container` configuration pointing to `ghcr.io/uspark-hq/uspark-toolchain:4c465ea`
- Added toolchain initialization step after checkout
- Maintained all existing permissions and configurations

## Benefits
This change gives Claude Code the complete ability to:
- Run `cd turbo && pnpm turbo run lint` for code quality checks
- Execute `cd turbo && pnpm check-types` for TypeScript validation
- Run `cd turbo && pnpm test` for testing
- Access all project-specific tools and configurations
- Maintain consistency with other CI jobs

## Test plan
- [ ] Verify Claude still responds to `@claude` mentions in issues and PRs
- [ ] Test that Claude can now run project commands like lint and test
- [ ] Confirm the container image is accessible and loads properly

Fixes #191

🤖 Generated with [Claude Code](https://claude.ai/code)