### PR TITLE
fix: use correct GitHub API endpoint for repository creation based on account type

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -133,7 +133,9 @@ describe("/api/projects/[projectId]/github/sync", () => {
         .limit(1);
 
       if (verifyProject.length === 0) {
-        throw new Error(`Test setup failed: Project ${projectId} was not inserted`);
+        throw new Error(
+          `Test setup failed: Project ${projectId} was not inserted`,
+        );
       }
 
       const request = new NextRequest(
@@ -142,7 +144,6 @@ describe("/api/projects/[projectId]/github/sync", () => {
           method: "POST",
         },
       );
-
 
       const response = await POST(request, {
         params: Promise.resolve({ projectId }),

--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -125,12 +125,24 @@ describe("/api/projects/[projectId]/github/sync", () => {
         repoId: 67890,
       });
 
+      // Verify data was inserted
+      const verifyProject = await db
+        .select()
+        .from(PROJECTS_TBL)
+        .where(eq(PROJECTS_TBL.id, projectId))
+        .limit(1);
+
+      if (verifyProject.length === 0) {
+        throw new Error(`Test setup failed: Project ${projectId} was not inserted`);
+      }
+
       const request = new NextRequest(
         `http://localhost/api/projects/${projectId}/github/sync`,
         {
           method: "POST",
         },
       );
+
 
       const response = await POST(request, {
         params: Promise.resolve({ projectId }),

--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -31,6 +31,22 @@ vi.mock("../../../../../../src/lib/github/auth", () => ({
     .mockResolvedValue("ghs_test_installation_token_12345"),
 }));
 
+// Mock getInstallationDetails to avoid real API calls
+vi.mock("../../../../../../src/lib/github/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../../../../src/lib/github/client")
+  >("../../../../../../src/lib/github/client");
+  return {
+    ...actual,
+    getInstallationDetails: vi.fn().mockResolvedValue({
+      account: {
+        type: "User",
+        login: "testuser",
+      },
+    }),
+  };
+});
+
 const mockAuth = vi.mocked(auth);
 
 describe("/api/projects/[projectId]/github/sync", () => {

--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -125,19 +125,6 @@ describe("/api/projects/[projectId]/github/sync", () => {
         repoId: 67890,
       });
 
-      // Verify data was inserted
-      const verifyProject = await db
-        .select()
-        .from(PROJECTS_TBL)
-        .where(eq(PROJECTS_TBL.id, projectId))
-        .limit(1);
-
-      if (verifyProject.length === 0) {
-        throw new Error(
-          `Test setup failed: Project ${projectId} was not inserted`,
-        );
-      }
-
       const request = new NextRequest(
         `http://localhost/api/projects/${projectId}/github/sync`,
         {

--- a/turbo/apps/web/app/components/github-sync-button.tsx
+++ b/turbo/apps/web/app/components/github-sync-button.tsx
@@ -18,6 +18,11 @@ export function GitHubSyncButton({ projectId }: GitHubSyncButtonProps) {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isCreatingRepo, setIsCreatingRepo] = useState(false);
   const [hasRepository, setHasRepository] = useState<boolean | null>(null);
+  const [repositoryInfo, setRepositoryInfo] = useState<{
+    fullName?: string;
+    accountName?: string;
+    repoName?: string;
+  } | null>(null);
   const [installations, setInstallations] = useState<GitHubInstallation[]>([]);
   const [selectedInstallationId, setSelectedInstallationId] = useState<
     number | null
@@ -37,12 +42,19 @@ export function GitHubSyncButton({ projectId }: GitHubSyncButtonProps) {
         );
         if (response.ok) {
           const data = await response.json();
-          setHasRepository(data.linked);
+          setHasRepository(true);
+          setRepositoryInfo({
+            fullName: data.repository.fullName,
+            accountName: data.repository.accountName,
+            repoName: data.repository.repoName,
+          });
         } else {
           setHasRepository(false);
+          setRepositoryInfo(null);
         }
       } catch {
         setHasRepository(false);
+        setRepositoryInfo(null);
       }
     };
 
@@ -119,9 +131,22 @@ export function GitHubSyncButton({ projectId }: GitHubSyncButtonProps) {
 
       if (response.ok) {
         setHasRepository(true);
+        // Find the selected installation to get account name
+        const selectedInstallation = installations.find(
+          (inst) => inst.installationId === selectedInstallationId,
+        );
+        setRepositoryInfo({
+          repoName: data.repository.repoName,
+          fullName:
+            data.repository.fullName ||
+            (selectedInstallation
+              ? `${selectedInstallation.accountName}/${data.repository.repoName}`
+              : data.repository.repoName),
+          accountName: selectedInstallation?.accountName,
+        });
         setSyncStatus({
           type: "success",
-          message: `Created repository: ${data.repository.repoName}`,
+          message: `Created repository: ${data.repository.fullName || data.repository.repoName}`,
         });
       } else {
         let errorMessage = "Failed to create repository";
@@ -331,52 +356,85 @@ export function GitHubSyncButton({ projectId }: GitHubSyncButtonProps) {
           )}
         </>
       ) : (
-        <button
-          onClick={handleSync}
-          disabled={isSyncing}
-          style={{
-            padding: "8px 16px",
-            fontSize: "14px",
-            color: isSyncing ? "rgba(156, 163, 175, 0.5)" : "#fff",
-            backgroundColor: isSyncing ? "rgba(156, 163, 175, 0.2)" : "#0969da",
-            border: "1px solid rgba(156, 163, 175, 0.2)",
-            borderRadius: "4px",
-            cursor: isSyncing ? "not-allowed" : "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-          }}
-        >
-          {isSyncing ? (
-            <>
-              <span
-                style={{
-                  display: "inline-block",
-                  width: "14px",
-                  height: "14px",
-                  border: "2px solid rgba(156, 163, 175, 0.3)",
-                  borderTopColor: "#0969da",
-                  borderRadius: "50%",
-                  animation: "spin 1s linear infinite",
-                }}
-              />
-              Syncing...
-            </>
-          ) : (
-            <>
+        <>
+          {/* Show repository info */}
+          {repositoryInfo?.fullName && (
+            <div
+              style={{
+                padding: "8px 12px",
+                fontSize: "13px",
+                color: "#0969da",
+                backgroundColor: "rgba(9, 105, 218, 0.1)",
+                border: "1px solid rgba(9, 105, 218, 0.3)",
+                borderRadius: "4px",
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+              }}
+            >
               <svg
-                width="16"
-                height="16"
+                width="14"
+                height="14"
                 viewBox="0 0 16 16"
                 fill="currentColor"
-                style={{ display: "block" }}
+                style={{ display: "block", flexShrink: 0 }}
               >
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
               </svg>
-              Sync to GitHub
-            </>
+              <span>{repositoryInfo.fullName}</span>
+            </div>
           )}
-        </button>
+
+          {/* Sync button */}
+          <button
+            onClick={handleSync}
+            disabled={isSyncing}
+            style={{
+              padding: "8px 16px",
+              fontSize: "14px",
+              color: isSyncing ? "rgba(156, 163, 175, 0.5)" : "#fff",
+              backgroundColor: isSyncing
+                ? "rgba(156, 163, 175, 0.2)"
+                : "#0969da",
+              border: "1px solid rgba(156, 163, 175, 0.2)",
+              borderRadius: "4px",
+              cursor: isSyncing ? "not-allowed" : "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            {isSyncing ? (
+              <>
+                <span
+                  style={{
+                    display: "inline-block",
+                    width: "14px",
+                    height: "14px",
+                    border: "2px solid rgba(156, 163, 175, 0.3)",
+                    borderTopColor: "#0969da",
+                    borderRadius: "50%",
+                    animation: "spin 1s linear infinite",
+                  }}
+                />
+                Syncing...
+              </>
+            ) : (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  style={{ display: "block" }}
+                >
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                </svg>
+                Sync to GitHub
+              </>
+            )}
+          </button>
+        </>
       )}
 
       {syncStatus.type && (

--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -141,13 +141,16 @@ describe("GitHub Repository", () => {
       });
 
       // Verify correct API endpoint was called for organization
-      expect(mockOctokit.request).toHaveBeenCalledWith("POST /orgs/{org}/repos", {
-        org: "testorg",
-        name: expectedRepoName,
-        private: true,
-        auto_init: true,
-        description: `uSpark sync repository for project ${testProjectId}`,
-      });
+      expect(mockOctokit.request).toHaveBeenCalledWith(
+        "POST /orgs/{org}/repos",
+        {
+          org: "testorg",
+          name: expectedRepoName,
+          private: true,
+          auto_init: true,
+          description: `uSpark sync repository for project ${testProjectId}`,
+        },
+      );
     });
 
     it("should throw error if repository already exists", async () => {

--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -222,39 +222,6 @@ describe("GitHub Repository", () => {
       });
     });
 
-    it("should fallback to database account name when getInstallationDetails fails", async () => {
-      // Create repository and installation in database
-      const db = globalThis.services.db;
-      await db.insert(githubInstallations).values({
-        userId: testUserId,
-        installationId: testInstallationId,
-        accountName: "fallback-account",
-      });
-      await db.insert(githubRepos).values({
-        projectId: testProjectId,
-        installationId: testInstallationId,
-        repoName: expectedRepoName,
-        repoId: 987654,
-      });
-
-      // Mock getInstallationDetails to throw error
-      vi.mocked(getInstallationDetails).mockRejectedValue(
-        new Error("API error"),
-      );
-
-      const result = await getProjectRepository(testProjectId);
-
-      expect(result).toMatchObject({
-        projectId: testProjectId,
-        installationId: testInstallationId,
-        repoName: expectedRepoName,
-        repoId: 987654,
-        fullName: "fallback-account/uspark-a1b2c3d4",
-      });
-      // accountType should be undefined in fallback case
-      expect(result?.accountType).toBeUndefined();
-    });
-
     it("should return null for non-existent project", async () => {
       const result = await getProjectRepository("non-existent-project");
       expect(result).toBeNull();

--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -62,7 +62,7 @@ describe("GitHub Repository", () => {
           type: "User",
           login: "testuser",
         },
-      } as any);
+      } as Awaited<ReturnType<typeof getInstallationDetails>>);
 
       // Create repository
       const result = await createProjectRepository(
@@ -123,7 +123,7 @@ describe("GitHub Repository", () => {
           type: "Organization",
           login: "testorg",
         },
-      } as any);
+      } as Awaited<ReturnType<typeof getInstallationDetails>>);
 
       // Create repository
       const result = await createProjectRepository(
@@ -208,7 +208,7 @@ describe("GitHub Repository", () => {
           type: "Organization",
           login: "test-org",
         },
-      } as any);
+      } as Awaited<ReturnType<typeof getInstallationDetails>>);
 
       const result = await getProjectRepository(testProjectId);
 

--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -9,12 +9,13 @@ import {
 import { initServices } from "../init-services";
 import { githubInstallations, githubRepos } from "../../db/schema/github";
 import { eq } from "drizzle-orm";
-import { createInstallationOctokit } from "./client";
+import { createInstallationOctokit, getInstallationDetails } from "./client";
 import type { Octokit } from "@octokit/core";
 
 // Mock the client module - we still need to mock external APIs
 vi.mock("./client", () => ({
   createInstallationOctokit: vi.fn(),
+  getInstallationDetails: vi.fn(),
 }));
 
 describe("GitHub Repository", () => {
@@ -55,6 +56,14 @@ describe("GitHub Repository", () => {
       } as unknown as Octokit;
       vi.mocked(createInstallationOctokit).mockResolvedValue(mockOctokit);
 
+      // Mock installation details to return a user account (not org)
+      vi.mocked(getInstallationDetails).mockResolvedValue({
+        account: {
+          type: "User",
+          login: "testuser",
+        },
+      } as any);
+
       // Create repository
       const result = await createProjectRepository(
         testProjectId,
@@ -90,6 +99,54 @@ describe("GitHub Repository", () => {
         installationId: testInstallationId,
         repoName: expectedRepoName,
         repoId: 987654,
+      });
+    });
+
+    it("should create a repository in an organization account", async () => {
+      // Setup GitHub API mock
+      const mockOctokit = {
+        request: vi.fn().mockResolvedValue({
+          data: {
+            id: 987654,
+            name: expectedRepoName,
+            full_name: `testorg/uspark-${testProjectId}`,
+            html_url: `https://github.com/testorg/uspark-${testProjectId}`,
+            clone_url: `https://github.com/testorg/uspark-${testProjectId}.git`,
+          },
+        }),
+      } as unknown as Octokit;
+      vi.mocked(createInstallationOctokit).mockResolvedValue(mockOctokit);
+
+      // Mock installation details to return an organization account
+      vi.mocked(getInstallationDetails).mockResolvedValue({
+        account: {
+          type: "Organization",
+          login: "testorg",
+        },
+      } as any);
+
+      // Create repository
+      const result = await createProjectRepository(
+        testProjectId,
+        testInstallationId,
+      );
+
+      // Verify result
+      expect(result).toEqual({
+        repoId: 987654,
+        repoName: expectedRepoName,
+        fullName: `testorg/uspark-${testProjectId}`,
+        url: `https://github.com/testorg/uspark-${testProjectId}`,
+        cloneUrl: `https://github.com/testorg/uspark-${testProjectId}.git`,
+      });
+
+      // Verify correct API endpoint was called for organization
+      expect(mockOctokit.request).toHaveBeenCalledWith("POST /orgs/{org}/repos", {
+        org: "testorg",
+        name: expectedRepoName,
+        private: true,
+        auto_init: true,
+        description: `uSpark sync repository for project ${testProjectId}`,
       });
     });
 

--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -182,6 +182,14 @@ describe("GitHub Repository", () => {
         repoId: 987654,
       });
 
+      // Mock getInstallationDetails
+      vi.mocked(getInstallationDetails).mockResolvedValue({
+        account: {
+          type: "User",
+          login: "testuser",
+        },
+      } as Awaited<ReturnType<typeof getInstallationDetails>>);
+
       const result = await getProjectRepository(testProjectId);
 
       expect(result).toMatchObject({
@@ -189,6 +197,8 @@ describe("GitHub Repository", () => {
         installationId: testInstallationId,
         repoName: expectedRepoName,
         repoId: 987654,
+        accountType: "User",
+        fullName: "testuser/uspark-a1b2c3d4",
       });
     });
 

--- a/turbo/apps/web/src/lib/github/repository.ts
+++ b/turbo/apps/web/src/lib/github/repository.ts
@@ -23,6 +23,9 @@ type RepositoryInfo = {
   installationId: number;
   repoName: string;
   repoId: number;
+  accountName?: string;
+  accountType?: string;
+  fullName?: string;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -114,8 +117,21 @@ export async function getProjectRepository(
   const db = globalThis.services.db;
 
   const repos = await db
-    .select()
+    .select({
+      id: githubRepos.id,
+      projectId: githubRepos.projectId,
+      installationId: githubRepos.installationId,
+      repoName: githubRepos.repoName,
+      repoId: githubRepos.repoId,
+      createdAt: githubRepos.createdAt,
+      updatedAt: githubRepos.updatedAt,
+      accountName: githubInstallations.accountName,
+    })
     .from(githubRepos)
+    .leftJoin(
+      githubInstallations,
+      eq(githubRepos.installationId, githubInstallations.installationId),
+    )
     .where(eq(githubRepos.projectId, projectId))
     .limit(1);
 
@@ -123,7 +139,25 @@ export async function getProjectRepository(
     return null;
   }
 
-  return repos[0] as RepositoryInfo;
+  const repo = repos[0]!;
+
+  // Get installation details to determine account type and get full name
+  try {
+    const installation = await getInstallationDetails(repo.installationId);
+    return {
+      ...repo,
+      accountType: installation.account?.type,
+      fullName: `${installation.account?.login}/${repo.repoName}`,
+    };
+  } catch {
+    // If we can't get installation details, return what we have
+    return {
+      ...repo,
+      fullName: repo.accountName
+        ? `${repo.accountName}/${repo.repoName}`
+        : repo.repoName,
+    };
+  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/github/repository.ts
+++ b/turbo/apps/web/src/lib/github/repository.ts
@@ -142,22 +142,12 @@ export async function getProjectRepository(
   const repo = repos[0]!;
 
   // Get installation details to determine account type and get full name
-  try {
-    const installation = await getInstallationDetails(repo.installationId);
-    return {
-      ...repo,
-      accountType: installation.account?.type,
-      fullName: `${installation.account?.login}/${repo.repoName}`,
-    };
-  } catch {
-    // If we can't get installation details, return what we have
-    return {
-      ...repo,
-      fullName: repo.accountName
-        ? `${repo.accountName}/${repo.repoName}`
-        : repo.repoName,
-    };
-  }
+  const installation = await getInstallationDetails(repo.installationId);
+  return {
+    ...repo,
+    accountType: installation.account?.type,
+    fullName: `${installation.account?.login}/${repo.repoName}`,
+  };
 }
 
 /**

--- a/turbo/apps/web/src/lib/github/repository.ts
+++ b/turbo/apps/web/src/lib/github/repository.ts
@@ -23,7 +23,7 @@ type RepositoryInfo = {
   installationId: number;
   repoName: string;
   repoId: number;
-  accountName?: string;
+  accountName?: string | null;
   accountType?: string;
   fullName?: string;
   createdAt: Date;

--- a/turbo/apps/web/src/lib/github/sync.test.ts
+++ b/turbo/apps/web/src/lib/github/sync.test.ts
@@ -19,6 +19,20 @@ vi.mock("./auth", () => ({
     .mockResolvedValue("ghs_test_installation_token_12345"),
 }));
 
+// Mock getInstallationDetails to avoid real API calls
+vi.mock("./client", async () => {
+  const actual = await vi.importActual<typeof import("./client")>("./client");
+  return {
+    ...actual,
+    getInstallationDetails: vi.fn().mockResolvedValue({
+      account: {
+        type: "User",
+        login: "testuser",
+      },
+    }),
+  };
+});
+
 describe("GitHub Sync", () => {
   beforeEach(async () => {
     // Set up environment variables for blob storage

--- a/turbo/apps/web/src/test/msw-handlers.ts
+++ b/turbo/apps/web/src/test/msw-handlers.ts
@@ -402,9 +402,12 @@ const githubHandlers = [
 // Vercel Blob handlers
 const blobHandlers = [
   // Mock blob download
-  http.get("https://*.public.blob.vercel-storage.com/projects/:projectId/:hash", () => {
-    return HttpResponse.arrayBuffer(new ArrayBuffer(100));
-  }),
+  http.get(
+    "https://*.public.blob.vercel-storage.com/projects/:projectId/:hash",
+    () => {
+      return HttpResponse.arrayBuffer(new ArrayBuffer(100));
+    },
+  ),
 ];
 
 // Export all handlers

--- a/turbo/apps/web/src/test/msw-handlers.ts
+++ b/turbo/apps/web/src/test/msw-handlers.ts
@@ -402,7 +402,7 @@ const githubHandlers = [
 // Vercel Blob handlers
 const blobHandlers = [
   // Mock blob download
-  http.get("https://*/projects/:projectId/:hash", () => {
+  http.get("https://*.public.blob.vercel-storage.com/projects/:projectId/:hash", () => {
     return HttpResponse.arrayBuffer(new ArrayBuffer(100));
   }),
 ];


### PR DESCRIPTION
## Summary
Fixed GitHub repository creation errors and added multi-account selection support.

## Issues Fixed
1. **403 "Resource not accessible by integration" error** when creating repositories
2. **No way to select which account/organization** to use for repository creation

## Changes

### Fix API Endpoint Issue
- Detect if installation is on Organization or User account
- Use `POST /orgs/{org}/repos` for organization accounts
- Use `POST /user/repos` for user accounts
- Added `getInstallationDetails` to determine account type

### Add Multi-Account Selection
- Added dropdown selector to choose GitHub installation (organization/user account)
- Fetch all available installations from `/api/github/installations` endpoint
- Auto-select if only one installation is available
- Disable create button until an installation is selected
- Show helpful message if no GitHub installations found

## Test Plan
- [x] Unit tests pass for both organization and user repository creation
- [x] Component fetches installations correctly
- [x] Dropdown shows all available accounts
- [x] Create button disabled until selection made
- [x] Auto-selects single installation
- [ ] Test with GitHub App installed on organization account
- [ ] Test with multiple installations (org + personal)

## Screenshots
- Dropdown shows all available GitHub accounts/organizations
- Clear visual feedback when no selection made
- Auto-selects if only one option available

Fixes the error: `Error [HttpError]: Resource not accessible by integration`

🤖 Generated with [Claude Code](https://claude.ai/code)