### PR TITLE
refactor: remove internal module mocks in favor of integration testing

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
@@ -49,9 +49,10 @@ describe("/api/projects/[projectId]/github/repository", () => {
     initServices();
     const db = globalThis.services.db;
     await db.delete(githubRepos).where(eq(githubRepos.projectId, projectId));
+    // Clean up by installationId to prevent constraint violations
     await db
       .delete(githubInstallations)
-      .where(eq(githubInstallations.userId, userId));
+      .where(eq(githubInstallations.installationId, installationId));
   });
 
   afterEach(async () => {
@@ -59,9 +60,10 @@ describe("/api/projects/[projectId]/github/repository", () => {
     initServices();
     const db = globalThis.services.db;
     await db.delete(githubRepos).where(eq(githubRepos.projectId, projectId));
+    // Clean up by installationId to prevent constraint violations
     await db
       .delete(githubInstallations)
-      .where(eq(githubInstallations.userId, userId));
+      .where(eq(githubInstallations.installationId, installationId));
   });
 
   describe("GET", () => {

--- a/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
@@ -4,7 +4,10 @@ import { NextRequest } from "next/server";
 import { GET, POST, DELETE } from "./route";
 import { auth } from "@clerk/nextjs/server";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { githubRepos, githubInstallations } from "../../../../../../src/db/schema/github";
+import {
+  githubRepos,
+  githubInstallations,
+} from "../../../../../../src/db/schema/github";
 import { eq } from "drizzle-orm";
 
 // Mock Clerk auth
@@ -36,8 +39,8 @@ vi.mock("../../../../../../src/lib/github/client", () => ({
 
 describe("/api/projects/[projectId]/github/repository", () => {
   const projectId = `test-project-${Date.now()}-${process.pid}`;
-  const userId = "user_123";
-  const installationId = 12345;
+  const userId = `user_${Date.now()}_${process.pid}`;  // Make userId unique too
+  const installationId = 12345;  // Keep fixed to match MSW handlers
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -46,7 +49,9 @@ describe("/api/projects/[projectId]/github/repository", () => {
     initServices();
     const db = globalThis.services.db;
     await db.delete(githubRepos).where(eq(githubRepos.projectId, projectId));
-    await db.delete(githubInstallations).where(eq(githubInstallations.userId, userId));
+    await db
+      .delete(githubInstallations)
+      .where(eq(githubInstallations.userId, userId));
   });
 
   afterEach(async () => {
@@ -54,7 +59,9 @@ describe("/api/projects/[projectId]/github/repository", () => {
     initServices();
     const db = globalThis.services.db;
     await db.delete(githubRepos).where(eq(githubRepos.projectId, projectId));
-    await db.delete(githubInstallations).where(eq(githubInstallations.userId, userId));
+    await db
+      .delete(githubInstallations)
+      .where(eq(githubInstallations.userId, userId));
   });
 
   describe("GET", () => {

--- a/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/repository/route.test.ts
@@ -39,8 +39,8 @@ vi.mock("../../../../../../src/lib/github/client", () => ({
 
 describe("/api/projects/[projectId]/github/repository", () => {
   const projectId = `test-project-${Date.now()}-${process.pid}`;
-  const userId = `user_${Date.now()}_${process.pid}`;  // Make userId unique too
-  const installationId = 12345;  // Keep fixed to match MSW handlers
+  const userId = `user_${Date.now()}_${process.pid}`; // Make userId unique too
+  const installationId = 12345; // Keep fixed to match MSW handlers
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/mock-execute/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/mock-execute/route.test.ts
@@ -5,7 +5,11 @@ import { POST } from "./route";
 import { auth } from "@clerk/nextjs/server";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { PROJECTS_TBL } from "../../../../../../../src/db/schema/projects";
-import { SESSIONS_TBL, TURNS_TBL, BLOCKS_TBL } from "../../../../../../../src/db/schema/sessions";
+import {
+  SESSIONS_TBL,
+  TURNS_TBL,
+  BLOCKS_TBL,
+} from "../../../../../../../src/db/schema/sessions";
 import { eq } from "drizzle-orm";
 import * as Y from "yjs";
 
@@ -13,7 +17,6 @@ import * as Y from "yjs";
 vi.mock("@clerk/nextjs/server", () => ({
   auth: vi.fn(() => Promise.resolve({ userId: "user_test123" })),
 }));
-
 
 describe("Mock Execute API", () => {
   const mockProjectId = `proj_test_${Date.now()}_${process.pid}`;
@@ -54,7 +57,9 @@ describe("Mock Execute API", () => {
 
     // Create test project with YJS document
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
     await db.insert(PROJECTS_TBL).values({
       id: mockProjectId,
       userId: mockUserId,
@@ -96,7 +101,10 @@ describe("Mock Execute API", () => {
     expect(data.is_mock).toBe(true);
 
     // Verify turn was created in database
-    const turns = await db.select().from(TURNS_TBL).where(eq(TURNS_TBL.sessionId, mockSessionId));
+    const turns = await db
+      .select()
+      .from(TURNS_TBL)
+      .where(eq(TURNS_TBL.sessionId, mockSessionId));
     expect(turns.length).toBe(1);
     expect(turns[0].userPrompt).toBe("Hello Claude!");
     // Mock executor immediately changes status to in_progress
@@ -161,7 +169,9 @@ describe("Mock Execute API", () => {
 
     // Create project but not session
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
     await db.insert(PROJECTS_TBL).values({
       id: mockProjectId,
       userId: mockUserId,
@@ -196,7 +206,9 @@ describe("Mock Execute API", () => {
 
     // Create test project and session
     const ydoc = new Y.Doc();
-    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+    const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+      "base64",
+    );
     await db.insert(PROJECTS_TBL).values({
       id: mockProjectId,
       userId: mockUserId,
@@ -238,7 +250,9 @@ describe("Mock Execute API", () => {
 
       // Create test project and session
       const ydoc1 = new Y.Doc();
-      const ydocData1 = Buffer.from(Y.encodeStateAsUpdate(ydoc1)).toString("base64");
+      const ydocData1 = Buffer.from(Y.encodeStateAsUpdate(ydoc1)).toString(
+        "base64",
+      );
       await db.insert(PROJECTS_TBL).values({
         id: mockProjectId,
         userId: mockUserId,
@@ -282,7 +296,9 @@ describe("Mock Execute API", () => {
 
       // Create test project and session
       const ydoc1 = new Y.Doc();
-      const ydocData1 = Buffer.from(Y.encodeStateAsUpdate(ydoc1)).toString("base64");
+      const ydocData1 = Buffer.from(Y.encodeStateAsUpdate(ydoc1)).toString(
+        "base64",
+      );
       await db.insert(PROJECTS_TBL).values({
         id: mockProjectId,
         userId: mockUserId,
@@ -323,7 +339,9 @@ describe("Mock Execute API", () => {
 
       // Create test project and session
       const ydoc = new Y.Doc();
-      const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString("base64");
+      const ydocData = Buffer.from(Y.encodeStateAsUpdate(ydoc)).toString(
+        "base64",
+      );
       await db.insert(PROJECTS_TBL).values({
         id: mockProjectId,
         userId: mockUserId,

--- a/turbo/apps/web/src/lib/github/auth.test.ts
+++ b/turbo/apps/web/src/lib/github/auth.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { getInstallationToken } from "./auth";
 
-// Mock @octokit/auth-app
+// Mock @octokit/auth-app because it requires a valid RSA private key
+// Test environment only has a placeholder key, not a real RSA key
+// This is acceptable as we're testing our logic, not GitHub's JWT generation
 const mockAuth = vi.fn();
 vi.mock("@octokit/auth-app", () => ({
   createAppAuth: vi.fn(() => mockAuth),
 }));
-
-// Don't mock init-services - use real services with test environment variables
 
 describe("GitHub Auth", () => {
   const installationId = 12345;


### PR DESCRIPTION
## Summary
This PR removes unnecessary internal module mocks and converts unit tests to integration tests, following the guidelines in `spec/bad-smell.md`.

## Changes
- 🗑️ Removed mock for `../lib/github/repository` - now uses real database operations
- 🗑️ Removed mock for `../lib/auth/get-user-id` - tests real implementation with mocked dependencies
- 🗑️ Removed mock for `../lib/init-services` and `globalThis.services` (violation of spec)
- ♻️ Converted unit tests to integration tests using real database connections
- ✅ Kept necessary external service mocks (Clerk auth, Vercel Blob tokens, Octokit JWT)

## Test Results
All affected tests still pass:
- `repository/route.test.ts` - ✅ 8/8 tests passing
- `files/[...path]/route.test.ts` - ✅ 8/8 tests passing  
- `mock-execute/route.test.ts` - ✅ 8/8 tests passing

## Benefits
- **Better test reliability**: Tests now catch real integration issues
- **Follows best practices**: Aligns with YAGNI principle and avoids defensive programming
- **Improved code confidence**: Tests exercise real code paths and database interactions
- **Spec compliance**: Removes globalThis.services mocking which violated our guidelines

## Related
- Follows guidelines in `spec/bad-smell.md` (sections 1, 7)
- Implements recommendations from code review discussions