### PR TITLE
fix: decode base64 encoded github app private key

### DIFF
--- a/turbo/apps/web/src/lib/github/auth.ts
+++ b/turbo/apps/web/src/lib/github/auth.ts
@@ -11,9 +11,12 @@ export async function getInstallationToken(
   initServices();
   const env = globalThis.services.env;
 
+  // Decode base64 encoded private key
+  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, 'base64').toString('utf-8');
+
   const auth = createAppAuth({
     appId: env.GH_APP_ID,
-    privateKey: env.GH_APP_PRIVATE_KEY,
+    privateKey: privateKey,
   });
 
   const installationAuthentication = await auth({

--- a/turbo/apps/web/src/lib/github/auth.ts
+++ b/turbo/apps/web/src/lib/github/auth.ts
@@ -12,7 +12,9 @@ export async function getInstallationToken(
   const env = globalThis.services.env;
 
   // Decode base64 encoded private key
-  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, 'base64').toString('utf-8');
+  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, "base64").toString(
+    "utf-8",
+  );
 
   const auth = createAppAuth({
     appId: env.GH_APP_ID,

--- a/turbo/apps/web/src/lib/github/client.ts
+++ b/turbo/apps/web/src/lib/github/client.ts
@@ -11,9 +11,12 @@ export function createAppOctokit(): App {
   initServices();
   const env = globalThis.services.env;
 
+  // Decode base64 encoded private key
+  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, 'base64').toString('utf-8');
+
   return new App({
     appId: env.GH_APP_ID,
-    privateKey: env.GH_APP_PRIVATE_KEY,
+    privateKey: privateKey,
   });
 }
 

--- a/turbo/apps/web/src/lib/github/client.ts
+++ b/turbo/apps/web/src/lib/github/client.ts
@@ -12,7 +12,9 @@ export function createAppOctokit(): App {
   const env = globalThis.services.env;
 
   // Decode base64 encoded private key
-  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, 'base64').toString('utf-8');
+  const privateKey = Buffer.from(env.GH_APP_PRIVATE_KEY, "base64").toString(
+    "utf-8",
+  );
 
   return new App({
     appId: env.GH_APP_ID,


### PR DESCRIPTION
## Summary
- Add base64 decoding for GH_APP_PRIVATE_KEY in client.ts and auth.ts
- GitHub App private key is stored as base64 in environment variables
- Octokit requires the decoded PEM format string

## Problem
When trying to create a GitHub repository, the API was failing with:
```
Error [DataError]: Invalid keyData
Failed to read private key
```

## Solution
The GitHub App private key is stored as base64 encoded in environment variables (starting with `LS0tLS1CRUdJTi...`). However, Octokit expects the actual PEM formatted string. This PR adds decoding before passing the key to Octokit.

## Changes
- Added `Buffer.from(env.GH_APP_PRIVATE_KEY, 'base64').toString('utf-8')` in:
  - `src/lib/github/client.ts` - createAppOctokit function
  - `src/lib/github/auth.ts` - getInstallationToken function