### PR TITLE
fix: replace hardcoded url with env.app_url in device auth

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/device/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.test.ts
@@ -29,7 +29,7 @@ describe("/api/cli/auth/device", () => {
 
       // Check all required fields are present
       expect(validData.user_code).toBe(validData.device_code);
-      expect(validData.verification_url).toBe("https://uspark.ai/cli-auth");
+      expect(validData.verification_url).toBe("http://localhost:3000/cli-auth");
       expect(validData.expires_in).toBe(900); // 15 minutes
     }
   });

--- a/turbo/apps/web/app/api/cli/auth/device/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/device/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { type DeviceAuthResponse } from "@uspark/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { DEVICE_CODES_TBL } from "../../../../../src/db/schema/device-codes";
+import { env } from "../../../../../src/env";
 import crypto from "crypto";
 
 /**
@@ -59,7 +60,7 @@ export async function POST() {
   const response: DeviceAuthResponse = {
     device_code: deviceCode,
     user_code: deviceCode, // Same as device_code for simplicity
-    verification_url: "https://uspark.ai/cli-auth",
+    verification_url: `${env().APP_URL}/cli-auth`,
     expires_in: expiresIn,
     interval: interval,
   };


### PR DESCRIPTION
## Summary
- Replaces hardcoded URL https://uspark.ai/cli-auth with env().APP_URL configuration
- Addresses technical debt item in spec/tech-debt.md
- Enables proper URL configuration for different environments

## Test plan
- [ ] Verify device auth endpoint returns correct URL for production and development environments
- [ ] Ensure environment variable APP_URL is properly loaded
- [ ] Test CLI authentication flow continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)