### PR TITLE
refactor: change workspace app routing to use root path

### DIFF
--- a/turbo/apps/workspace/src/signals/bootstrap.ts
+++ b/turbo/apps/workspace/src/signals/bootstrap.ts
@@ -23,7 +23,7 @@ const setupAuthPageWrapper = (
 
 const ROUTE_CONFIG = [
   {
-    path: '/workspace',
+    path: '/',
     setup: setupAuthPageWrapper(setupWorkspacePage$),
   },
   {

--- a/turbo/apps/workspace/src/types/route.ts
+++ b/turbo/apps/workspace/src/types/route.ts
@@ -1,1 +1,1 @@
-export type RoutePath = '/workspace' | '/projects/:id'
+export type RoutePath = '/' | '/projects/:id'

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -21,6 +21,6 @@ describe('projectPage', () => {
     expect(back).toBeInTheDocument()
     await user.click(back)
 
-    expect(context.store.get(pathname$)).toBe('/workspace')
+    expect(context.store.get(pathname$)).toBe('/')
   })
 })

--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -4,7 +4,7 @@ export function ProjectPage() {
   return (
     <>
       <div>Project Page</div>
-      <Link pathname="/workspace">Go to Workspace</Link>
+      <Link pathname="/">Go to Workspace</Link>
     </>
   )
 }

--- a/turbo/apps/workspace/src/views/workspace/__tests__/workspace.test.tsx
+++ b/turbo/apps/workspace/src/views/workspace/__tests__/workspace.test.tsx
@@ -6,7 +6,7 @@ const context = testContext()
 
 describe('homePage', () => {
   beforeEach(async () => {
-    await setupPage('/workspace', context)
+    await setupPage('/', context)
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Changed workspace app homepage route from `/workspace` to `/`
- Updated all references and tests to use the new root path
- Aligned with the dedicated domain setup (app.uspark.ai)

## Changes
- Modified route configuration in `bootstrap.ts` to use `/` for workspace page
- Updated `RoutePath` type definition to reflect new routing
- Fixed navigation link in project page to point to root
- Updated all related tests to use the new path

## Testing
- All tests passing ✅
- Linting and type checks clean ✅
- Verified routing logic works correctly