### PR TITLE
feat: add playwright chromium deps to toolchain image

### DIFF
--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -27,6 +27,10 @@ RUN curl -sL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-am
 # Install global npm packages for CI/CD
 RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@46.1.1 neonctl@2.15.0
 
+# Install Playwright system dependencies for Chromium
+# This is needed for e2e tests in CI
+RUN npx playwright install-deps chromium
+
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development
 


### PR DESCRIPTION
## Summary
- Adds Playwright system dependencies installation for Chromium to the toolchain Docker image
- Runs `npx playwright install-deps chromium` during image build

## Why this change?
Currently, the e2e tests need to install Playwright dependencies at runtime, which:
- Slows down CI pipeline execution
- Adds unnecessary complexity to test setup
- Can fail if network issues occur during CI runs

## Benefits
- ✅ E2E tests can run immediately without additional setup
- ✅ Faster CI pipeline execution (no need to install deps each time)
- ✅ More reliable CI runs (dependencies are baked into the image)
- ✅ Consistent environment across all CI jobs

## Test plan
- [ ] Docker image builds successfully
- [ ] E2E tests run without needing to install Playwright deps
- [ ] CI pipelines continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)