### PR TITLE
fix: make blob upload failures fail fast in cli push command

### DIFF
--- a/turbo/apps/cli/src/project-sync.ts
+++ b/turbo/apps/cli/src/project-sync.ts
@@ -204,7 +204,10 @@ export class ProjectSync {
       );
 
       if (!uploadResponse.ok) {
-        console.warn(`Failed to upload blob ${localHash}, continuing anyway`);
+        const errorText = await uploadResponse.text();
+        throw new Error(
+          `Failed to upload blob: ${uploadResponse.status} ${uploadResponse.statusText}\n${errorText}`,
+        );
       }
 
       // Store locally as well
@@ -322,7 +325,10 @@ export class ProjectSync {
             );
 
             if (!uploadResponse.ok) {
-              console.warn(`Failed to upload blob ${hash}, continuing anyway`);
+              const errorText = await uploadResponse.text();
+              throw new Error(
+                `Failed to upload blob: ${uploadResponse.status} ${uploadResponse.statusText}\n${errorText}`,
+              );
             }
           }
         }


### PR DESCRIPTION
## Problem
The CLI `push` command was reporting success even when blob uploads failed with 401 or other errors. This was misleading users as their files weren't actually uploaded to blob storage.

## Root Cause
Blob upload failures were only logged as warnings (`console.warn`) and the push operation continued, leading to:
- False success messages
- Incomplete file uploads
- Metadata updated without actual file content being stored

## Solution
Changed blob upload error handling to throw exceptions immediately on failure:
- Replace `console.warn` with `throw new Error`
- Include HTTP status code and error details in exception
- Ensure push operation stops immediately on first blob upload failure

## Testing
- Test that push command fails with clear error when blob upload fails
- Verify no partial uploads or false success messages
- Confirm error message includes helpful debugging info (status code, error text)

Fixes the issue discovered in #329 where CLI reported success despite blob upload 401 errors.