### PR TITLE
fix: require CLAUDE_TOKEN_ENCRYPTION_KEY env var and update workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,6 +99,7 @@ jobs:
             GH_APP_ID=${{ vars.GH_APP_ID }}
             GH_APP_PRIVATE_KEY=${{ secrets.GH_APP_PRIVATE_KEY }}
             GH_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
+            CLAUDE_TOKEN_ENCRYPTION_KEY=${{ secrets.CLAUDE_TOKEN_ENCRYPTION_KEY }}
 
   # Deploy workspace app to production
   deploy-workspace-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -124,6 +124,7 @@ jobs:
           CLERK_SECRET_KEY: "test_clerk_secret_key"
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "test_clerk_publishable_key"
           VITE_CLERK_PUBLISHABLE_KEY: "test_clerk_publishable_key"
+          CLAUDE_TOKEN_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
   # Deploy web application with database
   deploy-web:
@@ -171,6 +172,7 @@ jobs:
             GH_APP_ID=${{ vars.GH_APP_ID }}
             GH_APP_PRIVATE_KEY=${{ secrets.GH_APP_PRIVATE_KEY }}
             GH_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
+            CLAUDE_TOKEN_ENCRYPTION_KEY=${{ secrets.CLAUDE_TOKEN_ENCRYPTION_KEY }}
           meta-branch: ${{ github.head_ref }}
           meta-pr: ${{ github.event.pull_request.number }}
 

--- a/turbo/apps/web/app/settings/claude-token/page.tsx
+++ b/turbo/apps/web/app/settings/claude-token/page.tsx
@@ -293,7 +293,7 @@ export default function ClaudeTokenPage() {
             </label>
             <input
               id="token"
-              type="password"
+              type="text"
               value={newToken}
               onChange={(e) => setNewToken(e.target.value)}
               placeholder="Enter your Claude OAuth token"
@@ -307,6 +307,8 @@ export default function ClaudeTokenPage() {
               }}
               required
               minLength={30}
+              autoComplete="off"
+              spellCheck={false}
             />
             <small
               style={{ color: "#666", marginTop: "4px", display: "block" }}

--- a/turbo/apps/web/src/lib/claude-token-crypto.ts
+++ b/turbo/apps/web/src/lib/claude-token-crypto.ts
@@ -5,22 +5,13 @@ import crypto from "crypto";
  * Uses AES-256-GCM encryption for security
  */
 
-// Get encryption key from environment or generate a stable one for development
+// Get encryption key from environment (required)
 export const getEncryptionKey = (): Buffer => {
   const key = process.env.CLAUDE_TOKEN_ENCRYPTION_KEY;
 
   if (!key) {
-    // In development, use a deterministic key based on the environment
-    // In production, this MUST be set as an environment variable
-    if (
-      process.env.NODE_ENV === "development" ||
-      process.env.NODE_ENV === "test"
-    ) {
-      // Use a stable development key (DO NOT use in production!)
-      return crypto.scryptSync("development-key", "stable-salt", 32);
-    }
     throw new Error(
-      "CLAUDE_TOKEN_ENCRYPTION_KEY environment variable is required in production",
+      "CLAUDE_TOKEN_ENCRYPTION_KEY environment variable is required",
     );
   }
 


### PR DESCRIPTION
## Summary
- Remove fallback encryption key generation for better security
- Add CLAUDE_TOKEN_ENCRYPTION_KEY to CI/CD workflows  
- Fix token input validation issues

## Changes
1. **Security Enhancement**: Removed the automatic fallback generation of encryption keys in development/test environments. Now the CLAUDE_TOKEN_ENCRYPTION_KEY environment variable is always required.

2. **CI/CD Updates**: Added CLAUDE_TOKEN_ENCRYPTION_KEY to both workflow files:
   - `turbo.yml`: Added test key for test job and GitHub secret for deploy-web job
   - `release-please.yml`: Added GitHub secret for production deployment

3. **UI Fix**: Changed the token input field from `type="password"` to `type="text"` to avoid browser-specific password validation that was incorrectly rejecting valid Claude tokens.

## Notes
- You'll need to add `CLAUDE_TOKEN_ENCRYPTION_KEY` as a GitHub repository secret with a 64-character hex string value
- The .env.local file has been updated with a generated encryption key for local development

🤖 Generated with Claude Code