### PR TITLE
refactor: implement complete mirror sync for github integration

### DIFF
--- a/turbo/apps/web/src/lib/github/sync.ts
+++ b/turbo/apps/web/src/lib/github/sync.ts
@@ -126,16 +126,6 @@ async function createGitHubCommit(
 
   const currentCommitSha = ref.object.sha;
 
-  // Get the current tree
-  const { data: currentCommit } = await octokit.request(
-    "GET /repos/{owner}/{repo}/git/commits/{commit_sha}",
-    {
-      owner,
-      repo,
-      commit_sha: currentCommitSha,
-    },
-  );
-
   // Create blobs for each file
   const blobs = await Promise.all(
     files.map(async (file) => {

--- a/turbo/apps/web/src/lib/github/sync.ts
+++ b/turbo/apps/web/src/lib/github/sync.ts
@@ -159,14 +159,14 @@ async function createGitHubCommit(
     }),
   );
 
-  // Create a new tree
+  // Create a new tree (complete replacement, not based on existing tree)
   const { data: newTree } = await octokit.request(
     "POST /repos/{owner}/{repo}/git/trees",
     {
       owner,
       repo,
       tree: blobs,
-      base_tree: currentCommit.tree.sha,
+      // Intentionally not using base_tree to create a complete mirror
     },
   );
 
@@ -176,7 +176,7 @@ async function createGitHubCommit(
     {
       owner,
       repo,
-      message: `Sync from uSpark at ${new Date().toISOString()}`,
+      message: `[Mirror Sync] Complete mirror from uSpark at ${new Date().toISOString()}`,
       tree: newTree.sha,
       parents: [currentCommitSha],
     },


### PR DESCRIPTION
## Summary
- Implement complete mirror synchronization strategy for GitHub integration
- Remove `base_tree` parameter to ensure GitHub exactly reflects Web state
- Simplify conflict handling by making Web the single source of truth

## Changes
- **sync.ts**: Remove `base_tree` parameter from tree creation API call
- **sync.ts**: Add `[Mirror Sync]` prefix to commit messages for clarity
- Creates fresh tree on each sync, automatically removing files that don't exist in Web

## Rationale
This is the simplest MVP approach for GitHub integration:
- Eliminates all conflict resolution complexity
- GitHub becomes a perfect mirror of Web content
- No need for Task 8 (conflict handling) with this approach
- Clear and predictable behavior for users

## Test Results
✅ All 9 tests passing in sync.test.ts

🤖 Generated with [Claude Code](https://claude.ai/code)