### PR TITLE
feat: add centralized change detection for optimized CI pipeline

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -43,7 +43,7 @@ jobs:
           
           # Check web app
           cd turbo/apps/web
-          if npx turbo-ignore web; then
+          if npx turbo-ignore; then
             echo "No changes detected in web app"
             echo "web-changed=false" >> $GITHUB_OUTPUT
           else
@@ -53,7 +53,7 @@ jobs:
           
           # Check docs app
           cd ../docs
-          if npx turbo-ignore docs; then
+          if npx turbo-ignore; then
             echo "No changes detected in docs app"
             echo "docs-changed=false" >> $GITHUB_OUTPUT
           else
@@ -63,7 +63,7 @@ jobs:
           
           # Check CLI app
           cd ../cli
-          if npx turbo-ignore cli; then
+          if npx turbo-ignore; then
             echo "No changes detected in CLI app"
             echo "cli-changed=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -8,6 +8,66 @@ on:
   merge_group:
 
 jobs:
+  # Detect changes in apps to optimize CI pipeline
+  change-detection:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
+    # Run for all events, but only do actual detection for PRs
+    outputs:
+      web-changed: ${{ steps.detect.outputs.web-changed }}
+      docs-changed: ${{ steps.detect.outputs.docs-changed }}
+      cli-changed: ${{ steps.detect.outputs.cli-changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      
+      - name: Detect changes
+        id: detect
+        run: |
+          # For non-PR events, assume everything changed
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a PR, assuming all apps changed"
+            echo "web-changed=true" >> $GITHUB_OUTPUT
+            echo "docs-changed=true" >> $GITHUB_OUTPUT
+            echo "cli-changed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # For PRs, use turbo-ignore to detect changes
+          echo "Checking for changes in PR..."
+          
+          # Check web app
+          cd turbo/apps/web
+          if npx turbo-ignore web; then
+            echo "No changes detected in web app"
+            echo "web-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in web app"
+            echo "web-changed=true" >> $GITHUB_OUTPUT
+          fi
+          
+          # Check docs app
+          cd ../docs
+          if npx turbo-ignore docs; then
+            echo "No changes detected in docs app"
+            echo "docs-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in docs app"
+            echo "docs-changed=true" >> $GITHUB_OUTPUT
+          fi
+          
+          # Check CLI app
+          cd ../cli
+          if npx turbo-ignore cli; then
+            echo "No changes detected in CLI app"
+            echo "cli-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in CLI app"
+            echo "cli-changed=true" >> $GITHUB_OUTPUT
+          fi
+
   lint:
     runs-on: ubuntu-latest
     container:
@@ -54,7 +114,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
-    if: github.event_name == 'pull_request'
+    needs: [change-detection]
+    # Deploy if it's a PR and either web or CLI changed (CLI needs web for e2e tests)
+    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.cli-changed == 'true')
     outputs:
       preview-url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -63,35 +125,10 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      
-      - name: Check for changes affecting deployment
-        id: check-changes
-        run: |
-          # Check if web app has changes
-          cd turbo/apps/web
-          if npx turbo-ignore web; then
-            # No web changes, but check if CLI changed (for e2e testing)
-            cd ../cli
-            if npx turbo-ignore cli; then
-              echo "No changes affecting deployment"
-              echo "has-changes=false" >> $GITHUB_OUTPUT
-            else
-              echo "CLI changes detected, deploying web for e2e testing"
-              echo "has-changes=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "Web app changes detected"
-            echo "has-changes=true" >> $GITHUB_OUTPUT
-          fi
-      
       - uses: ./.github/actions/toolchain-init
-        if: steps.check-changes.outputs.has-changes == 'true'
 
       # Step 1: Create Neon database branch
       - name: Create Neon Branch and Run Migrations
-        if: steps.check-changes.outputs.has-changes == 'true'
         id: branch
         uses: ./.github/actions/neon-branch
         with:
@@ -102,7 +139,6 @@ jobs:
 
       # Step 2: Deploy to Vercel with database URL
       - name: Deploy Web to Vercel
-        if: steps.check-changes.outputs.has-changes == 'true'
         id: deploy
         uses: ./.github/actions/vercel-deploy
         with:
@@ -123,27 +159,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
-    if: github.event_name == 'pull_request'
+    needs: [change-detection]
+    # Only deploy if it's a PR and docs changed
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.docs-changed == 'true'
     permissions:
       contents: read
       pull-requests: write
       deployments: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      
-      - name: Check for changes in docs app
-        id: check-changes
-        run: |
-          cd turbo/apps/docs
-          npx turbo-ignore docs || echo "has-changes=true" >> $GITHUB_OUTPUT
-      
       - uses: ./.github/actions/toolchain-init
-        if: steps.check-changes.outputs.has-changes == 'true'
 
       - name: Deploy Docs to Vercel
-        if: steps.check-changes.outputs.has-changes == 'true'
         id: deploy
         uses: ./.github/actions/vercel-deploy
         with:
@@ -160,8 +187,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
-    needs: [deploy-web]
-    if: github.event_name == 'pull_request' && needs.deploy-web.outputs.preview-url != ''
+    needs: [change-detection, deploy-web]
+    # Run if CLI changed and web deployment succeeded
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.cli-changed == 'true' && needs.deploy-web.outputs.preview-url != ''
     steps:
       - uses: actions/checkout@v4
         with:
@@ -192,8 +220,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
-    needs: [deploy-web]
-    if: github.event_name == 'pull_request' && needs.deploy-web.outputs.preview-url != ''
+    needs: [change-detection, deploy-web]
+    # Run if web changed and deployment succeeded
+    if: github.event_name == 'pull_request' && needs.change-detection.outputs.web-changed == 'true' && needs.deploy-web.outputs.preview-url != ''
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           fetch-depth: 2
       
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory /__w/uspark/uspark
+      
       - name: Detect changes
         id: detect
         run: |


### PR DESCRIPTION
## Summary
Introduces a centralized change detection job that runs `turbo-ignore` for all apps and provides outputs that control which deployment and test jobs run.

## Problem
Currently, each deploy job runs its own change detection, leading to:
- Duplicated logic across jobs
- Unnecessary CI runs for unchanged apps
- Wasted compute resources and time
- Complex conditional logic scattered throughout the workflow

## Solution
A single `change-detection` job that:
1. Runs once at the beginning of the CI pipeline
2. Uses `turbo-ignore` to detect changes in each app (web, docs, cli)
3. Outputs boolean flags for each app
4. Other jobs use these flags to decide whether to run

## Changes

### New Job: `change-detection`
- Runs for all events (PR, push, merge_group)
- For PRs: Uses `turbo-ignore` to detect actual changes
- For non-PRs: Assumes all apps changed (to ensure main branch builds work)
- Outputs: `web-changed`, `docs-changed`, `cli-changed`

### Updated Jobs
All deployment and test jobs now:
- Depend on `change-detection` via `needs`
- Use the outputs in their `if` conditions
- Removed redundant change detection logic

| Job | Runs when |
|-----|-----------|
| `deploy-web` | PR + (web changed OR cli changed) |
| `deploy-docs` | PR + docs changed |
| `cli-e2e` | PR + cli changed + web deployed |
| `web-e2e` | PR + web changed + web deployed |

## Benefits
- 🚀 **Faster CI**: Skip unnecessary deployments and tests
- 📊 **Single source of truth**: All change detection in one place
- 💰 **Cost savings**: Reduced compute resource usage
- 🎯 **Clearer dependencies**: Job relationships are explicit
- 🧹 **Cleaner code**: Removed ~40 lines of redundant logic

## Example Scenarios

### Scenario 1: Only docs changed
- ✅ lint, test run
- ✅ deploy-docs runs
- ❌ deploy-web skips
- ❌ cli-e2e skips
- ❌ web-e2e skips

### Scenario 2: Only CLI changed
- ✅ lint, test run
- ✅ deploy-web runs (needed for CLI e2e)
- ❌ deploy-docs skips
- ✅ cli-e2e runs
- ❌ web-e2e skips

### Scenario 3: Web app changed
- ✅ lint, test run
- ✅ deploy-web runs
- ❌ deploy-docs skips
- ❌ cli-e2e skips (unless CLI also changed)
- ✅ web-e2e runs

## Test plan
- [ ] CI passes with no unnecessary job runs
- [ ] PRs that only change docs don't trigger web deployment
- [ ] PRs that only change CLI still deploy web (for e2e)
- [ ] Push to main still runs all jobs

🤖 Generated with [Claude Code](https://claude.ai/code)