### PR TITLE
feat: implement claude sessions and turns api endpoints

### DIFF
--- a/spec/issues/e2b-runtime-container.md
+++ b/spec/issues/e2b-runtime-container.md
@@ -209,14 +209,18 @@ async function syncFile(projectId: string, filePath: string) {
 
 ### Phase 1: Core Container Integration
 
-#### 1. E2B Container Setup
+#### 1. E2B Container Setup 🟡 PARTIALLY COMPLETED
 
 **Acceptance Criteria**:
 
-- [ ] Create E2B container template with required dependencies (待开始)
+- [x] Create E2B container template with required dependencies ✅ (Basic Dockerfile)
 - [ ] Implement container initialization script (待开始)
 - [ ] Configure authentication and environment variables (待开始)
 - [ ] Test basic container startup and teardown (待开始)
+
+**Partial Implementation**:
+- Basic Dockerfile exists at `e2b/e2b.Dockerfile` with Node.js 22 and Claude Code CLI
+- Still needs: uspark CLI installation, init scripts, environment configuration
 
 #### 2. uspark watch-claude Implementation ✅ COMPLETED
 

--- a/spec/issues/mvp.md
+++ b/spec/issues/mvp.md
@@ -48,11 +48,12 @@ This document defines the mid-term goals and user stories for the MVP release of
 
 #### Acceptance Criteria
 
-- [x] `uspark pull --project-id <id>` downloads entire project to container
-- [x] `uspark push <file-path> --project-id <id>` uploads changes immediately
-- [x] `uspark watch-claude` monitors Claude output and syncs file changes
-- [x] Authentication via environment variable (USPARK_TOKEN)
-- [ ] E2B container pre-configured with uspark CLI ❌
+- [x] `uspark pull --project-id <id>` downloads entire project to container ✅
+- [x] `uspark push <file-path> --project-id <id>` uploads changes immediately ✅
+- [x] `uspark watch-claude` monitors Claude output and syncs file changes ✅
+- [x] Authentication via environment variable (USPARK_TOKEN) ✅
+- [x] E2B container pre-configured with Claude Code CLI ✅ (Basic Dockerfile)
+- [ ] E2B container pre-configured with uspark CLI ❌ (Still needs installation)
 
 #### Technical Requirements
 
@@ -237,13 +238,13 @@ Post-MVP priorities (not in scope for current release):
 5. Mobile applications
 6. API for third-party integrations
 
-## Implementation Status Summary (2025-01-12)
+## Implementation Status Summary (2025-01-13)
 
-### Overall Completion: ~70%
+### Overall Completion: ~75%
 
 #### ✅ Completed Features (Working)
-- **Story 1b (CLI)**: 80% - All CLI commands working, E2B container config missing
-- **Story 2 (Web UI)**: 60% - UI complete, Claude execution integration missing  
+- **Story 1b (CLI)**: 85% - All CLI commands working, E2B container partially configured
+- **Story 2 (Web UI)**: 65% - UI complete, Claude sessions schema done, APIs missing
 - **Story 3 (Sharing)**: 100% - Fully implemented with management interface
 
 #### 🟡 Partially Completed
@@ -252,9 +253,9 @@ Post-MVP priorities (not in scope for current release):
 
 #### ❌ Critical Gaps
 1. **GitHub bidirectional sync** - No document push/pull with GitHub
-2. **Claude execution in E2B** - Container not configured with Claude CLI
-3. **Real-time updates** - Polling hooks need to be re-implemented (closed PRs not satisfactory)
-4. **Frontend components** - SessionDisplay, TurnDisplay, BlockDisplay need complete re-implementation
+2. **Claude execution in E2B** - Container has Claude CLI but missing uspark CLI
+3. **Real-time updates** - Polling hooks need to be re-implemented
+4. **Session/Turn/Block APIs** - Schema exists but API endpoints not implemented
 
 ### Key Findings
 - **Strong backend infrastructure** with complete APIs and database schema

--- a/spec/issues/yjs.md
+++ b/spec/issues/yjs.md
@@ -349,14 +349,17 @@ File contents are stored separately in Vercel Blob Storage, referenced by hash f
 
 ### Phase 2: CLI Implementation
 
-#### 3. Blob Token API Implementation
+#### 3. Blob Token API Implementation ✅ COMPLETED
 
 **Task**: Add STS token endpoint for direct blob access
 **Acceptance Criteria**:
-- [ ] Implement GET /api/projects/:projectId/blob-token endpoint (🔄 进行中 - 任务 9)
-- [ ] Generate time-limited STS tokens (10 minutes) (🔄 进行中 - 任务 9)
-- [ ] Include upload/download URLs in response (🔄 进行中 - 任务 9)
-- [ ] Validate user has project access (🔄 进行中 - 任务 9)
+- [x] Implement GET /api/projects/:projectId/blob-token endpoint ✅
+- [x] Generate time-limited STS tokens (10 minutes) ✅
+- [x] Include upload/download URLs in response ✅
+- [x] Validate user has project access ✅
+
+**Implementation Location**: `turbo/apps/web/app/api/projects/[projectId]/blob-token/route.ts`
+**Test**: `turbo/apps/web/app/api/projects/[projectId]/blob-token/route.test.ts`
 
 #### 4. Extend FileSystem class with direct blob access
 

--- a/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET, DELETE } from "./route";
 import { initServices } from "../../../../../src/lib/init-services";
-import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import {
+  SESSIONS_TBL,
+  TURNS_TBL,
+  BLOCKS_TBL,
+} from "../../../../../src/db/schema/sessions";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
 import { eq } from "drizzle-orm";
 import * as Y from "yjs";
@@ -53,7 +57,9 @@ describe("/api/claude/sessions/[sessionId]", () => {
 
     // Create a test project
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
 
     const projects = await db
       .insert(PROJECTS_TBL)
@@ -110,8 +116,8 @@ describe("/api/claude/sessions/[sessionId]", () => {
           content: {
             tool_name: "test_tool",
             parameters: {},
-            tool_use_id: "test_1"
-          }
+            tool_use_id: "test_1",
+          },
         },
         sequenceNumber: 2,
       },
@@ -121,10 +127,12 @@ describe("/api/claude/sessions/[sessionId]", () => {
   describe("GET /api/claude/sessions/[sessionId]", () => {
     it("should get session details with turns and blocks", async () => {
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
       );
 
-      const response = await GET(request, { params: Promise.resolve({ sessionId: testSessionId }) });
+      const response = await GET(request, {
+        params: Promise.resolve({ sessionId: testSessionId }),
+      });
       const data = await response.json();
 
       expect(response.status).toBe(200);
@@ -140,11 +148,11 @@ describe("/api/claude/sessions/[sessionId]", () => {
 
     it("should return 404 if session doesn't exist", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/claude/sessions/sess_nonexistent"
+        "http://localhost:3000/api/claude/sessions/sess_nonexistent",
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ sessionId: "sess_nonexistent" })
+        params: Promise.resolve({ sessionId: "sess_nonexistent" }),
       });
       const data = await response.json();
 
@@ -153,14 +161,14 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ sessionId: testSessionId })
+        params: Promise.resolve({ sessionId: testSessionId }),
       });
       const data = await response.json();
 
@@ -169,14 +177,14 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ sessionId: testSessionId })
+        params: Promise.resolve({ sessionId: testSessionId }),
       });
       const data = await response.json();
 
@@ -189,11 +197,11 @@ describe("/api/claude/sessions/[sessionId]", () => {
     it("should delete session and cascade delete turns and blocks", async () => {
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
-        { method: "DELETE" }
+        { method: "DELETE" },
       );
 
       const response = await DELETE(request, {
-        params: Promise.resolve({ sessionId: testSessionId })
+        params: Promise.resolve({ sessionId: testSessionId }),
       });
       const data = await response.json();
 
@@ -226,11 +234,11 @@ describe("/api/claude/sessions/[sessionId]", () => {
     it("should return 404 if session doesn't exist", async () => {
       const request = new NextRequest(
         "http://localhost:3000/api/claude/sessions/sess_nonexistent",
-        { method: "DELETE" }
+        { method: "DELETE" },
       );
 
       const response = await DELETE(request, {
-        params: Promise.resolve({ sessionId: "sess_nonexistent" })
+        params: Promise.resolve({ sessionId: "sess_nonexistent" }),
       });
       const data = await response.json();
 
@@ -239,15 +247,15 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
-        { method: "DELETE" }
+        { method: "DELETE" },
       );
 
       const response = await DELETE(request, {
-        params: Promise.resolve({ sessionId: testSessionId })
+        params: Promise.resolve({ sessionId: testSessionId }),
       });
       const data = await response.json();
 
@@ -256,15 +264,15 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
-        { method: "DELETE" }
+        { method: "DELETE" },
       );
 
       const response = await DELETE(request, {
-        params: Promise.resolve({ sessionId: testSessionId })
+        params: Promise.resolve({ sessionId: testSessionId }),
       });
       const data = await response.json();
 

--- a/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, DELETE } from "./route";
+import { initServices } from "../../../../../src/lib/init-services";
+import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+import * as Y from "yjs";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
+describe("/api/claude/sessions/[sessionId]", () => {
+  const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).substring(7)}`;
+  const userId = `test-user-session-detail-${uniqueId}`;
+  let testProjectId: string;
+  let testSessionId: string;
+  let testTurnId: string;
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    const db = globalThis.services.db;
+
+    // Delete in reverse order of creation to avoid foreign key constraints
+    if (testTurnId) {
+      await db.delete(BLOCKS_TBL).where(eq(BLOCKS_TBL.turnId, testTurnId));
+      await db.delete(TURNS_TBL).where(eq(TURNS_TBL.id, testTurnId));
+    }
+    if (testSessionId) {
+      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.id, testSessionId));
+    }
+    if (testProjectId) {
+      await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.id, testProjectId));
+    }
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
+    // Initialize services
+    initServices();
+    const db = globalThis.services.db;
+
+    // Clean up any existing test data
+    await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.userId, userId));
+
+    // Create a test project
+    const ydoc = new Y.Doc();
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+
+    const projects = await db
+      .insert(PROJECTS_TBL)
+      .values({
+        id: `proj_test_${Date.now()}`,
+        userId,
+        ydocData,
+        version: 0,
+      })
+      .returning();
+
+    testProjectId = projects[0]!.id;
+
+    // Create a test session
+    const sessions = await db
+      .insert(SESSIONS_TBL)
+      .values({
+        id: `sess_test_${Date.now()}`,
+        projectId: testProjectId,
+        title: "Test Session",
+      })
+      .returning();
+
+    testSessionId = sessions[0]!.id;
+
+    // Create a test turn
+    const turns = await db
+      .insert(TURNS_TBL)
+      .values({
+        id: `turn_test_${Date.now()}`,
+        sessionId: testSessionId,
+        userPrompt: "Test prompt",
+        status: "completed",
+      })
+      .returning();
+
+    testTurnId = turns[0]!.id;
+
+    // Create test blocks
+    await db.insert(BLOCKS_TBL).values([
+      {
+        id: `block_test_1`,
+        turnId: testTurnId,
+        type: "content",
+        content: { type: "content", content: { text: "Response 1" } },
+        sequenceNumber: 1,
+      },
+      {
+        id: `block_test_2`,
+        turnId: testTurnId,
+        type: "tool_use",
+        content: {
+          type: "tool_use",
+          content: {
+            tool_name: "test_tool",
+            parameters: {},
+            tool_use_id: "test_1"
+          }
+        },
+        sequenceNumber: 2,
+      },
+    ]);
+  });
+
+  describe("GET /api/claude/sessions/[sessionId]", () => {
+    it("should get session details with turns and blocks", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+      );
+
+      const response = await GET(request, { params: Promise.resolve({ sessionId: testSessionId }) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(testSessionId);
+      expect(data.projectId).toBe(testProjectId);
+      expect(data.title).toBe("Test Session");
+      expect(data.turns).toHaveLength(1);
+      expect(data.turns[0]!.id).toBe(testTurnId);
+      expect(data.turns[0]!.blocks).toHaveLength(2);
+      expect(data.turns[0]!.blocks[0]!.type).toBe("content");
+      expect(data.turns[0]!.blocks[1]!.type).toBe("tool_use");
+    });
+
+    it("should return 404 if session doesn't exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions/sess_nonexistent"
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ sessionId: "sess_nonexistent" })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ sessionId: testSessionId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ sessionId: testSessionId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+
+  describe("DELETE /api/claude/sessions/[sessionId]", () => {
+    it("should delete session and cascade delete turns and blocks", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ sessionId: testSessionId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+
+      // Verify session is deleted
+      const db = globalThis.services.db;
+      const sessions = await db
+        .select()
+        .from(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.id, testSessionId));
+      expect(sessions).toHaveLength(0);
+
+      // Verify turns are cascade deleted
+      const turns = await db
+        .select()
+        .from(TURNS_TBL)
+        .where(eq(TURNS_TBL.sessionId, testSessionId));
+      expect(turns).toHaveLength(0);
+
+      // Verify blocks are cascade deleted
+      const blocks = await db
+        .select()
+        .from(BLOCKS_TBL)
+        .where(eq(BLOCKS_TBL.turnId, testTurnId));
+      expect(blocks).toHaveLength(0);
+    });
+
+    it("should return 404 if session doesn't exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions/sess_nonexistent",
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ sessionId: "sess_nonexistent" })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ sessionId: testSessionId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions/${testSessionId}`,
+        { method: "DELETE" }
+      );
+
+      const response = await DELETE(request, {
+        params: Promise.resolve({ sessionId: testSessionId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.test.ts
@@ -77,7 +77,7 @@ describe("/api/claude/sessions/[sessionId]", () => {
     const sessions = await db
       .insert(SESSIONS_TBL)
       .values({
-        id: `sess_test_${Date.now()}`,
+        id: `sess_test_${uniqueId}_${Date.now()}`,
         projectId: testProjectId,
         title: "Test Session",
       })
@@ -89,7 +89,7 @@ describe("/api/claude/sessions/[sessionId]", () => {
     const turns = await db
       .insert(TURNS_TBL)
       .values({
-        id: `turn_test_${Date.now()}`,
+        id: `turn_test_${uniqueId}_${Date.now()}`,
         sessionId: testSessionId,
         userPrompt: "Test prompt",
         status: "completed",
@@ -101,14 +101,14 @@ describe("/api/claude/sessions/[sessionId]", () => {
     // Create test blocks
     await db.insert(BLOCKS_TBL).values([
       {
-        id: `block_test_1`,
+        id: `block_test_${uniqueId}_1`,
         turnId: testTurnId,
         type: "content",
         content: { type: "content", content: { text: "Response 1" } },
         sequenceNumber: 1,
       },
       {
-        id: `block_test_2`,
+        id: `block_test_${uniqueId}_2`,
         turnId: testTurnId,
         type: "tool_use",
         content: {
@@ -161,7 +161,9 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
@@ -177,7 +179,9 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
@@ -247,7 +251,9 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,
@@ -264,7 +270,9 @@ describe("/api/claude/sessions/[sessionId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/sessions/${testSessionId}`,

--- a/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.ts
+++ b/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { initServices } from "../../../../../src/lib/init-services";
-import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import {
+  SESSIONS_TBL,
+  TURNS_TBL,
+  BLOCKS_TBL,
+} from "../../../../../src/db/schema/sessions";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
 import { eq, desc } from "drizzle-orm";
 
@@ -11,14 +15,14 @@ import { eq, desc } from "drizzle-orm";
  */
 export async function GET(
   _request: NextRequest,
-  context: { params: Promise<{ sessionId: string }> }
+  context: { params: Promise<{ sessionId: string }> },
 ) {
   const { userId } = await auth();
 
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -45,7 +49,7 @@ export async function GET(
     if (sessionResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Session not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
@@ -55,7 +59,7 @@ export async function GET(
     if (session.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -79,7 +83,7 @@ export async function GET(
           ...turn,
           blocks,
         };
-      })
+      }),
     );
 
     return NextResponse.json({
@@ -94,7 +98,7 @@ export async function GET(
     console.error("Failed to get session:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to get session" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -105,14 +109,14 @@ export async function GET(
  */
 export async function DELETE(
   _request: NextRequest,
-  context: { params: Promise<{ sessionId: string }> }
+  context: { params: Promise<{ sessionId: string }> },
 ) {
   const { userId } = await auth();
 
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -134,14 +138,14 @@ export async function DELETE(
     if (sessionResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Session not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     if (sessionResult[0]!.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -152,8 +156,11 @@ export async function DELETE(
   } catch (error) {
     console.error("Failed to delete session:", error);
     return NextResponse.json(
-      { error: "internal_error", error_description: "Failed to delete session" },
-      { status: 500 }
+      {
+        error: "internal_error",
+        error_description: "Failed to delete session",
+      },
+      { status: 500 },
     );
   }
 }

--- a/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.ts
+++ b/turbo/apps/web/app/api/claude/sessions/[sessionId]/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { eq, desc } from "drizzle-orm";
+
+/**
+ * GET /api/claude/sessions/:sessionId
+ * Get session details including all turns and blocks
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+  const { sessionId } = await context.params;
+
+  try {
+    // Get session with project info
+    const sessionResult = await db
+      .select({
+        id: SESSIONS_TBL.id,
+        projectId: SESSIONS_TBL.projectId,
+        title: SESSIONS_TBL.title,
+        createdAt: SESSIONS_TBL.createdAt,
+        updatedAt: SESSIONS_TBL.updatedAt,
+        projectUserId: PROJECTS_TBL.userId,
+      })
+      .from(SESSIONS_TBL)
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(SESSIONS_TBL.id, sessionId))
+      .limit(1);
+
+    if (sessionResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    const session = sessionResult[0]!;
+
+    // Verify user owns the project
+    if (session.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Get all turns for this session
+    const turns = await db
+      .select()
+      .from(TURNS_TBL)
+      .where(eq(TURNS_TBL.sessionId, sessionId))
+      .orderBy(desc(TURNS_TBL.createdAt));
+
+    // Get all blocks for all turns
+    const turnsWithBlocks = await Promise.all(
+      turns.map(async (turn) => {
+        const blocks = await db
+          .select()
+          .from(BLOCKS_TBL)
+          .where(eq(BLOCKS_TBL.turnId, turn.id))
+          .orderBy(BLOCKS_TBL.sequenceNumber);
+
+        return {
+          ...turn,
+          blocks,
+        };
+      })
+    );
+
+    return NextResponse.json({
+      id: session.id,
+      projectId: session.projectId,
+      title: session.title,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      turns: turnsWithBlocks,
+    });
+  } catch (error) {
+    console.error("Failed to get session:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to get session" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/claude/sessions/:sessionId
+ * Delete a session (cascade deletes turns and blocks)
+ */
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ sessionId: string }> }
+) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+  const { sessionId } = await context.params;
+
+  try {
+    // Verify user owns the session's project
+    const sessionResult = await db
+      .select({
+        projectUserId: PROJECTS_TBL.userId,
+      })
+      .from(SESSIONS_TBL)
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(SESSIONS_TBL.id, sessionId))
+      .limit(1);
+
+    if (sessionResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (sessionResult[0]!.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Delete session (cascade deletes turns and blocks)
+    await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.id, sessionId));
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error("Failed to delete session:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to delete session" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo/apps/web/app/api/claude/sessions/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/route.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { initServices } from "../../../../src/lib/init-services";
+import { SESSIONS_TBL } from "../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+import * as Y from "yjs";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
+describe("/api/claude/sessions", () => {
+  const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).substring(7)}`;
+  const userId = `test-user-sessions-${uniqueId}`;
+  let testProjectId: string;
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    const db = globalThis.services.db;
+
+    // Delete sessions first to avoid foreign key constraint
+    if (testProjectId) {
+      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.projectId, testProjectId));
+    }
+
+    // Then delete projects
+    await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.userId, userId));
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
+    // Initialize services
+    initServices();
+    const db = globalThis.services.db;
+
+    // Clean up any existing test data
+    // Note: Can't delete sessions by projectId yet since it doesn't exist
+    // Just delete all projects for this test user (cascade will handle sessions)
+    await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.userId, userId));
+
+    // Create a test project
+    const ydoc = new Y.Doc();
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+
+    const projects = await db
+      .insert(PROJECTS_TBL)
+      .values({
+        id: `proj_test_${Date.now()}`,
+        userId,
+        ydocData,
+        version: 0,
+      })
+      .returning();
+
+    testProjectId = projects[0]!.id;
+  });
+
+  describe("POST /api/claude/sessions", () => {
+    it("should create a new session successfully", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: testProjectId,
+          title: "Test Session",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.id).toMatch(/^sess_/);
+      expect(data.projectId).toBe(testProjectId);
+      expect(data.title).toBe("Test Session");
+    });
+
+    it("should use default title if not provided", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: testProjectId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.title).toBe("New Session");
+    });
+
+    it("should return 400 if projectId is missing", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          title: "Test Session",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("bad_request");
+    });
+
+    it("should return 404 if project doesn't exist", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: "proj_nonexistent",
+          title: "Test Session",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: testProjectId,
+          title: "Test Session",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+
+    it("should return 404 if user doesn't own the project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          projectId: testProjectId,
+          title: "Test Session",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+  });
+
+  describe("GET /api/claude/sessions", () => {
+    beforeEach(async () => {
+      // Create some test sessions
+      const db = globalThis.services.db;
+
+      for (let i = 0; i < 3; i++) {
+        await db.insert(SESSIONS_TBL).values({
+          id: `sess_test_${uniqueId}_${i}`,
+          projectId: testProjectId,
+          title: `Session ${i}`,
+        });
+      }
+    });
+
+    it("should list all sessions for user's projects", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.sessions).toHaveLength(3);
+      expect(data.sessions[0]!.title).toMatch(/Session \d/);
+      expect(data.limit).toBe(20);
+      expect(data.offset).toBe(0);
+    });
+
+    it("should filter sessions by projectId", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/sessions?projectId=${testProjectId}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.sessions).toHaveLength(3);
+      expect(data.sessions.every((s: any) => s.projectId === testProjectId)).toBe(true);
+    });
+
+    it("should support pagination", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions?limit=2&offset=1"
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.sessions).toHaveLength(2);
+      expect(data.limit).toBe(2);
+      expect(data.offset).toBe(1);
+    });
+
+    it("should return empty array if no sessions exist", async () => {
+      // Delete all sessions
+      const db = globalThis.services.db;
+      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.projectId, testProjectId));
+
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.sessions).toHaveLength(0);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/claude/sessions/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/route.test.ts
@@ -58,7 +58,7 @@ describe("/api/claude/sessions", () => {
     const projects = await db
       .insert(PROJECTS_TBL)
       .values({
-        id: `proj_test_${Date.now()}`,
+        id: `proj_test_${uniqueId}_${Date.now()}`,
         userId,
         ydocData,
         version: 0,
@@ -146,7 +146,9 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         "http://localhost:3000/api/claude/sessions",
@@ -167,7 +169,9 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 404 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         "http://localhost:3000/api/claude/sessions",
@@ -228,7 +232,9 @@ describe("/api/claude/sessions", () => {
       expect(response.status).toBe(200);
       expect(data.sessions).toHaveLength(3);
       expect(
-        data.sessions.every((s: { projectId: string }) => s.projectId === testProjectId),
+        data.sessions.every(
+          (s: { projectId: string }) => s.projectId === testProjectId,
+        ),
       ).toBe(true);
     });
 
@@ -265,7 +271,9 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         "http://localhost:3000/api/claude/sessions",

--- a/turbo/apps/web/app/api/claude/sessions/route.test.ts
+++ b/turbo/apps/web/app/api/claude/sessions/route.test.ts
@@ -26,7 +26,9 @@ describe("/api/claude/sessions", () => {
 
     // Delete sessions first to avoid foreign key constraint
     if (testProjectId) {
-      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.projectId, testProjectId));
+      await db
+        .delete(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.projectId, testProjectId));
     }
 
     // Then delete projects
@@ -49,7 +51,9 @@ describe("/api/claude/sessions", () => {
 
     // Create a test project
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
 
     const projects = await db
       .insert(PROJECTS_TBL)
@@ -66,13 +70,16 @@ describe("/api/claude/sessions", () => {
 
   describe("POST /api/claude/sessions", () => {
     it("should create a new session successfully", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: testProjectId,
-          title: "Test Session",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: testProjectId,
+            title: "Test Session",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -84,12 +91,15 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should use default title if not provided", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: testProjectId,
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: testProjectId,
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -99,12 +109,15 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 400 if projectId is missing", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          title: "Test Session",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: "Test Session",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -114,13 +127,16 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 404 if project doesn't exist", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: "proj_nonexistent",
-          title: "Test Session",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: "proj_nonexistent",
+            title: "Test Session",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -130,15 +146,18 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: testProjectId,
-          title: "Test Session",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: testProjectId,
+            title: "Test Session",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -148,15 +167,18 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 404 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions", {
-        method: "POST",
-        body: JSON.stringify({
-          projectId: testProjectId,
-          title: "Test Session",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            projectId: testProjectId,
+            title: "Test Session",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -181,7 +203,9 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should list all sessions for user's projects", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+      );
 
       const response = await GET(request);
       const data = await response.json();
@@ -195,7 +219,7 @@ describe("/api/claude/sessions", () => {
 
     it("should filter sessions by projectId", async () => {
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/sessions?projectId=${testProjectId}`
+        `http://localhost:3000/api/claude/sessions?projectId=${testProjectId}`,
       );
 
       const response = await GET(request);
@@ -203,12 +227,14 @@ describe("/api/claude/sessions", () => {
 
       expect(response.status).toBe(200);
       expect(data.sessions).toHaveLength(3);
-      expect(data.sessions.every((s: any) => s.projectId === testProjectId)).toBe(true);
+      expect(
+        data.sessions.every((s: { projectId: string }) => s.projectId === testProjectId),
+      ).toBe(true);
     });
 
     it("should support pagination", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/claude/sessions?limit=2&offset=1"
+        "http://localhost:3000/api/claude/sessions?limit=2&offset=1",
       );
 
       const response = await GET(request);
@@ -223,9 +249,13 @@ describe("/api/claude/sessions", () => {
     it("should return empty array if no sessions exist", async () => {
       // Delete all sessions
       const db = globalThis.services.db;
-      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.projectId, testProjectId));
+      await db
+        .delete(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.projectId, testProjectId));
 
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+      );
 
       const response = await GET(request);
       const data = await response.json();
@@ -235,9 +265,11 @@ describe("/api/claude/sessions", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest("http://localhost:3000/api/claude/sessions");
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/sessions",
+      );
 
       const response = await GET(request);
       const data = await response.json();

--- a/turbo/apps/web/app/api/claude/sessions/route.ts
+++ b/turbo/apps/web/app/api/claude/sessions/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
     if (!projectId) {
       return NextResponse.json(
         { error: "bad_request", error_description: "Project ID is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -38,13 +38,15 @@ export async function POST(request: NextRequest) {
     const project = await db
       .select()
       .from(PROJECTS_TBL)
-      .where(and(eq(PROJECTS_TBL.id, projectId), eq(PROJECTS_TBL.userId, userId)))
+      .where(
+        and(eq(PROJECTS_TBL.id, projectId), eq(PROJECTS_TBL.userId, userId)),
+      )
       .limit(1);
 
     if (project.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Project not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
@@ -63,8 +65,11 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Failed to create session:", error);
     return NextResponse.json(
-      { error: "internal_error", error_description: "Failed to create session" },
-      { status: 500 }
+      {
+        error: "internal_error",
+        error_description: "Failed to create session",
+      },
+      { status: 500 },
     );
   }
 }
@@ -79,7 +84,7 @@ export async function GET(request: NextRequest) {
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -116,14 +121,14 @@ export async function GET(request: NextRequest) {
           title: SESSIONS_TBL.title,
           createdAt: SESSIONS_TBL.createdAt,
           updatedAt: SESSIONS_TBL.updatedAt,
-          })
+        })
         .from(SESSIONS_TBL)
         .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
         .where(
           and(
             eq(PROJECTS_TBL.userId, userId),
-            eq(SESSIONS_TBL.projectId, projectId)
-          )
+            eq(SESSIONS_TBL.projectId, projectId),
+          ),
         )
         .orderBy(desc(SESSIONS_TBL.updatedAt))
         .limit(limit)
@@ -142,7 +147,7 @@ export async function GET(request: NextRequest) {
     console.error("Failed to list sessions:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to list sessions" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/turbo/apps/web/app/api/claude/sessions/route.ts
+++ b/turbo/apps/web/app/api/claude/sessions/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { SESSIONS_TBL } from "../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
+import { eq, and, desc } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+/**
+ * POST /api/claude/sessions
+ * Create a new Claude session for a project
+ */
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+
+  try {
+    const body = await request.json();
+    const { projectId, title } = body;
+
+    if (!projectId) {
+      return NextResponse.json(
+        { error: "bad_request", error_description: "Project ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify user owns the project
+    const project = await db
+      .select()
+      .from(PROJECTS_TBL)
+      .where(and(eq(PROJECTS_TBL.id, projectId), eq(PROJECTS_TBL.userId, userId)))
+      .limit(1);
+
+    if (project.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Project not found" },
+        { status: 404 }
+      );
+    }
+
+    // Create new session
+    const sessionId = `sess_${nanoid()}`;
+    const session = await db
+      .insert(SESSIONS_TBL)
+      .values({
+        id: sessionId,
+        projectId,
+        title: title || "New Session",
+      })
+      .returning();
+
+    return NextResponse.json(session[0], { status: 201 });
+  } catch (error) {
+    console.error("Failed to create session:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to create session" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/claude/sessions
+ * List all sessions for the user's projects
+ */
+export async function GET(request: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get("projectId");
+    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 100);
+    const offset = parseInt(searchParams.get("offset") || "0");
+
+    // Build query based on whether projectId is provided
+    let query = db
+      .select({
+        id: SESSIONS_TBL.id,
+        projectId: SESSIONS_TBL.projectId,
+        title: SESSIONS_TBL.title,
+        createdAt: SESSIONS_TBL.createdAt,
+        updatedAt: SESSIONS_TBL.updatedAt,
+      })
+      .from(SESSIONS_TBL)
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(PROJECTS_TBL.userId, userId))
+      .orderBy(desc(SESSIONS_TBL.updatedAt))
+      .limit(limit)
+      .offset(offset);
+
+    if (projectId) {
+      query = db
+        .select({
+          id: SESSIONS_TBL.id,
+          projectId: SESSIONS_TBL.projectId,
+          title: SESSIONS_TBL.title,
+          createdAt: SESSIONS_TBL.createdAt,
+          updatedAt: SESSIONS_TBL.updatedAt,
+          })
+        .from(SESSIONS_TBL)
+        .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+        .where(
+          and(
+            eq(PROJECTS_TBL.userId, userId),
+            eq(SESSIONS_TBL.projectId, projectId)
+          )
+        )
+        .orderBy(desc(SESSIONS_TBL.updatedAt))
+        .limit(limit)
+        .offset(offset);
+    }
+
+    const sessions = await query;
+
+    return NextResponse.json({
+      sessions,
+      limit,
+      offset,
+      total: sessions.length,
+    });
+  } catch (error) {
+    console.error("Failed to list sessions:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to list sessions" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET, PATCH } from "./route";
 import { initServices } from "../../../../../src/lib/init-services";
-import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import {
+  SESSIONS_TBL,
+  TURNS_TBL,
+  BLOCKS_TBL,
+} from "../../../../../src/db/schema/sessions";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
 import { eq } from "drizzle-orm";
 import * as Y from "yjs";
@@ -53,7 +57,9 @@ describe("/api/claude/turns/[turnId]", () => {
 
     // Create a test project
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
 
     const projects = await db
       .insert(PROJECTS_TBL)
@@ -120,8 +126,8 @@ describe("/api/claude/turns/[turnId]", () => {
             type: "tool_result",
             content: {
               tool_use_id: "test_1",
-              result: "Tool output"
-            }
+              result: "Tool output",
+            },
           },
           sequenceNumber: 3,
         },
@@ -130,11 +136,11 @@ describe("/api/claude/turns/[turnId]", () => {
 
     it("should get turn details with all blocks", async () => {
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns/${testTurnId}`
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -159,11 +165,11 @@ describe("/api/claude/turns/[turnId]", () => {
       await db.delete(BLOCKS_TBL).where(eq(BLOCKS_TBL.turnId, testTurnId));
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns/${testTurnId}`
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -173,11 +179,11 @@ describe("/api/claude/turns/[turnId]", () => {
 
     it("should return 404 if turn doesn't exist", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/claude/turns/turn_nonexistent"
+        "http://localhost:3000/api/claude/turns/turn_nonexistent",
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ turnId: "turn_nonexistent" })
+        params: Promise.resolve({ turnId: "turn_nonexistent" }),
       });
       const data = await response.json();
 
@@ -186,14 +192,14 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns/${testTurnId}`
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -202,14 +208,14 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns/${testTurnId}`
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
       );
 
       const response = await GET(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -227,11 +233,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "running",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -249,11 +255,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "completed",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -271,11 +277,11 @@ describe("/api/claude/turns/[turnId]", () => {
             status: "failed",
             errorMessage: "Test error",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -297,7 +303,7 @@ describe("/api/claude/turns/[turnId]", () => {
       const originalUpdatedAt = sessionBefore[0]!.updatedAt;
 
       // Wait a bit to ensure timestamp difference
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -306,11 +312,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "completed",
           }),
-        }
+        },
       );
 
       await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
 
       // Check if updatedAt was updated
@@ -320,7 +326,9 @@ describe("/api/claude/turns/[turnId]", () => {
         .where(eq(SESSIONS_TBL.id, testSessionId))
         .limit(1);
 
-      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(
+        originalUpdatedAt.getTime(),
+      );
     });
 
     it("should return 400 if status is missing", async () => {
@@ -331,11 +339,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             errorMessage: "Test error",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -351,11 +359,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "completed",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: "turn_nonexistent" })
+        params: Promise.resolve({ turnId: "turn_nonexistent" }),
       });
       const data = await response.json();
 
@@ -364,7 +372,7 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -373,11 +381,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "completed",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 
@@ -386,7 +394,7 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -395,11 +403,11 @@ describe("/api/claude/turns/[turnId]", () => {
           body: JSON.stringify({
             status: "completed",
           }),
-        }
+        },
       );
 
       const response = await PATCH(request, {
-        params: Promise.resolve({ turnId: testTurnId })
+        params: Promise.resolve({ turnId: testTurnId }),
       });
       const data = await response.json();
 

--- a/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
@@ -64,7 +64,7 @@ describe("/api/claude/turns/[turnId]", () => {
     const projects = await db
       .insert(PROJECTS_TBL)
       .values({
-        id: `proj_test_${Date.now()}`,
+        id: `proj_test_${uniqueId}_${Date.now()}`,
         userId,
         ydocData,
         version: 0,
@@ -77,7 +77,7 @@ describe("/api/claude/turns/[turnId]", () => {
     const sessions = await db
       .insert(SESSIONS_TBL)
       .values({
-        id: `sess_test_${Date.now()}`,
+        id: `sess_test_${uniqueId}_${Date.now()}`,
         projectId: testProjectId,
         title: "Test Session",
       })
@@ -89,7 +89,7 @@ describe("/api/claude/turns/[turnId]", () => {
     const turns = await db
       .insert(TURNS_TBL)
       .values({
-        id: `turn_test_${Date.now()}`,
+        id: `turn_test_${uniqueId}_${Date.now()}`,
         sessionId: testSessionId,
         userPrompt: "Test prompt",
         status: "pending",
@@ -105,21 +105,21 @@ describe("/api/claude/turns/[turnId]", () => {
       const db = globalThis.services.db;
       await db.insert(BLOCKS_TBL).values([
         {
-          id: `block_test_1`,
+          id: `block_test_${uniqueId}_1`,
           turnId: testTurnId,
           type: "thinking",
           content: { type: "thinking", content: { text: "Thinking..." } },
           sequenceNumber: 1,
         },
         {
-          id: `block_test_2`,
+          id: `block_test_${uniqueId}_2`,
           turnId: testTurnId,
           type: "content",
           content: { type: "content", content: { text: "Response text" } },
           sequenceNumber: 2,
         },
         {
-          id: `block_test_3`,
+          id: `block_test_${uniqueId}_3`,
           turnId: testTurnId,
           type: "tool_result",
           content: {
@@ -192,7 +192,9 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -208,7 +210,9 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -372,7 +376,9 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 403 if user doesn't own the project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,
@@ -394,7 +400,9 @@ describe("/api/claude/turns/[turnId]", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns/${testTurnId}`,

--- a/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/[turnId]/route.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "./route";
+import { initServices } from "../../../../../src/lib/init-services";
+import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+import * as Y from "yjs";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
+describe("/api/claude/turns/[turnId]", () => {
+  const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).substring(7)}`;
+  const userId = `test-user-turn-detail-${uniqueId}`;
+  let testProjectId: string;
+  let testSessionId: string;
+  let testTurnId: string;
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    const db = globalThis.services.db;
+
+    // Delete in reverse order to avoid foreign key constraints
+    if (testTurnId) {
+      await db.delete(BLOCKS_TBL).where(eq(BLOCKS_TBL.turnId, testTurnId));
+      await db.delete(TURNS_TBL).where(eq(TURNS_TBL.id, testTurnId));
+    }
+    if (testSessionId) {
+      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.id, testSessionId));
+    }
+    if (testProjectId) {
+      await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.id, testProjectId));
+    }
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
+    // Initialize services
+    initServices();
+    const db = globalThis.services.db;
+
+    // Clean up any existing test data
+    await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.userId, userId));
+
+    // Create a test project
+    const ydoc = new Y.Doc();
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+
+    const projects = await db
+      .insert(PROJECTS_TBL)
+      .values({
+        id: `proj_test_${Date.now()}`,
+        userId,
+        ydocData,
+        version: 0,
+      })
+      .returning();
+
+    testProjectId = projects[0]!.id;
+
+    // Create a test session
+    const sessions = await db
+      .insert(SESSIONS_TBL)
+      .values({
+        id: `sess_test_${Date.now()}`,
+        projectId: testProjectId,
+        title: "Test Session",
+      })
+      .returning();
+
+    testSessionId = sessions[0]!.id;
+
+    // Create a test turn
+    const turns = await db
+      .insert(TURNS_TBL)
+      .values({
+        id: `turn_test_${Date.now()}`,
+        sessionId: testSessionId,
+        userPrompt: "Test prompt",
+        status: "pending",
+      })
+      .returning();
+
+    testTurnId = turns[0]!.id;
+  });
+
+  describe("GET /api/claude/turns/[turnId]", () => {
+    beforeEach(async () => {
+      // Create test blocks
+      const db = globalThis.services.db;
+      await db.insert(BLOCKS_TBL).values([
+        {
+          id: `block_test_1`,
+          turnId: testTurnId,
+          type: "thinking",
+          content: { type: "thinking", content: { text: "Thinking..." } },
+          sequenceNumber: 1,
+        },
+        {
+          id: `block_test_2`,
+          turnId: testTurnId,
+          type: "content",
+          content: { type: "content", content: { text: "Response text" } },
+          sequenceNumber: 2,
+        },
+        {
+          id: `block_test_3`,
+          turnId: testTurnId,
+          type: "tool_result",
+          content: {
+            type: "tool_result",
+            content: {
+              tool_use_id: "test_1",
+              result: "Tool output"
+            }
+          },
+          sequenceNumber: 3,
+        },
+      ]);
+    });
+
+    it("should get turn details with all blocks", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.id).toBe(testTurnId);
+      expect(data.sessionId).toBe(testSessionId);
+      expect(data.userPrompt).toBe("Test prompt");
+      expect(data.status).toBe("pending");
+      expect(data.blocks).toHaveLength(3);
+      expect(data.blocks[0]!.type).toBe("thinking");
+      expect(data.blocks[1]!.type).toBe("content");
+      expect(data.blocks[2]!.type).toBe("tool_result");
+      // Verify blocks are ordered by sequence number
+      expect(data.blocks[0]!.sequenceNumber).toBe(1);
+      expect(data.blocks[1]!.sequenceNumber).toBe(2);
+      expect(data.blocks[2]!.sequenceNumber).toBe(3);
+    });
+
+    it("should return empty blocks array if no blocks exist", async () => {
+      // Delete all blocks
+      const db = globalThis.services.db;
+      await db.delete(BLOCKS_TBL).where(eq(BLOCKS_TBL.turnId, testTurnId));
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.blocks).toHaveLength(0);
+    });
+
+    it("should return 404 if turn doesn't exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns/turn_nonexistent"
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ turnId: "turn_nonexistent" })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`
+      );
+
+      const response = await GET(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+
+  describe("PATCH /api/claude/turns/[turnId]", () => {
+    it("should update turn status to running", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "running",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("running");
+      expect(data.startedAt).toBeDefined();
+      expect(data.completedAt).toBeNull();
+    });
+
+    it("should update turn status to completed", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "completed",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("completed");
+      expect(data.completedAt).toBeDefined();
+    });
+
+    it("should update turn status to failed with error message", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "failed",
+            errorMessage: "Test error",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("failed");
+      expect(data.completedAt).toBeDefined();
+      expect(data.errorMessage).toBe("Test error");
+    });
+
+    it("should update session's updatedAt timestamp", async () => {
+      const db = globalThis.services.db;
+
+      // Get original updatedAt
+      const sessionBefore = await db
+        .select()
+        .from(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.id, testSessionId))
+        .limit(1);
+      const originalUpdatedAt = sessionBefore[0]!.updatedAt;
+
+      // Wait a bit to ensure timestamp difference
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "completed",
+          }),
+        }
+      );
+
+      await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+
+      // Check if updatedAt was updated
+      const sessionAfter = await db
+        .select()
+        .from(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.id, testSessionId))
+        .limit(1);
+
+      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+    });
+
+    it("should return 400 if status is missing", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            errorMessage: "Test error",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("bad_request");
+    });
+
+    it("should return 404 if turn doesn't exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns/turn_nonexistent",
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "completed",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: "turn_nonexistent" })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "completed",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns/${testTurnId}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            status: "completed",
+          }),
+        }
+      );
+
+      const response = await PATCH(request, {
+        params: Promise.resolve({ turnId: testTurnId })
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/claude/turns/[turnId]/route.ts
+++ b/turbo/apps/web/app/api/claude/turns/[turnId]/route.ts
@@ -1,0 +1,186 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { initServices } from "../../../../../src/lib/init-services";
+import { TURNS_TBL, SESSIONS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+
+/**
+ * GET /api/claude/turns/:turnId
+ * Get turn details including all blocks
+ */
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ turnId: string }> }
+) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+  const { turnId } = await context.params;
+
+  try {
+    // Get turn with session and project info
+    const turnResult = await db
+      .select({
+        id: TURNS_TBL.id,
+        sessionId: TURNS_TBL.sessionId,
+        userPrompt: TURNS_TBL.userPrompt,
+        status: TURNS_TBL.status,
+        startedAt: TURNS_TBL.startedAt,
+        completedAt: TURNS_TBL.completedAt,
+        errorMessage: TURNS_TBL.errorMessage,
+        createdAt: TURNS_TBL.createdAt,
+        projectUserId: PROJECTS_TBL.userId,
+      })
+      .from(TURNS_TBL)
+      .innerJoin(SESSIONS_TBL, eq(TURNS_TBL.sessionId, SESSIONS_TBL.id))
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(TURNS_TBL.id, turnId))
+      .limit(1);
+
+    if (turnResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Turn not found" },
+        { status: 404 }
+      );
+    }
+
+    const turn = turnResult[0]!;
+
+    // Verify user owns the project
+    if (turn.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Get all blocks for this turn
+    const blocks = await db
+      .select()
+      .from(BLOCKS_TBL)
+      .where(eq(BLOCKS_TBL.turnId, turnId))
+      .orderBy(BLOCKS_TBL.sequenceNumber);
+
+    return NextResponse.json({
+      id: turn.id,
+      sessionId: turn.sessionId,
+      userPrompt: turn.userPrompt,
+      status: turn.status,
+      startedAt: turn.startedAt,
+      completedAt: turn.completedAt,
+      errorMessage: turn.errorMessage,
+      createdAt: turn.createdAt,
+      blocks,
+    });
+  } catch (error) {
+    console.error("Failed to get turn:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to get turn" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/claude/turns/:turnId
+ * Update turn status
+ */
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ turnId: string }> }
+) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+  const { turnId } = await context.params;
+
+  try {
+    const body = await request.json();
+    const { status, errorMessage } = body;
+
+    if (!status) {
+      return NextResponse.json(
+        { error: "bad_request", error_description: "Status is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify user owns the turn's project
+    const turnResult = await db
+      .select({
+        projectUserId: PROJECTS_TBL.userId,
+        sessionId: TURNS_TBL.sessionId,
+      })
+      .from(TURNS_TBL)
+      .innerJoin(SESSIONS_TBL, eq(TURNS_TBL.sessionId, SESSIONS_TBL.id))
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(TURNS_TBL.id, turnId))
+      .limit(1);
+
+    if (turnResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Turn not found" },
+        { status: 404 }
+      );
+    }
+
+    if (turnResult[0]!.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Update turn status
+    const updateData: Record<string, unknown> = { status };
+
+    if (status === "running" && !body.startedAt) {
+      updateData.startedAt = new Date();
+    }
+
+    if (status === "completed" || status === "failed") {
+      updateData.completedAt = new Date();
+    }
+
+    if (errorMessage !== undefined) {
+      updateData.errorMessage = errorMessage;
+    }
+
+    const updatedTurn = await db
+      .update(TURNS_TBL)
+      .set(updateData)
+      .where(eq(TURNS_TBL.id, turnId))
+      .returning();
+
+    // Update session's updatedAt timestamp
+    await db
+      .update(SESSIONS_TBL)
+      .set({ updatedAt: new Date() })
+      .where(eq(SESSIONS_TBL.id, turnResult[0]!.sessionId));
+
+    return NextResponse.json(updatedTurn[0]);
+  } catch (error) {
+    console.error("Failed to update turn:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to update turn" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo/apps/web/app/api/claude/turns/[turnId]/route.ts
+++ b/turbo/apps/web/app/api/claude/turns/[turnId]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { initServices } from "../../../../../src/lib/init-services";
-import { TURNS_TBL, SESSIONS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import {
+  TURNS_TBL,
+  SESSIONS_TBL,
+  BLOCKS_TBL,
+} from "../../../../../src/db/schema/sessions";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
 import { eq } from "drizzle-orm";
 
@@ -11,14 +15,14 @@ import { eq } from "drizzle-orm";
  */
 export async function GET(
   _request: NextRequest,
-  context: { params: Promise<{ turnId: string }> }
+  context: { params: Promise<{ turnId: string }> },
 ) {
   const { userId } = await auth();
 
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -49,7 +53,7 @@ export async function GET(
     if (turnResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Turn not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
@@ -59,7 +63,7 @@ export async function GET(
     if (turn.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -85,7 +89,7 @@ export async function GET(
     console.error("Failed to get turn:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to get turn" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -96,14 +100,14 @@ export async function GET(
  */
 export async function PATCH(
   request: NextRequest,
-  context: { params: Promise<{ turnId: string }> }
+  context: { params: Promise<{ turnId: string }> },
 ) {
   const { userId } = await auth();
 
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -118,7 +122,7 @@ export async function PATCH(
     if (!status) {
       return NextResponse.json(
         { error: "bad_request", error_description: "Status is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -137,14 +141,14 @@ export async function PATCH(
     if (turnResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Turn not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     if (turnResult[0]!.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -180,7 +184,7 @@ export async function PATCH(
     console.error("Failed to update turn:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to update turn" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/turbo/apps/web/app/api/claude/turns/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/route.test.ts
@@ -56,7 +56,7 @@ describe("/api/claude/turns", () => {
     const projects = await db
       .insert(PROJECTS_TBL)
       .values({
-        id: `proj_test_${Date.now()}`,
+        id: `proj_test_${uniqueId}_${Date.now()}`,
         userId,
         ydocData,
         version: 0,
@@ -69,7 +69,7 @@ describe("/api/claude/turns", () => {
     const sessions = await db
       .insert(SESSIONS_TBL)
       .values({
-        id: `sess_test_${Date.now()}`,
+        id: `sess_test_${uniqueId}_${Date.now()}`,
         projectId: testProjectId,
         title: "Test Session",
       })
@@ -196,7 +196,9 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 403 if user doesn't own the session's project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         "http://localhost:3000/api/claude/turns",
@@ -217,7 +219,9 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         "http://localhost:3000/api/claude/turns",
@@ -245,7 +249,7 @@ describe("/api/claude/turns", () => {
 
       for (let i = 0; i < 3; i++) {
         await db.insert(TURNS_TBL).values({
-          id: `turn_test_${i}`,
+          id: `turn_test_${uniqueId}_${i}`,
           sessionId: testSessionId,
           userPrompt: `Prompt ${i}`,
           status: i === 0 ? "completed" : i === 1 ? "running" : "pending",
@@ -264,9 +268,11 @@ describe("/api/claude/turns", () => {
       expect(response.status).toBe(200);
       expect(data.turns).toHaveLength(3);
       expect(data.turns[0]!.userPrompt).toMatch(/Prompt \d/);
-      expect(data.turns.every((t: { sessionId: string }) => t.sessionId === testSessionId)).toBe(
-        true,
-      );
+      expect(
+        data.turns.every(
+          (t: { sessionId: string }) => t.sessionId === testSessionId,
+        ),
+      ).toBe(true);
     });
 
     it("should return turns in chronological order", async () => {
@@ -307,7 +313,9 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 403 if user doesn't own the session's project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,
@@ -321,7 +329,9 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
 
       const request = new NextRequest(
         `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,

--- a/turbo/apps/web/app/api/claude/turns/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/route.test.ts
@@ -49,7 +49,9 @@ describe("/api/claude/turns", () => {
 
     // Create a test project
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
 
     const projects = await db
       .insert(PROJECTS_TBL)
@@ -78,13 +80,16 @@ describe("/api/claude/turns", () => {
 
   describe("POST /api/claude/turns", () => {
     it("should create a new turn successfully", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: testSessionId,
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: testSessionId,
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -108,15 +113,18 @@ describe("/api/claude/turns", () => {
       const originalUpdatedAt = sessionBefore[0]!.updatedAt;
 
       // Wait a bit to ensure timestamp difference
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: testSessionId,
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: testSessionId,
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       await POST(request);
 
@@ -127,16 +135,21 @@ describe("/api/claude/turns", () => {
         .where(eq(SESSIONS_TBL.id, testSessionId))
         .limit(1);
 
-      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(
+        originalUpdatedAt.getTime(),
+      );
     });
 
     it("should return 400 if sessionId is missing", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -146,12 +159,15 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 400 if userPrompt is missing", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: testSessionId,
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: testSessionId,
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -161,13 +177,16 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 404 if session doesn't exist", async () => {
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: "sess_nonexistent",
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: "sess_nonexistent",
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -177,15 +196,18 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 403 if user doesn't own the session's project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: testSessionId,
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: testSessionId,
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -195,15 +217,18 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
-      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
-        method: "POST",
-        body: JSON.stringify({
-          sessionId: testSessionId,
-          userPrompt: "Test user prompt",
-        }),
-      });
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            sessionId: testSessionId,
+            userPrompt: "Test user prompt",
+          }),
+        },
+      );
 
       const response = await POST(request);
       const data = await response.json();
@@ -230,7 +255,7 @@ describe("/api/claude/turns", () => {
 
     it("should list all turns for a session", async () => {
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,
       );
 
       const response = await GET(request);
@@ -239,12 +264,14 @@ describe("/api/claude/turns", () => {
       expect(response.status).toBe(200);
       expect(data.turns).toHaveLength(3);
       expect(data.turns[0]!.userPrompt).toMatch(/Prompt \d/);
-      expect(data.turns.every((t: any) => t.sessionId === testSessionId)).toBe(true);
+      expect(data.turns.every((t: { sessionId: string }) => t.sessionId === testSessionId)).toBe(
+        true,
+      );
     });
 
     it("should return turns in chronological order", async () => {
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,
       );
 
       const response = await GET(request);
@@ -269,7 +296,7 @@ describe("/api/claude/turns", () => {
 
     it("should return 404 if session doesn't exist", async () => {
       const request = new NextRequest(
-        "http://localhost:3000/api/claude/turns?sessionId=sess_nonexistent"
+        "http://localhost:3000/api/claude/turns?sessionId=sess_nonexistent",
       );
 
       const response = await GET(request);
@@ -280,10 +307,10 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 403 if user doesn't own the session's project", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,
       );
 
       const response = await GET(request);
@@ -294,10 +321,10 @@ describe("/api/claude/turns", () => {
     });
 
     it("should return 401 if not authenticated", async () => {
-      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+      mockAuth.mockResolvedValueOnce({ userId: null } as Awaited<ReturnType<typeof auth>>);
 
       const request = new NextRequest(
-        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`,
       );
 
       const response = await GET(request);

--- a/turbo/apps/web/app/api/claude/turns/route.test.ts
+++ b/turbo/apps/web/app/api/claude/turns/route.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { initServices } from "../../../../src/lib/init-services";
+import { SESSIONS_TBL, TURNS_TBL } from "../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+import * as Y from "yjs";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
+describe("/api/claude/turns", () => {
+  const uniqueId = `${Date.now()}-${process.pid}-${Math.random().toString(36).substring(7)}`;
+  const userId = `test-user-turns-${uniqueId}`;
+  let testProjectId: string;
+  let testSessionId: string;
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    const db = globalThis.services.db;
+
+    // Delete in reverse order to avoid foreign key constraints
+    if (testSessionId) {
+      await db.delete(TURNS_TBL).where(eq(TURNS_TBL.sessionId, testSessionId));
+      await db.delete(SESSIONS_TBL).where(eq(SESSIONS_TBL.id, testSessionId));
+    }
+    if (testProjectId) {
+      await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.id, testProjectId));
+    }
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
+    // Initialize services
+    initServices();
+    const db = globalThis.services.db;
+
+    // Clean up any existing test data
+    await db.delete(PROJECTS_TBL).where(eq(PROJECTS_TBL.userId, userId));
+
+    // Create a test project
+    const ydoc = new Y.Doc();
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+
+    const projects = await db
+      .insert(PROJECTS_TBL)
+      .values({
+        id: `proj_test_${Date.now()}`,
+        userId,
+        ydocData,
+        version: 0,
+      })
+      .returning();
+
+    testProjectId = projects[0]!.id;
+
+    // Create a test session
+    const sessions = await db
+      .insert(SESSIONS_TBL)
+      .values({
+        id: `sess_test_${Date.now()}`,
+        projectId: testProjectId,
+        title: "Test Session",
+      })
+      .returning();
+
+    testSessionId = sessions[0]!.id;
+  });
+
+  describe("POST /api/claude/turns", () => {
+    it("should create a new turn successfully", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: testSessionId,
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.id).toMatch(/^turn_/);
+      expect(data.sessionId).toBe(testSessionId);
+      expect(data.userPrompt).toBe("Test user prompt");
+      expect(data.status).toBe("pending");
+    });
+
+    it("should update session's updatedAt timestamp", async () => {
+      const db = globalThis.services.db;
+
+      // Get original updatedAt
+      const sessionBefore = await db
+        .select()
+        .from(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.id, testSessionId))
+        .limit(1);
+      const originalUpdatedAt = sessionBefore[0]!.updatedAt;
+
+      // Wait a bit to ensure timestamp difference
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: testSessionId,
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      await POST(request);
+
+      // Check if updatedAt was updated
+      const sessionAfter = await db
+        .select()
+        .from(SESSIONS_TBL)
+        .where(eq(SESSIONS_TBL.id, testSessionId))
+        .limit(1);
+
+      expect(sessionAfter[0]!.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+    });
+
+    it("should return 400 if sessionId is missing", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("bad_request");
+    });
+
+    it("should return 400 if userPrompt is missing", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: testSessionId,
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("bad_request");
+    });
+
+    it("should return 404 if session doesn't exist", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: "sess_nonexistent",
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the session's project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: testSessionId,
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest("http://localhost:3000/api/claude/turns", {
+        method: "POST",
+        body: JSON.stringify({
+          sessionId: testSessionId,
+          userPrompt: "Test user prompt",
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+
+  describe("GET /api/claude/turns", () => {
+    beforeEach(async () => {
+      // Create some test turns
+      const db = globalThis.services.db;
+
+      for (let i = 0; i < 3; i++) {
+        await db.insert(TURNS_TBL).values({
+          id: `turn_test_${i}`,
+          sessionId: testSessionId,
+          userPrompt: `Prompt ${i}`,
+          status: i === 0 ? "completed" : i === 1 ? "running" : "pending",
+        });
+      }
+    });
+
+    it("should list all turns for a session", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.turns).toHaveLength(3);
+      expect(data.turns[0]!.userPrompt).toMatch(/Prompt \d/);
+      expect(data.turns.every((t: any) => t.sessionId === testSessionId)).toBe(true);
+    });
+
+    it("should return turns in chronological order", async () => {
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // Turns should be ordered by createdAt (ascending)
+      expect(data.turns[0]!.userPrompt).toBe("Prompt 0");
+      expect(data.turns[1]!.userPrompt).toBe("Prompt 1");
+      expect(data.turns[2]!.userPrompt).toBe("Prompt 2");
+    });
+
+    it("should return 400 if sessionId is missing", async () => {
+      const request = new NextRequest("http://localhost:3000/api/claude/turns");
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("bad_request");
+    });
+
+    it("should return 404 if session doesn't exist", async () => {
+      const request = new NextRequest(
+        "http://localhost:3000/api/claude/turns?sessionId=sess_nonexistent"
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+
+    it("should return 403 if user doesn't own the session's project", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: "different-user" } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("forbidden");
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      mockAuth.mockResolvedValueOnce({ userId: null } as any);
+
+      const request = new NextRequest(
+        `http://localhost:3000/api/claude/turns?sessionId=${testSessionId}`
+      );
+
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/claude/turns/route.ts
+++ b/turbo/apps/web/app/api/claude/turns/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { TURNS_TBL, SESSIONS_TBL } from "../../../../src/db/schema/sessions";
+import { PROJECTS_TBL } from "../../../../src/db/schema/projects";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+/**
+ * POST /api/claude/turns
+ * Create a new turn in a session
+ */
+export async function POST(request: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+
+  try {
+    const body = await request.json();
+    const { sessionId, userPrompt } = body;
+
+    if (!sessionId || !userPrompt) {
+      return NextResponse.json(
+        {
+          error: "bad_request",
+          error_description: "Session ID and user prompt are required"
+        },
+        { status: 400 }
+      );
+    }
+
+    // Verify user owns the session's project
+    const sessionResult = await db
+      .select({
+        sessionId: SESSIONS_TBL.id,
+        projectUserId: PROJECTS_TBL.userId,
+      })
+      .from(SESSIONS_TBL)
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(SESSIONS_TBL.id, sessionId))
+      .limit(1);
+
+    if (sessionResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (sessionResult[0]!.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Create new turn
+    const turnId = `turn_${nanoid()}`;
+    const turn = await db
+      .insert(TURNS_TBL)
+      .values({
+        id: turnId,
+        sessionId,
+        userPrompt,
+        status: "pending",
+      })
+      .returning();
+
+    // Update session's updatedAt timestamp
+    await db
+      .update(SESSIONS_TBL)
+      .set({ updatedAt: new Date() })
+      .where(eq(SESSIONS_TBL.id, sessionId));
+
+    return NextResponse.json(turn[0], { status: 201 });
+  } catch (error) {
+    console.error("Failed to create turn:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to create turn" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/claude/turns
+ * List turns for a session
+ */
+export async function GET(request: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "unauthorized", error_description: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  initServices();
+  const db = globalThis.services.db;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get("sessionId");
+
+    if (!sessionId) {
+      return NextResponse.json(
+        { error: "bad_request", error_description: "Session ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify user owns the session's project
+    const sessionResult = await db
+      .select({
+        projectUserId: PROJECTS_TBL.userId,
+      })
+      .from(SESSIONS_TBL)
+      .innerJoin(PROJECTS_TBL, eq(SESSIONS_TBL.projectId, PROJECTS_TBL.id))
+      .where(eq(SESSIONS_TBL.id, sessionId))
+      .limit(1);
+
+    if (sessionResult.length === 0) {
+      return NextResponse.json(
+        { error: "not_found", error_description: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (sessionResult[0]!.projectUserId !== userId) {
+      return NextResponse.json(
+        { error: "forbidden", error_description: "Access denied" },
+        { status: 403 }
+      );
+    }
+
+    // Get turns for the session
+    const turns = await db
+      .select()
+      .from(TURNS_TBL)
+      .where(eq(TURNS_TBL.sessionId, sessionId))
+      .orderBy(TURNS_TBL.createdAt);
+
+    return NextResponse.json({ turns });
+  } catch (error) {
+    console.error("Failed to list turns:", error);
+    return NextResponse.json(
+      { error: "internal_error", error_description: "Failed to list turns" },
+      { status: 500 }
+    );
+  }
+}

--- a/turbo/apps/web/app/api/claude/turns/route.ts
+++ b/turbo/apps/web/app/api/claude/turns/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -31,9 +31,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           error: "bad_request",
-          error_description: "Session ID and user prompt are required"
+          error_description: "Session ID and user prompt are required",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -51,14 +51,14 @@ export async function POST(request: NextRequest) {
     if (sessionResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Session not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     if (sessionResult[0]!.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
     console.error("Failed to create turn:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to create turn" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -100,7 +100,7 @@ export async function GET(request: NextRequest) {
   if (!userId) {
     return NextResponse.json(
       { error: "unauthorized", error_description: "Authentication required" },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -114,7 +114,7 @@ export async function GET(request: NextRequest) {
     if (!sessionId) {
       return NextResponse.json(
         { error: "bad_request", error_description: "Session ID is required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -131,14 +131,14 @@ export async function GET(request: NextRequest) {
     if (sessionResult.length === 0) {
       return NextResponse.json(
         { error: "not_found", error_description: "Session not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     if (sessionResult[0]!.projectUserId !== userId) {
       return NextResponse.json(
         { error: "forbidden", error_description: "Access denied" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -154,7 +154,7 @@ export async function GET(request: NextRequest) {
     console.error("Failed to list turns:", error);
     return NextResponse.json(
       { error: "internal_error", error_description: "Failed to list turns" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/turbo/apps/web/app/settings/github/github-connection.test.tsx
+++ b/turbo/apps/web/app/settings/github/github-connection.test.tsx
@@ -1,29 +1,42 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { GitHubConnection } from "./github-connection";
-import { useRouter } from "next/navigation";
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-// Mock next/navigation
-vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
-}));
+// Use vi.hoisted for better control over mocks
+const { mockRouter, mockPush, mockRefresh } = vi.hoisted(() => {
+  const mockPush = vi.fn();
+  const mockRefresh = vi.fn();
+  const mockRouter = {
+    push: mockPush,
+    refresh: mockRefresh,
+    back: vi.fn(),
+    forward: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  };
+  return { mockRouter, mockPush, mockRefresh };
+});
 
-const mockUseRouter = vi.mocked(useRouter);
+// Mock next/navigation following Next.js testing best practices
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    useRouter: vi.fn(() => mockRouter),
+    usePathname: vi.fn(() => "/settings/github"),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+  };
+});
 
 // Mock fetch
 global.fetch = vi.fn();
 const mockFetch = vi.mocked(global.fetch);
 
 describe("GitHubConnection", () => {
-  const mockRouter = {
-    refresh: vi.fn(),
-  };
-
   const originalLocation = window.location;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseRouter.mockReturnValue(mockRouter);
 
     // Reset window.location before each test
     Object.defineProperty(window, "location", {
@@ -148,7 +161,7 @@ describe("GitHubConnection", () => {
       });
     });
 
-    expect(mockRouter.refresh).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
   });
 
   it("handles manage on GitHub button click", async () => {

--- a/turbo/apps/web/app/settings/github/github-connection.test.tsx
+++ b/turbo/apps/web/app/settings/github/github-connection.test.tsx
@@ -3,23 +3,23 @@ import { GitHubConnection } from "./github-connection";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 // Use vi.hoisted for better control over mocks
-const { mockRouter, mockPush, mockRefresh } = vi.hoisted(() => {
-  const mockPush = vi.fn();
+const { mockRouter, mockRefresh } = vi.hoisted(() => {
   const mockRefresh = vi.fn();
   const mockRouter = {
-    push: mockPush,
+    push: vi.fn(),
     refresh: mockRefresh,
     back: vi.fn(),
     forward: vi.fn(),
     replace: vi.fn(),
     prefetch: vi.fn(),
   };
-  return { mockRouter, mockPush, mockRefresh };
+  return { mockRouter, mockRefresh };
 });
 
 // Mock next/navigation following Next.js testing best practices
 vi.mock("next/navigation", async () => {
-  const actual = await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
   return {
     ...actual,
     useRouter: vi.fn(() => mockRouter),


### PR DESCRIPTION
## Summary
Implements the Claude Sessions and Turns API endpoints needed for MVP Story 2 (Web-based AI Document Editing).

## Changes
### API Endpoints Added
- **Sessions API** (`/api/claude/sessions`)
  - `POST` - Create new session
  - `GET` - List user sessions with pagination
  - `GET /:id` - Get session details with all turns/blocks
  - `DELETE /:id` - Delete session (cascade deletes)

- **Turns API** (`/api/claude/turns`)
  - `POST` - Create new conversation turn
  - `GET` - List turns for a session
  - `GET /:id` - Get turn details with blocks
  - `PATCH /:id` - Update turn status

### Documentation Updates
- Updated `claude-sessions-design.md` - marked schema as completed
- Updated `yjs.md` - marked blob-token API as completed
- Updated `e2b-runtime-container.md` - marked partial container setup
- Updated `mvp.md` - updated overall completion from 70% to 75%

### Test Improvements
- Fixed `github-connection.test.tsx` TypeScript errors
- Improved router mocking using Next.js testing best practices with `vi.hoisted()`
- Removed `as any` type assertions for better type safety

## Testing
- ✅ TypeScript checks pass
- ✅ ESLint passes (after fixes)
- ✅ Tests pass (8/8 in github-connection.test.tsx)

## Next Steps
These APIs provide the backend foundation for:
- Frontend polling system (`useSessionPolling` hook)
- E2B container integration
- Claude execution flow

🤖 Generated with [Claude Code](https://claude.ai/code)