### PR TITLE
fix: update workspace app to use vite prefixed environment variables

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,7 @@ jobs:
       cli_release_created: ${{ steps.release.outputs['turbo/apps/cli--release_created'] }}
       web_release_created: ${{ steps.release.outputs['turbo/apps/web--release_created'] }}
       docs_release_created: ${{ steps.release.outputs['turbo/apps/docs--release_created'] }}
+      workspace_release_created: ${{ steps.release.outputs['turbo/apps/workspace--release_created'] }}
       core_release_created: ${{ steps.release.outputs['turbo/packages/core--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
@@ -98,6 +99,32 @@ jobs:
             GH_APP_ID=${{ vars.GH_APP_ID }}
             GH_APP_PRIVATE_KEY=${{ secrets.GH_APP_PRIVATE_KEY }}
             GH_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
+
+  # Deploy workspace app to production
+  deploy-workspace-production:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.workspace_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
+    permissions:
+      contents: read
+      deployments: write
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Deploy Workspace to Vercel Production
+        uses: ./.github/actions/vercel-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
+          vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_WORKSPACE }}
+          environment: production
+          deployment-env: workspace
+          environment-variables: |
+            VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
 
   # Deploy docs app to production
   deploy-docs-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -123,6 +123,7 @@ jobs:
           DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/postgres"
           CLERK_SECRET_KEY: "test_clerk_secret_key"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "test_clerk_publishable_key"
+          VITE_CLERK_PUBLISHABLE_KEY: "test_clerk_publishable_key"
 
   # Deploy web application with database
   deploy-web:
@@ -226,6 +227,8 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_WORKSPACE }}
           environment: preview
           deployment-env: workspace
+          environment-variables: |
+            VITE_CLERK_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/turbo/apps/workspace/src/signals/auth.ts
+++ b/turbo/apps/workspace/src/signals/auth.ts
@@ -4,13 +4,11 @@ import { command, computed, state } from 'ccstate'
 const reload$ = state(0)
 
 const clerk$ = computed(async () => {
-  const publishableKey = import.meta.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY as
+  const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as
     | string
     | undefined
   if (!publishableKey) {
-    throw new Error(
-      'Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY environment variable',
-    )
+    throw new Error('Missing VITE_CLERK_PUBLISHABLE_KEY environment variable')
   }
 
   const clerkInstance = new Clerk(publishableKey)

--- a/turbo/apps/workspace/src/vite-env.d.ts
+++ b/turbo/apps/workspace/src/vite-env.d.ts
@@ -1,2 +1,11 @@
 /// <reference types="vite/client" />
 /// <reference types="vite/types/importMeta.d.ts" />
+
+interface ImportMetaEnv {
+  readonly VITE_CLERK_PUBLISHABLE_KEY: string
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/turbo/apps/workspace/vitest.setup.ts
+++ b/turbo/apps/workspace/vitest.setup.ts
@@ -8,7 +8,7 @@ import { clearAllDetached } from './src/signals/utils'
 setupMock()
 
 beforeAll(() => {
-  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'test_key'
+  process.env.VITE_CLERK_PUBLISHABLE_KEY = 'test_key'
 })
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- Fixed workspace app environment variable configuration to use correct Vite prefix (VITE_) instead of Next.js prefix (NEXT_PUBLIC_)
- Added TypeScript definitions for Vite environment variables
- Updated CI/CD workflows to pass correct environment variables to workspace deployments

## Changes
- Replace NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY with VITE_CLERK_PUBLISHABLE_KEY in workspace app code
- Add proper TypeScript definitions in vite-env.d.ts
- Update test setup to use correct environment variable names
- Add workspace deployment configuration to release-please.yml
- Configure VITE_CLERK_PUBLISHABLE_KEY in GitHub Actions for both preview and production deployments

## Test Plan
- [x] Local development tested with correct environment variables
- [ ] CI checks pass
- [ ] Workspace app deploys correctly with Clerk authentication