### PR TITLE
chore: add workspace app to release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,9 @@
         },
         "turbo/apps/docs": {
             "releaseType": "node"
+        },
+        "turbo/apps/workspace": {
+            "releaseType": "node"
         }
     },
     "plugins": [


### PR DESCRIPTION
## Summary
Add workspace app to the release-please configuration to include it in the automated release process.

## Changes
- Added `turbo/apps/workspace` entry to release-please-config.json with `releaseType: "node"`

This ensures the workspace app will be included in version management and release notes generation.

🤖 Generated with [Claude Code](https://claude.ai/code)