### PR TITLE
refactor: remove unnecessary try-catch blocks to follow fail-fast principle

### DIFF
--- a/turbo/apps/web/app/api/github/installations/route.ts
+++ b/turbo/apps/web/app/api/github/installations/route.ts
@@ -13,12 +13,7 @@ export async function GET() {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  try {
-    const installations = await getUserInstallations(userId);
+  const installations = await getUserInstallations(userId);
 
-    return NextResponse.json({ installations });
-  } catch (error) {
-    console.error("Error getting installations:", error);
-    return NextResponse.json({ error: "internal_error" }, { status: 500 });
-  }
+  return NextResponse.json({ installations });
 }

--- a/turbo/apps/web/app/api/github/webhook/route.ts
+++ b/turbo/apps/web/app/api/github/webhook/route.ts
@@ -13,56 +13,48 @@ export async function POST(request: NextRequest) {
 
   const webhookSecret = globalThis.services.env.GH_WEBHOOK_SECRET;
 
-  try {
-    const body = await request.text();
-    const signature = request.headers.get("x-hub-signature-256");
-    const eventType = request.headers.get("x-github-event");
+  const body = await request.text();
+  const signature = request.headers.get("x-hub-signature-256");
+  const eventType = request.headers.get("x-github-event");
 
-    if (!signature || !eventType) {
-      return NextResponse.json(
-        { error: "Missing required headers" },
-        { status: 400 },
-      );
-    }
-
-    // Verify webhook signature
-    const webhooks = new Webhooks({ secret: webhookSecret });
-    const isValid = await webhooks.verify(body, signature);
-
-    if (!isValid) {
-      console.error("Invalid webhook signature");
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
-    }
-
-    const payload = JSON.parse(body);
-
-    // Handle different event types
-    switch (eventType) {
-      case "installation":
-        await handleInstallationEvent(payload);
-        break;
-
-      case "installation_repositories":
-        await handleInstallationRepositoriesEvent(payload);
-        break;
-
-      case "push":
-        // TODO: Handle push events for future GitHub → Web sync
-        console.log("Push event received (not implemented yet)");
-        break;
-
-      default:
-        console.log(`Unhandled webhook event: ${eventType}`);
-    }
-
-    return NextResponse.json({ message: "Webhook processed" });
-  } catch (error) {
-    console.error("Webhook processing error:", error);
+  if (!signature || !eventType) {
     return NextResponse.json(
-      { error: "Webhook processing failed" },
-      { status: 500 },
+      { error: "Missing required headers" },
+      { status: 400 },
     );
   }
+
+  // Verify webhook signature
+  const webhooks = new Webhooks({ secret: webhookSecret });
+  const isValid = await webhooks.verify(body, signature);
+
+  if (!isValid) {
+    console.error("Invalid webhook signature");
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const payload = JSON.parse(body);
+
+  // Handle different event types
+  switch (eventType) {
+    case "installation":
+      await handleInstallationEvent(payload);
+      break;
+
+    case "installation_repositories":
+      await handleInstallationRepositoriesEvent(payload);
+      break;
+
+    case "push":
+      // TODO: Handle push events for future GitHub → Web sync
+      console.log("Push event received (not implemented yet)");
+      break;
+
+    default:
+      console.log(`Unhandled webhook event: ${eventType}`);
+  }
+
+  return NextResponse.json({ message: "Webhook processed" });
 }
 
 /**

--- a/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.ts
@@ -54,30 +54,21 @@ export async function GET(
     return NextResponse.json(error, { status: 500 });
   }
 
-  try {
-    // Generate a secure client token with project-scoped permissions
-    const clientToken = await generateClientTokenFromReadWriteToken({
-      token: readWriteToken,
-      pathname: `projects/${projectId}/*`,
-      validUntil: Date.now() + 10 * 60 * 1000, // 10 minutes
-      allowedContentTypes: ["text/*", "application/*", "image/*"],
-    });
+  // Generate a secure client token with project-scoped permissions
+  const clientToken = await generateClientTokenFromReadWriteToken({
+    token: readWriteToken,
+    pathname: `projects/${projectId}/*`,
+    validUntil: Date.now() + 10 * 60 * 1000, // 10 minutes
+    allowedContentTypes: ["text/*", "application/*", "image/*"],
+  });
 
-    // Return the client token with upload/download URLs
-    const response: BlobTokenResponse = {
-      token: clientToken,
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(), // 10 minutes
-      uploadUrl: "https://blob.vercel-storage.com/upload",
-      downloadUrlPrefix: "https://blob.vercel-storage.com/files",
-    };
+  // Return the client token with upload/download URLs
+  const response: BlobTokenResponse = {
+    token: clientToken,
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(), // 10 minutes
+    uploadUrl: "https://blob.vercel-storage.com/upload",
+    downloadUrlPrefix: "https://blob.vercel-storage.com/files",
+  };
 
-    return NextResponse.json(response);
-  } catch (error) {
-    console.error("Failed to generate client token:", error);
-    const errorResponse: BlobTokenError = {
-      error: "token_generation_failed",
-      error_description: "Failed to generate client token",
-    };
-    return NextResponse.json(errorResponse, { status: 500 });
-  }
+  return NextResponse.json(response);
 }


### PR DESCRIPTION
## Summary
- Remove generic error handling in GitHub installations API
- Remove wrapper try-catch in webhook processing 
- Remove defensive catch for Vercel blob token generation
- Let errors propagate naturally to Next.js error handling
- Keeps legitimate try-catch in GitHub setup with fallback behavior

## Test plan
- [x] Verify API routes still function correctly
- [x] Ensure Next.js error handling catches and processes errors appropriately
- [x] Confirm legitimate try-catch with fallback behavior remains intact

Addresses technical debt item: overuse of try-catch blocks violating fail-fast principle

🤖 Generated with [Claude Code](https://claude.ai/code)