### PR TITLE
fix: use correct GitHub API endpoint for installation details

### DIFF
--- a/turbo/apps/web/app/api/github/setup/route.ts
+++ b/turbo/apps/web/app/api/github/setup/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
       try {
         const installationDetails =
           await getInstallationDetails(installationId);
-        accountName = installationDetails.account.login;
+        accountName = installationDetails.account?.login || 'unknown';
       } catch (error) {
         console.error("Failed to fetch installation details:", error);
         // Fallback to placeholder if API call fails

--- a/turbo/apps/web/app/api/github/setup/route.ts
+++ b/turbo/apps/web/app/api/github/setup/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
       try {
         const installationDetails =
           await getInstallationDetails(installationId);
-        accountName = installationDetails.account?.login || 'unknown';
+        accountName = installationDetails.account?.login || "unknown";
       } catch (error) {
         console.error("Failed to fetch installation details:", error);
         // Fallback to placeholder if API call fails

--- a/turbo/apps/web/src/lib/github/client.test.ts
+++ b/turbo/apps/web/src/lib/github/client.test.ts
@@ -25,10 +25,28 @@ vi.mock("@octokit/app", () => {
     }),
   };
 
+  const mockApp = {
+    getInstallationOctokit: vi.fn().mockResolvedValue(mockOctokit),
+    octokit: {
+      request: vi.fn().mockResolvedValue({
+        data: {
+          id: 12345,
+          account: {
+            login: "test-org",
+            type: "Organization",
+          },
+          repository_selection: "all",
+          permissions: {
+            contents: "write",
+            metadata: "read",
+          },
+        },
+      }),
+    },
+  };
+
   return {
-    App: vi.fn().mockImplementation(() => ({
-      getInstallationOctokit: vi.fn().mockResolvedValue(mockOctokit),
-    })),
+    App: vi.fn().mockImplementation(() => mockApp),
   };
 });
 

--- a/turbo/apps/web/src/lib/github/client.ts
+++ b/turbo/apps/web/src/lib/github/client.ts
@@ -41,9 +41,22 @@ export async function createInstallationOctokit(
  * Simple implementation for MVP
  */
 export async function getInstallationDetails(installationId: number) {
-  const app = createAppOctokit();
-  const octokit = await app.getInstallationOctokit(installationId);
+  console.log("getInstallationDetails: starting for installationId:", installationId);
 
-  const { data } = await octokit.request("GET /installation");
-  return data;
+  try {
+    // Use App-level client with JWT token to get installation details
+    const app = createAppOctokit();
+    console.log("getInstallationDetails: app created");
+
+    console.log("getInstallationDetails: calling GET /app/installations/{installation_id}");
+    const { data } = await app.octokit.request("GET /app/installations/{installation_id}", {
+      installation_id: installationId,
+    });
+    console.log("getInstallationDetails: success, account:", data.account?.login, "type:", data.account?.type);
+
+    return data;
+  } catch (error) {
+    console.error("getInstallationDetails: failed", error);
+    throw error;
+  }
 }

--- a/turbo/apps/web/src/lib/github/client.ts
+++ b/turbo/apps/web/src/lib/github/client.ts
@@ -41,18 +41,31 @@ export async function createInstallationOctokit(
  * Simple implementation for MVP
  */
 export async function getInstallationDetails(installationId: number) {
-  console.log("getInstallationDetails: starting for installationId:", installationId);
+  console.log(
+    "getInstallationDetails: starting for installationId:",
+    installationId,
+  );
 
   try {
     // Use App-level client with JWT token to get installation details
     const app = createAppOctokit();
     console.log("getInstallationDetails: app created");
 
-    console.log("getInstallationDetails: calling GET /app/installations/{installation_id}");
-    const { data } = await app.octokit.request("GET /app/installations/{installation_id}", {
-      installation_id: installationId,
-    });
-    console.log("getInstallationDetails: success, account:", data.account?.login, "type:", data.account?.type);
+    console.log(
+      "getInstallationDetails: calling GET /app/installations/{installation_id}",
+    );
+    const { data } = await app.octokit.request(
+      "GET /app/installations/{installation_id}",
+      {
+        installation_id: installationId,
+      },
+    );
+    console.log(
+      "getInstallationDetails: success, account:",
+      data.account?.login,
+      "type:",
+      data.account?.type,
+    );
 
     return data;
   } catch (error) {


### PR DESCRIPTION
## Problem
The getInstallationDetails function was using GET /installation endpoint which does not exist in GitHub REST API, causing 404 errors when creating repositories.

## Root Cause
- GET /installation is not a valid GitHub REST API endpoint
- The function was using an installation token but trying to call a non-existent endpoint

## Solution
- Changed to use GET /app/installations/{installation_id} which is the correct endpoint
- Use JWT token via app.octokit instead of installation token (as required by this endpoint)
- Added detailed logging for better debugging
- This matches the pattern already used in sync.ts

## Testing
The fix should resolve the 404 error and allow repository creation to proceed. Debug logs will show:
- getInstallationDetails: calling GET /app/installations/{installation_id}
- getInstallationDetails: success, account: username, type: User/Organization

## References
- GitHub REST API docs: Get an installation endpoint
- Similar usage in sync.ts:258-269