### PR TITLE
feat: replace native html elements with shadcn/ui components

### DIFF
--- a/turbo/apps/web/app/page.tsx
+++ b/turbo/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SignUpButton } from "@clerk/nextjs";
+import { Button } from "@uspark/ui";
 import {
   AINetworkIllustration,
   DataFlowIllustration,
@@ -40,7 +41,9 @@ export default function Home() {
 
             <div className={styles.heroCta}>
               <SignUpButton mode="modal">
-                <button className={styles.primaryButton}>Join Waitlist</button>
+                <Button size="lg" className={styles.primaryButton}>
+                  Join Waitlist
+                </Button>
               </SignUpButton>
             </div>
           </div>
@@ -325,7 +328,9 @@ export default function Home() {
             disappear into the void.
           </p>
           <SignUpButton mode="modal">
-            <button className={styles.primaryButton}>Join Waitlist</button>
+            <Button size="lg" className={styles.primaryButton}>
+              Join Waitlist
+            </Button>
           </SignUpButton>
           <p className={styles.finalCtaBottomText}>
             Free to start. No credit card required. Your documents stay yours

--- a/turbo/apps/web/app/projects/page.tsx
+++ b/turbo/apps/web/app/projects/page.tsx
@@ -2,6 +2,20 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@uspark/ui";
 
 import type { Project } from "@uspark/core";
 
@@ -166,31 +180,10 @@ export default function ProjectsListPage() {
               </p>
             </div>
 
-            <button
-              onClick={() => setShowCreateDialog(true)}
-              style={{
-                padding: "12px 24px",
-                backgroundColor: "#3b82f6",
-                color: "white",
-                border: "none",
-                borderRadius: "8px",
-                fontSize: "16px",
-                fontWeight: "500",
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-              }}
-              onMouseOver={(e) => {
-                e.currentTarget.style.backgroundColor = "#2563eb";
-              }}
-              onMouseOut={(e) => {
-                e.currentTarget.style.backgroundColor = "#3b82f6";
-              }}
-            >
+            <Button onClick={() => setShowCreateDialog(true)} size="lg">
               <span>+</span>
               New Project
-            </button>
+            </Button>
           </div>
         </div>
       </header>
@@ -220,73 +213,29 @@ export default function ProjectsListPage() {
           }}
         >
           {projects.map((project) => (
-            <div
+            <Card
               key={project.id}
+              className="cursor-pointer transition-all hover:shadow-lg hover:-translate-y-0.5"
               onClick={() => router.push(`/projects/${project.id}`)}
-              style={{
-                border: "1px solid rgba(156, 163, 175, 0.2)",
-                borderRadius: "12px",
-                padding: "24px",
-                backgroundColor: "var(--background)",
-                cursor: "pointer",
-                transition: "all 0.2s ease",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.borderColor = "rgba(59, 130, 246, 0.4)";
-                e.currentTarget.style.transform = "translateY(-2px)";
-                e.currentTarget.style.boxShadow =
-                  "0 8px 25px rgba(0, 0, 0, 0.1)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.borderColor = "rgba(156, 163, 175, 0.2)";
-                e.currentTarget.style.transform = "translateY(0)";
-                e.currentTarget.style.boxShadow = "none";
-              }}
             >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  marginBottom: "16px",
-                }}
-              >
-                <div style={{ fontSize: "32px", marginRight: "12px" }}>📁</div>
-                <div>
-                  <h3
-                    style={{
-                      fontSize: "18px",
-                      fontWeight: "600",
-                      margin: "0 0 4px 0",
-                    }}
-                  >
-                    {project.name}
-                  </h3>
-                  <p
-                    style={{
-                      fontSize: "12px",
-                      color: "rgba(156, 163, 175, 0.6)",
-                      margin: 0,
-                    }}
-                  >
-                    Updated {formatDate(project.updated_at)}
-                  </p>
+              <CardHeader>
+                <div className="flex items-center">
+                  <div className="text-3xl mr-3">📁</div>
+                  <div>
+                    <CardTitle>{project.name}</CardTitle>
+                    <CardDescription>
+                      Updated {formatDate(project.updated_at)}
+                    </CardDescription>
+                  </div>
                 </div>
-              </div>
-
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  fontSize: "14px",
-                  color: "rgba(156, 163, 175, 0.8)",
-                  paddingTop: "16px",
-                  borderTop: "1px solid rgba(156, 163, 175, 0.1)",
-                }}
-              >
-                <span>0 files</span>
-                <span>{formatFileSize(0)}</span>
-              </div>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex justify-between text-sm text-muted-foreground">
+                  <span>0 files</span>
+                  <span>{formatFileSize(0)}</span>
+                </div>
+              </CardContent>
+            </Card>
           ))}
         </div>
 
@@ -305,150 +254,60 @@ export default function ProjectsListPage() {
             <p style={{ fontSize: "16px", marginBottom: "32px" }}>
               Create your first project to start collaborating with Claude Code
             </p>
-            <button
-              onClick={() => setShowCreateDialog(true)}
-              style={{
-                padding: "12px 24px",
-                backgroundColor: "#3b82f6",
-                color: "white",
-                border: "none",
-                borderRadius: "8px",
-                fontSize: "16px",
-                cursor: "pointer",
-              }}
-            >
+            <Button onClick={() => setShowCreateDialog(true)} size="lg">
               Create Project
-            </button>
+            </Button>
           </div>
         )}
       </main>
 
       {/* Create Project Dialog */}
-      {showCreateDialog && (
-        <div
-          style={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: "rgba(0, 0, 0, 0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 1000,
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: "var(--background)",
-              borderRadius: "12px",
-              padding: "32px",
-              width: "400px",
-              maxWidth: "90vw",
-              border: "1px solid rgba(156, 163, 175, 0.2)",
-            }}
-          >
-            <h3
-              style={{
-                fontSize: "20px",
-                fontWeight: "600",
-                margin: "0 0 16px 0",
-              }}
-            >
-              Create New Project
-            </h3>
-
-            <div style={{ marginBottom: "24px" }}>
-              <label
-                style={{
-                  display: "block",
-                  fontSize: "14px",
-                  fontWeight: "500",
-                  marginBottom: "8px",
-                  color: "var(--foreground)",
-                }}
-              >
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Project</DialogTitle>
+            <DialogDescription>
+              Give your project a name to get started.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <label htmlFor="name" className="text-sm font-medium">
                 Project Name
               </label>
               <input
+                id="name"
                 type="text"
                 value={newProjectName}
                 onChange={(e) => setNewProjectName(e.target.value)}
                 placeholder="Enter project name..."
-                style={{
-                  width: "100%",
-                  padding: "12px",
-                  border: "2px solid rgba(156, 163, 175, 0.2)",
-                  borderRadius: "6px",
-                  fontSize: "16px",
-                  backgroundColor: "var(--background)",
-                  color: "var(--foreground)",
-                  outline: "none",
-                }}
-                onFocus={(e) => {
-                  e.target.style.borderColor = "rgba(59, 130, 246, 0.5)";
-                }}
-                onBlur={(e) => {
-                  e.target.style.borderColor = "rgba(156, 163, 175, 0.2)";
-                }}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && !creating) {
                     handleCreateProject();
-                  } else if (e.key === "Escape") {
-                    setShowCreateDialog(false);
                   }
                 }}
                 autoFocus
               />
             </div>
-
-            <div
-              style={{
-                display: "flex",
-                gap: "12px",
-                justifyContent: "flex-end",
-              }}
-            >
-              <button
-                onClick={() => setShowCreateDialog(false)}
-                disabled={creating}
-                style={{
-                  padding: "10px 20px",
-                  border: "1px solid rgba(156, 163, 175, 0.2)",
-                  borderRadius: "6px",
-                  fontSize: "14px",
-                  backgroundColor: "transparent",
-                  color: "var(--foreground)",
-                  cursor: creating ? "not-allowed" : "pointer",
-                  opacity: creating ? 0.5 : 1,
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleCreateProject}
-                disabled={!newProjectName.trim() || creating}
-                style={{
-                  padding: "10px 20px",
-                  backgroundColor: "#3b82f6",
-                  color: "white",
-                  border: "none",
-                  borderRadius: "6px",
-                  fontSize: "14px",
-                  cursor:
-                    !newProjectName.trim() || creating
-                      ? "not-allowed"
-                      : "pointer",
-                  opacity: !newProjectName.trim() || creating ? 0.5 : 1,
-                }}
-              >
-                {creating ? "Creating..." : "Create Project"}
-              </button>
-            </div>
           </div>
-        </div>
-      )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowCreateDialog(false)}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreateProject}
+              disabled={!newProjectName.trim() || creating}
+            >
+              {creating ? "Creating..." : "Create Project"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/turbo/apps/web/app/settings/shares/page.tsx
+++ b/turbo/apps/web/app/settings/shares/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { Button } from "@uspark/ui";
 
 interface Share {
   id: string;
@@ -243,57 +244,21 @@ export default function SharesPage() {
                     gap: "8px",
                   }}
                 >
-                  <button
+                  <Button
                     onClick={() => handleCopyLink(share.url)}
-                    style={{
-                      padding: "6px 12px",
-                      fontSize: "12px",
-                      color: "#3b82f6",
-                      backgroundColor: "transparent",
-                      border: "1px solid #3b82f6",
-                      borderRadius: "4px",
-                      cursor: "pointer",
-                      transition: "all 0.2s ease",
-                    }}
-                    onMouseOver={(e) => {
-                      e.currentTarget.style.backgroundColor = "#3b82f6";
-                      e.currentTarget.style.color = "white";
-                    }}
-                    onMouseOut={(e) => {
-                      e.currentTarget.style.backgroundColor = "transparent";
-                      e.currentTarget.style.color = "#3b82f6";
-                    }}
+                    variant="outline"
+                    size="sm"
                   >
                     Copy Link
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => handleDelete(share.id)}
                     disabled={deletingId === share.id}
-                    style={{
-                      padding: "6px 12px",
-                      fontSize: "12px",
-                      color: "#ef4444",
-                      backgroundColor: "transparent",
-                      border: "1px solid #ef4444",
-                      borderRadius: "4px",
-                      cursor:
-                        deletingId === share.id ? "not-allowed" : "pointer",
-                      opacity: deletingId === share.id ? 0.5 : 1,
-                      transition: "all 0.2s ease",
-                    }}
-                    onMouseOver={(e) => {
-                      if (deletingId !== share.id) {
-                        e.currentTarget.style.backgroundColor = "#ef4444";
-                        e.currentTarget.style.color = "white";
-                      }
-                    }}
-                    onMouseOut={(e) => {
-                      e.currentTarget.style.backgroundColor = "transparent";
-                      e.currentTarget.style.color = "#ef4444";
-                    }}
+                    variant="destructive"
+                    size="sm"
                   >
                     {deletingId === share.id ? "Revoking..." : "Revoke"}
-                  </button>
+                  </Button>
                 </div>
               </div>
 

--- a/turbo/apps/web/app/settings/tokens/token-form.tsx
+++ b/turbo/apps/web/app/settings/tokens/token-form.tsx
@@ -35,58 +35,57 @@ export function TokenForm({ action }: TokenFormProps) {
             <CardTitle>Generate New Token</CardTitle>
           </CardHeader>
           <CardContent>
-
-          <div style={{ marginBottom: "16px" }}>
-            <label
-              htmlFor="name"
-              style={{
-                display: "block",
-                marginBottom: "8px",
-                fontWeight: "500",
-                color: "var(--foreground)",
-              }}
-            >
-              Token Name
-            </label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              placeholder="e.g., My Development Token"
-              disabled={isPending}
-              required
-              style={{
-                width: "100%",
-                padding: "10px",
-                border: "1px solid #ccc",
-                borderRadius: "4px",
-                fontSize: "14px",
-                backgroundColor: "var(--background)",
-                color: "var(--foreground)",
-              }}
-            />
-          </div>
-
-          <input name="expires_in_days" type="hidden" value="90" />
-
-          <Button type="submit" disabled={isPending}>
-            {isPending ? "Generating..." : "Generate Token"}
-          </Button>
-
-          {error && (
-            <div
-              style={{
-                backgroundColor: "#fee",
-                border: "1px solid #fcc",
-                borderRadius: "4px",
-                padding: "12px",
-                marginTop: "16px",
-                color: "#c00",
-              }}
-            >
-              {error}
+            <div style={{ marginBottom: "16px" }}>
+              <label
+                htmlFor="name"
+                style={{
+                  display: "block",
+                  marginBottom: "8px",
+                  fontWeight: "500",
+                  color: "var(--foreground)",
+                }}
+              >
+                Token Name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                placeholder="e.g., My Development Token"
+                disabled={isPending}
+                required
+                style={{
+                  width: "100%",
+                  padding: "10px",
+                  border: "1px solid #ccc",
+                  borderRadius: "4px",
+                  fontSize: "14px",
+                  backgroundColor: "var(--background)",
+                  color: "var(--foreground)",
+                }}
+              />
             </div>
-          )}
+
+            <input name="expires_in_days" type="hidden" value="90" />
+
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Generating..." : "Generate Token"}
+            </Button>
+
+            {error && (
+              <div
+                style={{
+                  backgroundColor: "#fee",
+                  border: "1px solid #fcc",
+                  borderRadius: "4px",
+                  padding: "12px",
+                  marginTop: "16px",
+                  color: "#c00",
+                }}
+              >
+                {error}
+              </div>
+            )}
           </CardContent>
         </Card>
       </form>
@@ -97,45 +96,44 @@ export function TokenForm({ action }: TokenFormProps) {
             <CardTitle>Your New Token</CardTitle>
           </CardHeader>
           <CardContent>
+            <div
+              style={{
+                backgroundColor: "#f9f9f9",
+                border: "1px solid #e1e1e1",
+                borderRadius: "4px",
+                padding: "12px",
+                fontFamily: "monospace",
+                fontSize: "13px",
+                marginBottom: "12px",
+                wordBreak: "break-all",
+                color: "#333",
+              }}
+            >
+              {token}
+            </div>
 
-          <div
-            style={{
-              backgroundColor: "#f9f9f9",
-              border: "1px solid #e1e1e1",
-              borderRadius: "4px",
-              padding: "12px",
-              fontFamily: "monospace",
-              fontSize: "13px",
-              marginBottom: "12px",
-              wordBreak: "break-all",
-              color: "#333",
-            }}
-          >
-            {token}
-          </div>
+            <Button
+              onClick={() => copyToClipboard(token)}
+              variant={copySuccess ? "default" : "secondary"}
+              className="mr-3"
+            >
+              {copySuccess ? "✓ Copied!" : "Copy Token"}
+            </Button>
 
-          <Button
-            onClick={() => copyToClipboard(token)}
-            variant={copySuccess ? "default" : "secondary"}
-            className="mr-3"
-          >
-            {copySuccess ? "✓ Copied!" : "Copy Token"}
-          </Button>
-
-          <div
-            style={{
-              backgroundColor: "#fff3cd",
-              border: "1px solid #ffeaa7",
-              borderRadius: "4px",
-              padding: "12px",
-              marginTop: "16px",
-              color: "#856404",
-            }}
-          >
-            <strong>Important:</strong> This token will only be shown once. Make
-            sure to copy it now and store it securely. You can use it by setting
-            the <code>USPARK_TOKEN</code> environment variable.
-          </div>
+            <div
+              style={{
+                backgroundColor: "#fff3cd",
+                border: "1px solid #ffeaa7",
+                borderRadius: "4px",
+                padding: "12px",
+                marginTop: "16px",
+                color: "#856404",
+              }}
+            >
+              <strong>Important:</strong> This token will only be shown once.
+              Make sure to copy it now and store it securely. You can use it by
+              setting the <code>USPARK_TOKEN</code> environment variable.
+            </div>
           </CardContent>
         </Card>
       )}

--- a/turbo/apps/web/app/settings/tokens/token-form.tsx
+++ b/turbo/apps/web/app/settings/tokens/token-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useActionState } from "react";
+import { Button, Card, CardContent, CardHeader, CardTitle } from "@uspark/ui";
 import { type GenerateTokenResult } from "./actions";
 
 interface TokenFormProps {
@@ -29,24 +30,11 @@ export function TokenForm({ action }: TokenFormProps) {
   return (
     <>
       <form action={formAction}>
-        <div
-          style={{
-            backgroundColor: "var(--background)",
-            border: "1px solid #e5e5e5",
-            borderRadius: "8px",
-            padding: "24px",
-            marginBottom: "20px",
-          }}
-        >
-          <h2
-            style={{
-              fontSize: "1.25rem",
-              marginBottom: "16px",
-              color: "var(--foreground)",
-            }}
-          >
-            Generate New Token
-          </h2>
+        <Card className="mb-5">
+          <CardHeader>
+            <CardTitle>Generate New Token</CardTitle>
+          </CardHeader>
+          <CardContent>
 
           <div style={{ marginBottom: "16px" }}>
             <label
@@ -81,22 +69,9 @@ export function TokenForm({ action }: TokenFormProps) {
 
           <input name="expires_in_days" type="hidden" value="90" />
 
-          <button
-            type="submit"
-            disabled={isPending}
-            style={{
-              backgroundColor: isPending ? "#ccc" : "#0070f3",
-              color: "white",
-              border: "none",
-              padding: "10px 20px",
-              borderRadius: "4px",
-              fontSize: "14px",
-              cursor: isPending ? "not-allowed" : "pointer",
-              transition: "background-color 0.2s",
-            }}
-          >
+          <Button type="submit" disabled={isPending}>
             {isPending ? "Generating..." : "Generate Token"}
-          </button>
+          </Button>
 
           {error && (
             <div
@@ -112,27 +87,16 @@ export function TokenForm({ action }: TokenFormProps) {
               {error}
             </div>
           )}
-        </div>
+          </CardContent>
+        </Card>
       </form>
 
       {token && (
-        <div
-          style={{
-            backgroundColor: "var(--background)",
-            border: "1px solid #e5e5e5",
-            borderRadius: "8px",
-            padding: "24px",
-          }}
-        >
-          <h2
-            style={{
-              fontSize: "1.25rem",
-              marginBottom: "16px",
-              color: "var(--foreground)",
-            }}
-          >
-            Your New Token
-          </h2>
+        <Card>
+          <CardHeader>
+            <CardTitle>Your New Token</CardTitle>
+          </CardHeader>
+          <CardContent>
 
           <div
             style={{
@@ -150,22 +114,13 @@ export function TokenForm({ action }: TokenFormProps) {
             {token}
           </div>
 
-          <button
+          <Button
             onClick={() => copyToClipboard(token)}
-            style={{
-              backgroundColor: copySuccess ? "#28a745" : "#6c757d",
-              color: "white",
-              border: "none",
-              padding: "8px 16px",
-              borderRadius: "4px",
-              fontSize: "14px",
-              cursor: "pointer",
-              marginRight: "12px",
-              transition: "background-color 0.2s",
-            }}
+            variant={copySuccess ? "default" : "secondary"}
+            className="mr-3"
           >
             {copySuccess ? "✓ Copied!" : "Copy Token"}
-          </button>
+          </Button>
 
           <div
             style={{
@@ -181,7 +136,8 @@ export function TokenForm({ action }: TokenFormProps) {
             sure to copy it now and store it securely. You can use it by setting
             the <code>USPARK_TOKEN</code> environment variable.
           </div>
-        </div>
+          </CardContent>
+        </Card>
       )}
     </>
   );

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -20,6 +20,7 @@
     "@neondatabase/serverless": "^1.0.1",
     "@t3-oss/env-nextjs": "^0.13.8",
     "@uspark/core": "workspace:*",
+    "@uspark/ui": "workspace:*",
     "@vercel/blob": "^1.1.1",
     "drizzle-orm": "^0.44.5",
     "nanoid": "^5.1.5",

--- a/turbo/packages/ui/src/components/ui/button.tsx
+++ b/turbo/packages/ui/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/turbo/packages/ui/src/components/ui/card.tsx
+++ b/turbo/packages/ui/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       '@uspark/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@uspark/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@vercel/blob':
         specifier: ^1.1.1
         version: 1.1.1
@@ -8033,26 +8036,6 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
-    dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.18
-      sirv: 3.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
-      ws: 8.18.3
-    optionalDependencies:
-      playwright: 1.55.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -8068,9 +8051,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -8099,16 +8082,6 @@ snapshots:
     optionalDependencies:
       msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
       vite: 6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)
-
-  '@vitest/mocker@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.18
-    optionalDependencies:
-      msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
-      vite: 7.1.3(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)
-    optional: true
 
   '@vitest/pretty-format@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrated web app to use shadcn/ui components from packages/ui
- Replaced native HTML elements with proper shadcn components for consistency
- Fixed import paths in shadcn components to use relative imports

## Changes
- **Button Component**: Replaced all native `<button>` elements with shadcn Button component
- **Card Component**: Replaced custom containers with Card, CardHeader, CardTitle, CardDescription, and CardContent
- **Dialog Component**: Replaced custom modal implementation with Dialog component in projects page

## Modified Files
- `/app/page.tsx` - Homepage buttons  
- `/app/projects/page.tsx` - Project list (buttons, cards, dialog)
- `/app/settings/tokens/token-form.tsx` - Token form (buttons, cards)
- `/app/settings/shares/page.tsx` - Share page buttons
- Fixed import paths in UI package components

## Benefits
- Consistent UI components across the application
- Professional design with built-in variants (default, outline, destructive, secondary)
- Better accessibility and responsive design
- Reduced custom CSS code

## Testing
- ✅ All lint checks pass
- ✅ All type checks pass
- ✅ Components render correctly with proper styling