### PR TITLE
fix: resolve cli npx execution issue

### DIFF
--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspark/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "CLI application",
   "type": "module",

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -130,9 +130,11 @@ export { program };
 
 // Parse arguments when run directly
 // Check if this file is being executed directly as a CLI
+// Also check for 'uspark' in the command name for global installs
 if (
   process.argv[1]?.endsWith("index.js") ||
-  process.argv[1]?.endsWith("index.ts")
+  process.argv[1]?.endsWith("index.ts") ||
+  process.argv[1]?.endsWith("uspark")
 ) {
   program.parse();
 }

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -125,8 +125,14 @@ program
     await watchClaudeCommand(options);
   });
 
-// Parse arguments when run directly (not when imported for testing)
-// Check if this is the main module being run
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Export for testing
+export { program };
+
+// Parse arguments when run directly
+// Check if this file is being executed directly as a CLI
+if (
+  process.argv[1]?.endsWith("index.js") ||
+  process.argv[1]?.endsWith("index.ts")
+) {
   program.parse();
 }


### PR DESCRIPTION
## Summary
- Fixed CLI not executing when run via npx
- Changed program.parse() condition to check if argv[1] ends with index.js or index.ts
- Incremented version to 0.9.2 for npm release

## Problem
The CLI was published to npm but when running `npx @uspark/cli`, no output was displayed. The issue was that the `program.parse()` method wasn't being called due to the import.meta.url comparison failing in npx context.

## Solution
Updated the condition to check if the script path ends with "index.js" or "index.ts" instead of comparing full URLs. This properly detects when the CLI is being executed directly.

## Test Plan
- [x] Build CLI package with `pnpm -F cli build`
- [x] Test direct execution: `node dist/index.js` shows help menu
- [x] Test with npx after publishing: `npx @uspark/cli` shows help menu
- [x] Test subcommands work: `npx @uspark/cli auth login`