### PR TITLE
chore: update toolchain image and simplify e2e web tests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -8,7 +8,7 @@ jobs:
   cleanup-database:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     permissions:
       contents: read
     steps:
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.release-please.outputs.web_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     permissions:
       contents: read
       deployments: write
@@ -101,7 +101,7 @@ jobs:
     if: ${{ needs.release-please.outputs.docs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     permissions:
       contents: read
       deployments: write
@@ -123,7 +123,7 @@ jobs:
     if: ${{ needs.release-please.outputs.cli_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
 
     services:
       postgres:
@@ -53,7 +53,7 @@ jobs:
   deploy-web:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     if: github.event_name == 'pull_request'
     outputs:
       preview-url: ${{ steps.deploy.outputs.url }}
@@ -122,7 +122,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -159,7 +159,7 @@ jobs:
   cli-e2e:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/uspark-hq/uspark-toolchain:4c465ea
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     needs: [deploy-web]
     if: github.event_name == 'pull_request' && needs.deploy-web.outputs.preview-url != ''
     steps:
@@ -190,20 +190,23 @@ jobs:
   # Run Web E2E tests with Playwright
   web-e2e:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     needs: [deploy-web]
     if: github.event_name == 'pull_request' && needs.deploy-web.outputs.preview-url != ''
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
-      - name: Install Playwright dependencies
+      - name: Install npm dependencies for e2e tests
         run: |
           cd e2e/web
           npm ci
+
+      - name: Install Playwright browser
+        run: |
+          cd e2e/web
           npx playwright install chromium
-          npx playwright install-deps chromium
+          # Note: install-deps is not needed as dependencies are already in the container
 
       - name: Run Playwright E2E Tests
         run: |


### PR DESCRIPTION
## Summary
- Updates all workflows to use new toolchain image `c2b456c` that includes Playwright system dependencies
- Simplifies web-e2e test setup by using the container environment

## Changes

### 1. Updated toolchain image tag
- All workflows now use `ghcr.io/uspark-hq/uspark-toolchain:c2b456c`
- This new image includes Playwright system dependencies installed via `npx playwright install-deps chromium`

### 2. Simplified web-e2e job
- **Before**: Running on bare `ubuntu-latest`, installing Node.js, npm deps, Playwright browser AND system deps
- **After**: Running in container, only installing npm deps and Playwright browser binary

### Removed steps in web-e2e:
- ❌ `uses: actions/setup-node@v4` - Node.js is already in container
- ❌ `npx playwright install-deps chromium` - System deps are already in container

### Benefits
- 🚀 **Faster CI**: No need to install Playwright system dependencies (saves ~30-60 seconds per run)
- 🎯 **Consistency**: All CI jobs now use the same container environment
- 🧹 **Simpler config**: Less setup code in the workflow file
- 🔒 **Reliability**: Dependencies are baked into the image, reducing network-related failures

## Test plan
- [ ] CI passes with new toolchain image
- [ ] web-e2e tests run successfully
- [ ] No regression in other CI jobs

🤖 Generated with [Claude Code](https://claude.ai/code)