### PR TITLE
feat: add E2B API key to deployment workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,6 +94,7 @@ jobs:
             DATABASE_URL=${{ steps.get-db-url.outputs.database-url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
+            E2B_API_KEY=${{ secrets.E2B_API_KEY }}
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -154,6 +154,7 @@ jobs:
             DATABASE_URL=${{ steps.branch.outputs.database-url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
             CLERK_SECRET_KEY=${{ secrets.CLERK_SECRET_KEY }}
+            E2B_API_KEY=${{ secrets.E2B_API_KEY }}
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -7,6 +7,7 @@ function initEnv() {
       DATABASE_URL: z.string().min(1),
       CLERK_SECRET_KEY: z.string().min(1),
       BLOB_READ_WRITE_TOKEN: z.string().min(1),
+      E2B_API_KEY: z.string().min(1).optional(),
     },
     client: {
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1),
@@ -15,6 +16,7 @@ function initEnv() {
       DATABASE_URL: process.env.DATABASE_URL,
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
       BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
+      E2B_API_KEY: process.env.E2B_API_KEY,
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
         process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     },

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -10,7 +10,8 @@
     "USPARK_API_URL",
     "USPARK_TOKEN",
     "VERCEL_BLOB_UPLOAD_URL",
-    "VERCEL_BLOB_URL"
+    "VERCEL_BLOB_URL",
+    "E2B_API_KEY"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Add E2B_API_KEY secret to Vercel deployment environment variables
- Configure E2B API key for both preview and production deployments
- Update web app environment configuration to support E2B integration

## Changes
- ✅ Added E2B_API_KEY to GitHub secrets (both E2B_API_KEY and E2B_ACCESS_TOKEN are configured)
- ✅ Updated deployment workflows to pass E2B_API_KEY to Vercel
- ✅ Added E2B_API_KEY to web app environment validation (optional)
- ✅ Added E2B_API_KEY to turbo globalEnv for proper caching

## Testing
The deployment workflows will now include the E2B API key, enabling:
- E2B sandbox functionality in preview deployments
- E2B integration in production environment
- Proper environment validation for E2B services

🤖 Generated with [Claude Code](https://claude.ai/code)