### PR TITLE
refactor: extract code review criteria to bad-smell.md

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -41,39 +41,15 @@ The command follows this automated workflow:
 
 ## Review Criteria
 
-Each commit is reviewed against these criteria:
+Each commit is reviewed against the bad code smells defined in [spec/bad-smell.md](../../spec/bad-smell.md).
 
-### 1. Mock Analysis
-- Identify new mock implementations
-- Suggest non-mock alternatives where possible
-- List all new mocks for user review
-
-### 2. Test Coverage
-- Evaluate test quality and completeness
-- Check for missing test scenarios
-- Assess test maintainability
-
-### 3. Error Handling
-- Identify unnecessary try/catch blocks
-- Suggest fail-fast improvements
-- Flag over-engineered error handling
-
-### 4. Interface Changes
-- Document new/modified public interfaces
-- Highlight breaking changes
-- Review API design decisions
-
-### 5. Timer and Delay Analysis
-- Identify artificial delays and timers in production code
-- Check for advancedTimer or fakeTimer usage in tests
-- Flag timeout increases to pass tests
-- Suggest deterministic alternatives to time-based solutions
-
-### 6. Dynamic Import Analysis
-- Identify dynamic `import()` calls that could be static imports
-- Convert runtime dynamic imports to static imports at file top
-- Preserve type-only imports (JSDoc/TypeScript annotations)
-- Flag unnecessary async operations from dynamic imports
+The review process checks for:
+- Mock implementations and alternatives
+- Test coverage and quality
+- Error handling patterns
+- Interface changes and API design
+- Timer and delay usage
+- Dynamic import patterns
 
 ## Output Structure
 

--- a/spec/bad-smell.md
+++ b/spec/bad-smell.md
@@ -1,0 +1,36 @@
+# Bad Code Smells
+
+This document defines code quality issues and anti-patterns to identify during code reviews.
+
+## 1. Mock Analysis
+- Identify new mock implementations
+- Suggest non-mock alternatives where possible
+- List all new mocks for user review
+- Flag fetch API mocking in tests (should use MSW for network mocking instead)
+
+## 2. Test Coverage
+- Evaluate test quality and completeness
+- Check for missing test scenarios
+- Assess test maintainability
+
+## 3. Error Handling
+- Identify unnecessary try/catch blocks
+- Suggest fail-fast improvements
+- Flag over-engineered error handling
+
+## 4. Interface Changes
+- Document new/modified public interfaces
+- Highlight breaking changes
+- Review API design decisions
+
+## 5. Timer and Delay Analysis
+- Identify artificial delays and timers in production code
+- Check for advancedTimer or fakeTimer usage in tests
+- Flag timeout increases to pass tests
+- Suggest deterministic alternatives to time-based solutions
+
+## 6. Dynamic Import Analysis
+- Identify dynamic `import()` calls that could be static imports
+- Convert runtime dynamic imports to static imports at file top
+- Preserve type-only imports (JSDoc/TypeScript annotations)
+- Flag unnecessary async operations from dynamic imports


### PR DESCRIPTION
## Summary
- Extract code review criteria from code-review.md to a centralized spec/bad-smell.md document
- Update code-review command documentation to reference the new location
- Add guideline about fetch API mocking (should use MSW instead)

## Purpose
Centralizes bad code smell definitions in a dedicated specification file for better maintainability and reusability across different tools and documentation.