### PR TITLE
chore: set workspace app initial version to 0.0.1

### DIFF
--- a/turbo/apps/workspace/package.json
+++ b/turbo/apps/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
Set the workspace app's initial version to 0.0.1 to start from the beginning of semantic versioning.

## Changes
- Updated workspace package.json version from 1.0.0 to 0.0.1

This ensures the workspace app follows proper semantic versioning from its initial release.

🤖 Generated with [Claude Code](https://claude.ai/code)