### PR TITLE
feat: add aws bedrock sts token generation task to mvp

### DIFF
--- a/spec/issues/mvp.md
+++ b/spec/issues/mvp.md
@@ -106,6 +106,7 @@ This document defines the mid-term goals and user stories for the MVP release of
 5. ⏳ Chat interface component (UI only, no backend)
 6. [ ] Polling system for status updates
 7. [ ] Document change detection via YJS polling
+8. [ ] AWS Bedrock STS token generation for E2B Claude Code tasks
 
 ### Phase 5: Sharing Features (Story 3)
 


### PR DESCRIPTION
## Summary
- Added AWS Bedrock STS token generation task to Phase 4 (AI Integration) of the MVP specification
- This token will be passed to E2B containers for Claude Code task execution

## Changes
- Updated `/spec/issues/mvp.md` to include the new task item

🤖 Generated with [Claude Code](https://claude.ai/code)