### PR TITLE
fix: add detailed error logging for github repository creation

### DIFF
--- a/turbo/apps/web/src/lib/github/auth.ts
+++ b/turbo/apps/web/src/lib/github/auth.ts
@@ -21,10 +21,21 @@ export async function getInstallationToken(
     privateKey: privateKey,
   });
 
-  const installationAuthentication = await auth({
-    type: "installation",
-    installationId,
-  });
+  try {
+    const installationAuthentication = await auth({
+      type: "installation",
+      installationId,
+    });
 
-  return installationAuthentication.token;
+    console.log("Installation token obtained for:", {
+      installationId,
+      tokenPrefix: installationAuthentication.token.substring(0, 10) + "...",
+      expiresAt: installationAuthentication.expiresAt,
+    });
+
+    return installationAuthentication.token;
+  } catch (error) {
+    console.error("Failed to get installation token:", error);
+    throw error;
+  }
 }

--- a/turbo/apps/web/src/lib/github/repository.ts
+++ b/turbo/apps/web/src/lib/github/repository.ts
@@ -114,11 +114,15 @@ export async function createProjectRepository(
       accountType: installation.account?.type,
       accountLogin: installation.account?.login,
       repoName,
-      error
+      error,
     });
 
     if (error instanceof Error && "status" in error) {
-      const githubError = error as { status: number; message: string; response?: { data?: unknown } };
+      const githubError = error as {
+        status: number;
+        message: string;
+        response?: { data?: unknown };
+      };
 
       // 404 can mean either wrong endpoint or missing permissions
       if (githubError.status === 404) {
@@ -126,10 +130,12 @@ export async function createProjectRepository(
           // For user accounts, this might be a GitHub App limitation
           throw new Error(
             `Cannot create repository for user account. GitHub Apps may have limited permissions for personal accounts. ` +
-            `Please ensure: 1) The GitHub App is installed on your personal account, 2) The App has 'Administration: write' and 'Contents: write' permissions for repositories.`
+              `Please ensure: 1) The GitHub App is installed on your personal account, 2) The App has 'Administration: write' and 'Contents: write' permissions for repositories.`,
           );
         } else {
-          throw new Error(`GitHub API endpoint not found for organization ${installation.account.login}. Please check the GitHub App installation.`);
+          throw new Error(
+            `GitHub API endpoint not found for organization ${installation.account.login}. Please check the GitHub App installation.`,
+          );
         }
       }
 
@@ -137,13 +143,15 @@ export async function createProjectRepository(
       if (githubError.status === 403) {
         throw new Error(
           `Permission denied. Please ensure the GitHub App has 'Administration: write' and 'Contents: write' permissions. ` +
-          `Error: ${githubError.message}`
+            `Error: ${githubError.message}`,
         );
       }
 
       // 422 means validation error (e.g., repo already exists on GitHub)
       if (githubError.status === 422) {
-        throw new Error(`Repository creation failed. The repository name '${repoName}' may already exist on GitHub.`);
+        throw new Error(
+          `Repository creation failed. The repository name '${repoName}' may already exist on GitHub.`,
+        );
       }
     }
 

--- a/turbo/apps/web/src/lib/github/repository.ts
+++ b/turbo/apps/web/src/lib/github/repository.ts
@@ -61,30 +61,93 @@ export async function createProjectRepository(
   // Get installation details to determine if it's an organization or user
   const installation = await getInstallationDetails(installationId);
 
+  console.log("Installation details:", {
+    installationId,
+    account: installation.account,
+    accountType: installation.account?.type,
+    accountLogin: installation.account?.login,
+  });
+
   // Generate repository name using first 8 characters of UUID for brevity
   const repoName = `uspark-${projectId.substring(0, 8)}`;
 
   // Create repository on GitHub - use appropriate endpoint based on account type
   let repo;
-  if (installation.account?.type === "Organization") {
-    // Create repository in organization
-    const { data } = await octokit.request("POST /orgs/{org}/repos", {
-      org: installation.account.login,
-      name: repoName,
-      private: true,
-      auto_init: true,
-      description: `uSpark sync repository for project ${projectId}`,
+
+  try {
+    if (installation.account?.type === "Organization") {
+      // Create repository in organization
+      console.log("Creating org repository:", {
+        endpoint: "POST /orgs/{org}/repos",
+        org: installation.account.login,
+        name: repoName,
+      });
+
+      const { data } = await octokit.request("POST /orgs/{org}/repos", {
+        org: installation.account.login,
+        name: repoName,
+        private: true,
+        auto_init: true,
+        description: `uSpark sync repository for project ${projectId}`,
+      });
+      repo = data;
+    } else {
+      // For user accounts, use the user endpoint
+      console.log("Creating user repository:", {
+        endpoint: "POST /user/repos",
+        name: repoName,
+        accountType: installation.account?.type,
+        accountLogin: installation.account?.login,
+      });
+
+      const { data } = await octokit.request("POST /user/repos", {
+        name: repoName,
+        private: true,
+        auto_init: true,
+        description: `uSpark sync repository for project ${projectId}`,
+      });
+      repo = data;
+    }
+  } catch (error: unknown) {
+    console.error("GitHub API Error Details:", {
+      installationId,
+      accountType: installation.account?.type,
+      accountLogin: installation.account?.login,
+      repoName,
+      error
     });
-    repo = data;
-  } else {
-    // Create repository for user account
-    const { data } = await octokit.request("POST /user/repos", {
-      name: repoName,
-      private: true,
-      auto_init: true,
-      description: `uSpark sync repository for project ${projectId}`,
-    });
-    repo = data;
+
+    if (error instanceof Error && "status" in error) {
+      const githubError = error as { status: number; message: string; response?: { data?: unknown } };
+
+      // 404 can mean either wrong endpoint or missing permissions
+      if (githubError.status === 404) {
+        if (installation.account?.type !== "Organization") {
+          // For user accounts, this might be a GitHub App limitation
+          throw new Error(
+            `Cannot create repository for user account. GitHub Apps may have limited permissions for personal accounts. ` +
+            `Please ensure: 1) The GitHub App is installed on your personal account, 2) The App has 'Administration: write' and 'Contents: write' permissions for repositories.`
+          );
+        } else {
+          throw new Error(`GitHub API endpoint not found for organization ${installation.account.login}. Please check the GitHub App installation.`);
+        }
+      }
+
+      // 403 means permission denied
+      if (githubError.status === 403) {
+        throw new Error(
+          `Permission denied. Please ensure the GitHub App has 'Administration: write' and 'Contents: write' permissions. ` +
+          `Error: ${githubError.message}`
+        );
+      }
+
+      // 422 means validation error (e.g., repo already exists on GitHub)
+      if (githubError.status === 422) {
+        throw new Error(`Repository creation failed. The repository name '${repoName}' may already exist on GitHub.`);
+      }
+    }
+
+    throw error;
   }
 
   // Store repository information in database


### PR DESCRIPTION
## Problem
Users were encountering a 404 error when trying to create GitHub repositories through the sync feature.

## Solution
Added comprehensive error logging and improved error messages to help diagnose the issue:

- Added installation token logging to verify authentication is working
- Added detailed logging for repository creation API calls
- Improved error messages to distinguish between different failure scenarios
- Added specific handling for 403 (permission denied) and 422 (validation error) status codes

## Changes
- Enhanced `getInstallationToken()` with try/catch and logging
- Added console logs for installation details and API endpoints being called
- Improved error messages to provide clearer guidance on permissions

## Testing
These changes add logging to help identify the root cause. Once the issue is identified through the logs, we can implement the actual fix.

## Notes
Based on GitHub documentation:
- Installation tokens can be used for both `POST /orgs/{org}/repos` and `POST /user/repos`
- Required permissions: Administration (write), Contents (write), Metadata (read)