### PR TITLE
refactor: convert dynamic imports to static imports

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -69,6 +69,12 @@ Each commit is reviewed against these criteria:
 - Flag timeout increases to pass tests
 - Suggest deterministic alternatives to time-based solutions
 
+### 6. Dynamic Import Analysis
+- Identify dynamic `import()` calls that could be static imports
+- Convert runtime dynamic imports to static imports at file top
+- Preserve type-only imports (JSDoc/TypeScript annotations)
+- Flag unnecessary async operations from dynamic imports
+
 ## Output Structure
 
 ```

--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "os";
 import { join } from "path";
 import { mkdtemp, readFile, rm } from "fs/promises";
+import { readdirSync } from "fs";
 import { mockServer } from "../test/mock-server";
 
 // Import the pull command functions for direct testing
@@ -177,7 +178,6 @@ describe("pull --all command", () => {
     });
 
     // Verify no files were created
-    const { readdirSync } = await import("fs");
     const files = readdirSync(tempDir);
     expect(files).toHaveLength(0);
   });

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -1,5 +1,7 @@
 import chalk from "chalk";
 import { requireAuth } from "./shared";
+import { readdir } from "fs/promises";
+import { join } from "path";
 
 export async function pullCommand(
   filePath: string,
@@ -54,8 +56,6 @@ export async function pushCommand(
     );
 
     // Get all files in current directory recursively
-    const { readdir } = await import("fs/promises");
-    const { join } = await import("path");
 
     const getAllFiles = async (dir: string): Promise<string[]> => {
       const files: string[] = [];

--- a/turbo/apps/workspace/src/main.ts
+++ b/turbo/apps/workspace/src/main.ts
@@ -1,10 +1,10 @@
 import './polyfill'
 import { createStore, type Store } from 'ccstate'
 import { createRoot } from 'react-dom/client'
+import { worker } from './mocks/browser'
 import { bootstrap$ } from './signals/bootstrap'
 import { detach, Reason } from './signals/utils'
 import { setupRouter } from './views/main'
-import { worker } from './mocks/browser'
 
 async function setupMockServer(signal: AbortSignal) {
   signal.throwIfAborted()

--- a/turbo/apps/workspace/src/main.ts
+++ b/turbo/apps/workspace/src/main.ts
@@ -4,9 +4,9 @@ import { createRoot } from 'react-dom/client'
 import { bootstrap$ } from './signals/bootstrap'
 import { detach, Reason } from './signals/utils'
 import { setupRouter } from './views/main'
+import { worker } from './mocks/browser'
 
 async function setupMockServer(signal: AbortSignal) {
-  const { worker } = await import('./mocks/browser')
   signal.throwIfAborted()
 
   signal.addEventListener('abort', () => {


### PR DESCRIPTION
## Summary
- Converted all runtime dynamic `import()` calls to static imports at the top of files
- Improves code consistency and eliminates unnecessary async operations
- Remaining `import()` occurrences are type-only annotations that don't need conversion

## Changes
- **turbo/apps/cli/src/commands/sync.ts**: Converted `fs/promises` and `path` dynamic imports
- **turbo/apps/cli/src/__tests__/pull.test.ts**: Converted `fs` dynamic import  
- **turbo/apps/workspace/src/main.ts**: Converted `mocks/browser` dynamic import

## Test plan
- [ ] Verify CLI commands still work correctly
- [ ] Ensure tests pass without issues
- [ ] Confirm workspace application starts properly

🤖 Generated with [Claude Code](https://claude.ai/code)