### PR TITLE
fix: remove broad try-catch block from github sync function

### DIFF
--- a/spec/tech-debt.md
+++ b/spec/tech-debt.md
@@ -135,8 +135,8 @@ const userId = `test-user-{context}-${Date.now()}-${process.pid}`;
 ## GitHub Sync Function Try-Catch Violation
 **Issue:** Main sync function uses broad try-catch that masks error details instead of allowing specific failures to propagate.
 **Source:** Code review commit 5744c7c - review-5744c7c.md
-**Status:** 🔴 **NEW ISSUE**
-**File:** `/turbo/apps/web/app/lib/sync.ts` (Lines 210-304)
+**Status:** ✅ **RESOLVED** (September 13, 2025)
+**File:** `/turbo/apps/web/src/lib/github/sync.ts` (Lines 210-304)
 
 **Problem:**
 ```typescript
@@ -159,7 +159,7 @@ try {
 - Makes debugging sync issues difficult
 - Prevents proper error propagation to calling code
 
-**Solution:** Remove the broad try-catch and let specific operations fail naturally, allowing for targeted error handling only where meaningful recovery is possible.
+**Solution Implemented:** ✅ Removed the broad try-catch block and let specific operations fail naturally, allowing errors to propagate to where they can be properly handled by the calling code.
 
 ## Timer Cleanup Issue
 **Issue:** setTimeout usage without proper cleanup in React component can cause memory leaks and state updates on unmounted components.
@@ -303,7 +303,7 @@ beforeEach(async () => {
 - Direct DB operations: **12 files** (down from 18+)
 - Test mock cleanup missing: **17 files** (58% of files with mocks)
 - TypeScript `any` violations: **3 test files** (down from 5, production code clean)
-- Try-catch violations: **2 new issues** 🔴 (sync.ts, github-sync-button.tsx)
+- Try-catch violations: **1 issue** 🔴 (github-sync-button.tsx)
 - Timer cleanup issues: **1 new issue** 🔴 (github-sync-button.tsx)
 - Hardcoded URLs: **0** ✅ RESOLVED
 - Database test isolation: **Unique IDs implemented** ✅ RESOLVED
@@ -353,7 +353,6 @@ beforeEach(async () => {
 - **Test Mock Cleanup** - 17 files still need `vi.clearAllMocks()` 
 - **Test Code `any` Types** - 3 violations in test files (low priority)
 - **Direct DB Operations in Tests** - 12 files need refactoring to use API endpoints
-- **GitHub Sync Try-Catch** - Remove broad error handling in sync.ts:210-304
 - **Timer Cleanup** - Fix setTimeout cleanup in github-sync-button.tsx:34-36
 
 ### Impact:

--- a/turbo/apps/web/src/lib/github/sync.test.ts
+++ b/turbo/apps/web/src/lib/github/sync.test.ts
@@ -178,7 +178,7 @@ describe("GitHub Sync", () => {
       expect(result.error).toBe("No files to sync");
     });
 
-    it("should handle blob storage configuration error", async () => {
+    it("should throw error when blob storage not configured", async () => {
       const projectId = "proj_test123";
       const userId = "user_123";
       const db = globalThis.services.db;
@@ -212,10 +212,10 @@ describe("GitHub Sync", () => {
         repoId: 67890,
       });
 
-      const result = await syncProjectToGitHub(projectId, userId);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toBe("Blob storage not configured");
+      // Now expect the function to throw instead of returning error
+      await expect(syncProjectToGitHub(projectId, userId)).rejects.toThrow(
+        "Blob storage not configured",
+      );
 
       // Restore token
       process.env.BLOB_READ_WRITE_TOKEN = originalToken;


### PR DESCRIPTION
## Summary
- Remove defensive try-catch wrapper from `syncProjectToGitHub` function to follow fail-fast principle
- Update tech-debt.md to mark GitHub Sync Function Try-Catch Violation as resolved
- Improve error debugging by allowing specific errors to propagate naturally

## Problem
The sync function was using a broad try-catch block that masked error details and violated the fail-fast principle outlined in the project's design guidelines. This made debugging sync issues difficult and prevented proper error propagation.

## Solution
- Removed the defensive try-catch block wrapping the entire sync process (lines 210-304)
- Kept early returns for specific business logic validation (project not found, unauthorized, etc.)
- Now allows GitHub API operations and other async operations to fail naturally
- Errors propagate to calling code where they can be handled appropriately

## Test plan
- [x] Code compiles without TypeScript errors
- [x] Maintains existing error handling for validation logic
- [x] GitHub API errors now propagate naturally instead of being masked
- [x] Tech debt documentation updated to reflect resolution

🤖 Generated with [Claude Code](https://claude.ai/code)