### PR TITLE
chore: update vitest from 3.2.0 to 3.2.4 in workspace app

### DIFF
--- a/turbo/apps/workspace/package.json
+++ b/turbo/apps/workspace/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.4"
   },
   "msw": {
     "workerDirectory": [

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         specifier: ^6.3.5
         version: 6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)
       vitest:
-        specifier: ^3.2.0
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
 
   packages/core:


### PR DESCRIPTION
## Summary
- Updates vitest dependency from 3.2.0 to 3.2.4 in the workspace app
- Updates pnpm lockfile accordingly

## Type of Change
- Dependency update (patch version)

## Test Plan
- [ ] Run tests to ensure they still pass with updated version
- [ ] Verify workspace app builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)