### PR TITLE
feat: add custom fetch support to contractfetch and integrate with workspace

### DIFF
--- a/turbo/apps/workspace/package.json
+++ b/turbo/apps/workspace/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@clerk/clerk-js": "^5.92.1",
+    "@uspark/core": "workspace:*",
     "ccstate": "^5.0.0",
     "ccstate-react": "^5.0.0",
     "path-to-regexp": "^8.3.0",

--- a/turbo/apps/workspace/src/signals/external/__tests__/project.test.ts
+++ b/turbo/apps/workspace/src/signals/external/__tests__/project.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for project external signals
+ */
+
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { testContext } from '../../__tests__/context'
+import { server } from '../../../mocks/node'
+import { createProject$ } from '../project'
+
+const context = testContext()
+
+describe('createProject$', () => {
+  it('should create a project successfully', async () => {
+    const { store, signal } = context
+
+    const mockProject = {
+      id: 'project-123',
+      name: 'Test Project',
+      created_at: '2024-01-01T00:00:00Z',
+    }
+
+    server.use(
+      http.post('*/api/projects', async ({ request }) => {
+        const body = (await request.json()) as { name: string }
+
+        expect(body).toMatchObject({
+          name: 'Test Project',
+        })
+
+        return HttpResponse.json(mockProject, { status: 201 })
+      }),
+    )
+
+    // 执行 command
+    const result = await store.set(
+      createProject$,
+      {
+        name: 'Test Project',
+      },
+      signal,
+    )
+
+    // 验证结果
+    expect(result).toStrictEqual(mockProject)
+  })
+})

--- a/turbo/apps/workspace/src/signals/external/project.ts
+++ b/turbo/apps/workspace/src/signals/external/project.ts
@@ -1,0 +1,25 @@
+import { contractFetch } from '@uspark/core/contract-fetch'
+import {
+  projectsContract,
+  type CreateProjectResponse,
+} from '@uspark/core/contracts/projects.contract'
+import { command } from 'ccstate'
+import { fetch$ } from '../fetch'
+
+export const createProject$ = command(
+  async (
+    { get },
+    params: { name: string },
+    signal: AbortSignal,
+  ): Promise<CreateProjectResponse> => {
+    const workspaceFetch = get(fetch$)
+
+    return await contractFetch(projectsContract.createProject, {
+      body: {
+        name: params.name,
+      },
+      fetch: workspaceFetch as typeof globalThis.fetch,
+      signal,
+    })
+  },
+)

--- a/turbo/packages/core/tsconfig.json
+++ b/turbo/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@uspark/typescript-config/base.json",
   "compilerOptions": {
-    "lib": ["ES2022"]
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*"],
   "exclude": [

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@clerk/clerk-js':
         specifier: ^5.92.1
         version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+      '@uspark/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       ccstate:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
## Summary
- Enhanced contractFetch to accept custom fetch function and signal parameters for request cancellation
- Integrated @uspark/core package into workspace app for type-safe API calls
- Created external signals directory with createProject$ command using the new contractFetch capability

## Changes
- Modified `packages/core/src/contract-fetch.ts` to accept optional `fetch` and `signal` parameters
- Added @uspark/core as workspace dependency in `apps/workspace/package.json`
- Created `apps/workspace/src/signals/external/project.ts` with createProject$ command
- Added comprehensive tests in `apps/workspace/src/signals/external/__tests__/project.test.ts` using MSW
- Updated TypeScript configuration to include DOM types

## Test Plan
- [x] All existing tests pass
- [x] New tests for createProject$ command pass
- [x] Type checking passes
- [x] Linting passes
- [x] Knip analysis passes

## Benefits
This enables workspace to use type-safe contract calls with its custom fetch that automatically handles:
- Authentication tokens
- API base URLs
- Request cancellation via AbortSignal

🤖 Generated with [Claude Code](https://claude.ai/code)