### PR TITLE
chore: update devcontainer image to latest version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "USpark Development",
-  "image": "ghcr.io/uspark-hq/uspark-dev:bd056ee",
+  "image": "ghcr.io/uspark-hq/uspark-dev:1dacb9c",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {}
   },


### PR DESCRIPTION
## Summary
- Updated devcontainer image tag from `bd056ee` to `1dacb9c`
- Includes PostgreSQL permission fixes from PR #198

## Why
The new image includes fixes for PostgreSQL permission issues that were preventing the database from starting correctly in the devcontainer.

## Test plan
- [ ] Rebuild devcontainer with new image
- [ ] Verify PostgreSQL starts automatically
- [ ] Confirm `psql $DATABASE_URL` works without manual fixes

🤖 Generated with [Claude Code](https://claude.ai/code)