### PR TITLE
fix: resolve cli push bug that only uploaded one blob for multiple files

### DIFF
--- a/test-push-bug.sh
+++ b/test-push-bug.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Test script to reproduce the push bug
+
+set -e
+
+echo "=== Setting up test environment ==="
+
+# Create temp directory
+TEST_DIR=$(mktemp -d)
+cd "$TEST_DIR"
+echo "Working in: $TEST_DIR"
+
+# Create test files
+echo "foo" > foo.md
+echo "bar" > bar.md
+echo "hello" > hello.md
+
+echo ""
+echo "=== Files created ==="
+ls -la *.md
+echo ""
+echo "=== File contents ==="
+for f in *.md; do
+  echo "$f: $(cat $f)"
+done
+
+# Build CLI
+echo ""
+echo "=== Building CLI ==="
+cd /workspaces/uspark/turbo
+pnpm --filter @uspark/cli build
+
+# Push files
+echo ""
+echo "=== Pushing files ==="
+cd "$TEST_DIR"
+PROJECT_ID="test-$(date +%s)"
+echo "Using project ID: $PROJECT_ID"
+
+# Run push with debug output
+NODE_ENV=development /workspaces/uspark/turbo/apps/cli/dist/index.js push --all --project-id "$PROJECT_ID" 2>&1 | tee push-output.log
+
+echo ""
+echo "=== Deleting local files ==="
+rm -f *.md
+ls -la *.md 2>/dev/null || echo "All .md files deleted"
+
+echo ""
+echo "=== Pulling files back ==="
+/workspaces/uspark/turbo/apps/cli/dist/index.js pull --all --project-id "$PROJECT_ID"
+
+echo ""
+echo "=== Verifying pulled files ==="
+for f in foo.md bar.md hello.md; do
+  if [ -f "$f" ]; then
+    content=$(cat "$f")
+    echo "$f: '$content'"
+    case "$f" in
+      foo.md) [ "$content" = "foo" ] && echo "  ✓ Content matches" || echo "  ✗ Expected 'foo', got '$content'" ;;
+      bar.md) [ "$content" = "bar" ] && echo "  ✓ Content matches" || echo "  ✗ Expected 'bar', got '$content'" ;;
+      hello.md) [ "$content" = "hello" ] && echo "  ✓ Content matches" || echo "  ✗ Expected 'hello', got '$content'" ;;
+    esac
+  else
+    echo "$f: NOT FOUND - ✗"
+  fi
+done
+
+# Cleanup
+echo ""
+echo "=== Cleaning up ==="
+cd /
+rm -rf "$TEST_DIR"
+
+echo "Test complete!"

--- a/turbo/apps/cli/src/__tests__/push-multiple-blobs.test.ts
+++ b/turbo/apps/cli/src/__tests__/push-multiple-blobs.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { pushCommand } from "../commands/sync";
+import { tmpdir } from "os";
+import { join } from "path";
+import { mkdtemp, writeFile, rm } from "fs/promises";
+import { setOverrideConfig } from "../config";
+import { put } from "@vercel/blob";
+
+// Mock @vercel/blob
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
+}));
+
+describe("Push Multiple Different Blobs", () => {
+  let tempDir: string;
+  const testProjectId = "test-multi-blob";
+
+  beforeEach(async () => {
+    // Create temp directory
+    tempDir = await mkdtemp(join(tmpdir(), "uspark-blob-test-"));
+    process.chdir(tempDir);
+
+    // Setup config
+    setOverrideConfig({
+      token: "test-token",
+      apiUrl: "http://localhost:3000",
+    });
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock put to track calls
+    vi.mocked(put).mockImplementation(async (pathname, content) => {
+      console.log(
+        `[TEST] put called with pathname: ${pathname}, content length: ${content.toString().length}`,
+      );
+      return {
+        url: `https://test.blob.storage/${pathname}`,
+        pathname,
+        contentType: "text/plain",
+        downloadUrl: `https://test.blob.storage/${pathname}`,
+      };
+    });
+
+    // Mock console
+    console.log = vi.fn();
+    console.error = vi.fn();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    setOverrideConfig(null);
+    vi.restoreAllMocks();
+  });
+
+  it("should upload ALL unique blobs when pushing multiple files", async () => {
+    // Create 3 files with 3 DIFFERENT contents
+    await writeFile("file1.md", "content-one");
+    await writeFile("file2.md", "content-two");
+    await writeFile("file3.md", "content-three");
+
+    // Push all files
+    await pushCommand(undefined, {
+      projectId: testProjectId,
+      all: true,
+    });
+
+    // CRITICAL: Verify put was called 3 times (one for each unique content)
+    expect(put).toHaveBeenCalledTimes(3);
+
+    // Verify each unique blob was uploaded
+    const calls = vi.mocked(put).mock.calls;
+    const uploadedPaths = calls.map((call) => call[0]);
+    const uploadedContents = calls.map((call) => call[1]);
+
+    // Should have 3 different blob uploads
+    expect(uploadedContents).toContain("content-one");
+    expect(uploadedContents).toContain("content-two");
+    expect(uploadedContents).toContain("content-three");
+
+    // Each should have project ID in path
+    uploadedPaths.forEach((path) => {
+      expect(path).toContain(testProjectId);
+    });
+  });
+
+  it("should upload only unique blobs when files have duplicate content", async () => {
+    // Create 4 files with only 2 unique contents
+    await writeFile("file1.md", "duplicate-content");
+    await writeFile("file2.md", "duplicate-content"); // Same as file1
+    await writeFile("file3.md", "unique-content");
+    await writeFile("file4.md", "duplicate-content"); // Same as file1 & file2
+
+    // Push all files
+    await pushCommand(undefined, {
+      projectId: testProjectId,
+      all: true,
+    });
+
+    // Should upload only 2 blobs (unique contents only)
+    expect(put).toHaveBeenCalledTimes(2);
+
+    const calls = vi.mocked(put).mock.calls;
+    const uploadedContents = calls.map((call) => call[1]);
+
+    // Should have both unique contents
+    expect(uploadedContents).toContain("duplicate-content");
+    expect(uploadedContents).toContain("unique-content");
+  });
+
+  it("should handle the hello/foo/bar scenario correctly", async () => {
+    // Reproduce the exact bug scenario
+    await writeFile("foo.md", "foo");
+    await writeFile("bar.md", "bar");
+    await writeFile("hello.md", "hello");
+
+    // Push all files
+    await pushCommand(undefined, {
+      projectId: testProjectId,
+      all: true,
+    });
+
+    // MUST upload 3 blobs for 3 different contents
+    expect(put).toHaveBeenCalledTimes(3);
+
+    const calls = vi.mocked(put).mock.calls;
+    const uploadedContents = new Set(calls.map((call) => call[1]));
+
+    // All three unique contents must be uploaded
+    expect(uploadedContents.has("foo")).toBe(true);
+    expect(uploadedContents.has("bar")).toBe(true);
+    expect(uploadedContents.has("hello")).toBe(true);
+  });
+
+  it("should not re-upload blobs on second push of same content", async () => {
+    // First push
+    await writeFile("test.md", "test-content");
+    await pushCommand("test.md", { projectId: testProjectId });
+
+    expect(put).toHaveBeenCalledTimes(1);
+    vi.clearAllMocks();
+
+    // Second push of same file (no changes)
+    await pushCommand("test.md", { projectId: testProjectId });
+
+    // Should NOT upload blob again
+    expect(put).toHaveBeenCalledTimes(0);
+  });
+
+  it("should track blob uploads in console output", async () => {
+    // Create multiple files
+    await writeFile("a.txt", "alpha");
+    await writeFile("b.txt", "beta");
+    await writeFile("c.txt", "gamma");
+
+    // Mock console.log to capture output
+    const logSpy = vi.fn();
+    console.log = logSpy;
+
+    await pushCommand(undefined, {
+      projectId: testProjectId,
+      all: true,
+    });
+
+    // Should log blob upload for each unique content
+    const blobUploadLogs = logSpy.mock.calls.filter((call) =>
+      call[0]?.includes("Blob uploaded successfully"),
+    );
+
+    // Should have 3 blob upload logs
+    expect(blobUploadLogs).toHaveLength(3);
+  });
+});

--- a/turbo/apps/cli/src/__tests__/push-multiple-blobs.test.ts
+++ b/turbo/apps/cli/src/__tests__/push-multiple-blobs.test.ts
@@ -147,27 +147,26 @@ describe("Push Multiple Different Blobs", () => {
     expect(put).toHaveBeenCalledTimes(0);
   });
 
-  it("should track blob uploads in console output", async () => {
+  it("should upload the correct number of blobs without duplicate uploads", async () => {
     // Create multiple files
     await writeFile("a.txt", "alpha");
     await writeFile("b.txt", "beta");
     await writeFile("c.txt", "gamma");
-
-    // Mock console.log to capture output
-    const logSpy = vi.fn();
-    console.log = logSpy;
 
     await pushCommand(undefined, {
       projectId: testProjectId,
       all: true,
     });
 
-    // Should log blob upload for each unique content
-    const blobUploadLogs = logSpy.mock.calls.filter((call) =>
-      call[0]?.includes("Blob uploaded successfully"),
-    );
+    // Should upload 3 blobs for 3 unique contents
+    expect(put).toHaveBeenCalledTimes(3);
 
-    // Should have 3 blob upload logs
-    expect(blobUploadLogs).toHaveLength(3);
+    const calls = vi.mocked(put).mock.calls;
+    const uploadedContents = new Set(calls.map((call) => call[1]));
+
+    // Should have all three unique contents
+    expect(uploadedContents.has("alpha")).toBe(true);
+    expect(uploadedContents.has("beta")).toBe(true);
+    expect(uploadedContents.has("gamma")).toBe(true);
   });
 });


### PR DESCRIPTION
## 问题描述

发现了一个严重的 bug：当使用 `uspark push --all` 推送多个文件时，即使文件内容不同，也只会上传一个 blob，导致其他文件在 pull 时内容为空。

## 根本原因

在 `project-sync.ts` 的 `pushFiles` 方法中存在逻辑错误：

1. 第 266-268 行：将文件内容存储到本地 FileSystem 缓存
2. 第 305-307 行：检查 blob 是否需要上传，但错误地检查了本地缓存而不是远程存储

由于第 266 行已经把所有 blob 存到本地了，所以第 305 行的检查永远返回 true，导致没有任何 blob 被加入上传队列。

## 修复内容

- ✅ 修正了 blob 上传逻辑，改为检查远程是否已存在 blob
- ✅ 移除了过多的调试日志输出
- ✅ 修正了代码缩进问题
- ✅ 添加了全面的测试用例，覆盖多文件上传场景

## 测试验证

添加了专门的测试文件 `push-multiple-blobs.test.ts`，测试场景包括：
- 3个不同文件上传3个不同blob
- 多个文件共享相同内容时只上传唯一blob
- 重现并修复 foo/bar/hello 场景
- 验证重复推送不会重复上传

修复后的测试结果显示所有文件都能正确上传和拉取：
- foo.md: 'foo' ✓
- bar.md: 'bar' ✓  
- hello.md: 'hello' ✓

🤖 Generated with [Claude Code](https://claude.ai/code)