### PR TITLE
fix: add cli token authentication support to blob-token and project apis

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.test.ts
@@ -13,6 +13,15 @@ vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(() => Promise.resolve({ userId: mockUserId })),
 }));
 
+// Mock next/headers
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => new Headers()),
+  cookies: vi.fn(() => ({
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  })),
+}));
+
 // Mock @vercel/blob client token generation
 vi.mock("@vercel/blob/client", () => ({
   generateClientTokenFromReadWriteToken: vi.fn(async (options) => {

--- a/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/blob-token/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
 import { generateClientTokenFromReadWriteToken } from "@vercel/blob/client";
 import { initServices } from "../../../../../src/lib/init-services";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
@@ -10,12 +10,13 @@ import { type BlobTokenResponse, type BlobTokenError } from "@uspark/core";
 /**
  * GET /api/projects/:projectId/blob-token
  * Returns temporary client token for direct Vercel Blob Storage access
+ * Supports both Clerk session auth and CLI token auth
  */
 export async function GET(
   _request: NextRequest,
   context: { params: Promise<{ projectId: string }> },
 ) {
-  const { userId } = await auth();
+  const userId = await getUserId();
 
   if (!userId) {
     const error: BlobTokenError = {

--- a/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
@@ -13,6 +13,15 @@ vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(),
 }));
 
+// Mock next/headers - needs to be hoisted before imports
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => new Headers()),
+  cookies: vi.fn(() => ({
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  })),
+}));
+
 import { auth } from "@clerk/nextjs/server";
 const mockAuth = vi.mocked(auth);
 

--- a/turbo/apps/web/app/api/projects/[projectId]/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ projectId: string }> },
 ) {
-  const userId = await getUserId(request);
+  const userId = await getUserId();
 
   if (!userId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
@@ -71,7 +71,7 @@ export async function PATCH(
   request: NextRequest,
   context: { params: Promise<{ projectId: string }> },
 ) {
-  const userId = await getUserId(request);
+  const userId = await getUserId();
 
   if (!userId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });

--- a/turbo/apps/web/src/lib/auth/get-user-id.ts
+++ b/turbo/apps/web/src/lib/auth/get-user-id.ts
@@ -1,17 +1,18 @@
 import { auth } from "@clerk/nextjs/server";
-import { NextRequest } from "next/server";
+import { headers } from "next/headers";
 import { initServices } from "../init-services";
 import { CLI_TOKENS_TBL } from "../../db/schema/cli-tokens";
 import { eq, and, gt } from "drizzle-orm";
 
 /**
- * Get the authenticated user ID from either Clerk session or CLI token
- * @param request - The Next.js request object
+ * Get the authenticated user ID from either Clerk session or CLI token.
+ * Uses AsyncLocalStorage via Next.js headers() to avoid requiring a request parameter.
  * @returns The user ID if authenticated, null otherwise
  */
-export async function getUserId(request: NextRequest): Promise<string | null> {
-  // Check for CLI token in Authorization header
-  const authHeader = request.headers.get("Authorization");
+export async function getUserId(): Promise<string | null> {
+  // Get headers from AsyncLocalStorage
+  const headersList = await headers();
+  const authHeader = headersList.get("Authorization");
 
   if (authHeader && authHeader.startsWith("Bearer usp_live_")) {
     const token = authHeader.substring(7); // Remove "Bearer " prefix

--- a/turbo/apps/web/src/test/setup.ts
+++ b/turbo/apps/web/src/test/setup.ts
@@ -1,4 +1,4 @@
-import { expect, afterEach } from "vitest";
+import { expect, afterEach, vi } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
 import "./msw-setup"; // Setup MSW for HTTP request mocking
@@ -35,3 +35,16 @@ process.env.GH_WEBHOOK_SECRET = "test_github_webhook_secret";
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is required for tests");
 }
+
+// Mock next/headers for testing
+vi.mock("next/headers", () => ({
+  headers: vi.fn(() => {
+    const h = new Headers();
+    // Return empty headers by default, tests can override if needed
+    return h;
+  }),
+  cookies: vi.fn(() => ({
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  })),
+}));


### PR DESCRIPTION
## Summary
- Refactored getUserId to use AsyncLocalStorage via Next.js headers() 
- Updated blob-token route to support CLI token authentication
- Fixed project API routes to use new getUserId without parameters

## Problem
The CLI push command was reporting success even when blob uploads were failing with 401 errors. This was because:
1. The blob-token API only supported Clerk session authentication, not CLI tokens
2. Blob upload failures were only logged as warnings, not treated as errors

## Solution
- Modified getUserId() to use Next.js headers() function with AsyncLocalStorage
- Removed the need to pass request parameter explicitly
- Updated blob-token and project routes to use the new authentication method
- Now both web users (via Clerk) and CLI users (via CLI tokens) can access these APIs

## Test Plan
- [ ] Test CLI push command works with CLI token authentication
- [ ] Verify web interface still works with Clerk authentication
- [ ] Confirm blob uploads succeed without 401 errors

🤖 Generated with [Claude Code](https://claude.ai/code)