### PR TITLE
fix: use relative path in claude hook script

### DIFF
--- a/scripts/claude-hook-check-push.sh
+++ b/scripts/claude-hook-check-push.sh
@@ -17,7 +17,7 @@ if echo "$COMMAND" | grep -qE "git\s+push"; then
     export SKIP_VERCEL_CHECK=1
     
     # Run the CI check script, redirect output to stderr
-    if /workspaces/uspark2/scripts/ci-check.sh >&2; then
+    if "$(dirname "$0")/ci-check.sh" >&2; then
         echo "✅ CI checks passed, allowing git push" >&2
         # Return correct format for Claude Code hook
         echo '{


### PR DESCRIPTION
## Summary
- Fixed hardcoded workspace path in claude-hook-check-push.sh
- Changed from absolute path `/workspaces/uspark2/scripts/ci-check.sh` to relative path using `$(dirname "$0")/ci-check.sh`
- This makes the script work regardless of workspace directory name (uspark2, uspark6, etc.)

## Test plan
- [x] Verified the script can now find ci-check.sh using relative path
- [x] Hook no longer throws "file not found" error