### PR TITLE
feat: add multi-account selection for GitHub repository creation

### DIFF
--- a/turbo/apps/web/src/lib/github/repository.test.ts
+++ b/turbo/apps/web/src/lib/github/repository.test.ts
@@ -9,12 +9,13 @@ import {
 import { initServices } from "../init-services";
 import { githubInstallations, githubRepos } from "../../db/schema/github";
 import { eq } from "drizzle-orm";
-import { createInstallationOctokit } from "./client";
+import { createInstallationOctokit, getInstallationDetails } from "./client";
 import type { Octokit } from "@octokit/core";
 
 // Mock the client module - we still need to mock external APIs
 vi.mock("./client", () => ({
   createInstallationOctokit: vi.fn(),
+  getInstallationDetails: vi.fn(),
 }));
 
 describe("GitHub Repository", () => {
@@ -55,6 +56,14 @@ describe("GitHub Repository", () => {
       } as unknown as Octokit;
       vi.mocked(createInstallationOctokit).mockResolvedValue(mockOctokit);
 
+      // Mock installation details to return a user account (not org)
+      vi.mocked(getInstallationDetails).mockResolvedValue({
+        account: {
+          type: "User",
+          login: "testuser",
+        },
+      } as any);
+
       // Create repository
       const result = await createProjectRepository(
         testProjectId,
@@ -90,6 +99,54 @@ describe("GitHub Repository", () => {
         installationId: testInstallationId,
         repoName: expectedRepoName,
         repoId: 987654,
+      });
+    });
+
+    it("should create a repository in an organization account", async () => {
+      // Setup GitHub API mock
+      const mockOctokit = {
+        request: vi.fn().mockResolvedValue({
+          data: {
+            id: 987654,
+            name: expectedRepoName,
+            full_name: `testorg/uspark-${testProjectId}`,
+            html_url: `https://github.com/testorg/uspark-${testProjectId}`,
+            clone_url: `https://github.com/testorg/uspark-${testProjectId}.git`,
+          },
+        }),
+      } as unknown as Octokit;
+      vi.mocked(createInstallationOctokit).mockResolvedValue(mockOctokit);
+
+      // Mock installation details to return an organization account
+      vi.mocked(getInstallationDetails).mockResolvedValue({
+        account: {
+          type: "Organization",
+          login: "testorg",
+        },
+      } as any);
+
+      // Create repository
+      const result = await createProjectRepository(
+        testProjectId,
+        testInstallationId,
+      );
+
+      // Verify result
+      expect(result).toEqual({
+        repoId: 987654,
+        repoName: expectedRepoName,
+        fullName: `testorg/uspark-${testProjectId}`,
+        url: `https://github.com/testorg/uspark-${testProjectId}`,
+        cloneUrl: `https://github.com/testorg/uspark-${testProjectId}.git`,
+      });
+
+      // Verify correct API endpoint was called for organization
+      expect(mockOctokit.request).toHaveBeenCalledWith("POST /orgs/{org}/repos", {
+        org: "testorg",
+        name: expectedRepoName,
+        private: true,
+        auto_init: true,
+        description: `uSpark sync repository for project ${testProjectId}`,
       });
     });
 


### PR DESCRIPTION
## Summary
Adds support for selecting which GitHub account/organization to use when creating repositories, solving the issue where users with multiple GitHub App installations couldn't choose where to create repos.

## Changes
- Added dropdown selector to choose GitHub installation (organization/user account)
- Fetch all available installations from `/api/github/installations` endpoint
- Auto-select if only one installation is available
- Disable create button until an installation is selected
- Show helpful message if no GitHub installations found
- Improved UI flow to make account selection clear

## How it works
1. When user clicks to create a repository, we fetch all their GitHub installations
2. User selects which account/org to use from dropdown
3. Repository is created under the selected account using the correct API endpoint

## Screenshots
- Dropdown shows all available GitHub accounts/organizations
- Clear visual feedback when no selection made
- Auto-selects if only one option available

## Test plan
- [x] Component fetches installations correctly
- [x] Dropdown shows all available accounts
- [x] Create button disabled until selection made
- [x] Auto-selects single installation
- [ ] Test with multiple installations (org + personal)
- [ ] Test repository creation with selected account

🤖 Generated with [Claude Code](https://claude.ai/code)