### PR TITLE
fix: correct test environment variable priority in web app

### DIFF
--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -29,30 +29,27 @@ function initEnv() {
     },
     runtimeEnv: {
       DATABASE_URL: process.env.DATABASE_URL,
-      CLERK_SECRET_KEY:
-        process.env.CLERK_SECRET_KEY ||
-        (isTest ? "sk_test_mock_secret_key_for_testing" : undefined),
-      BLOB_READ_WRITE_TOKEN:
-        process.env.BLOB_READ_WRITE_TOKEN ||
-        (isTest ? "vercel_blob_rw_test-store_secret-key" : undefined),
+      CLERK_SECRET_KEY: isTest
+        ? "sk_test_mock_secret_key_for_testing"
+        : process.env.CLERK_SECRET_KEY,
+      BLOB_READ_WRITE_TOKEN: isTest
+        ? "vercel_blob_rw_test-store_secret-key"
+        : process.env.BLOB_READ_WRITE_TOKEN,
       E2B_API_KEY: process.env.E2B_API_KEY,
       APP_URL: process.env.APP_URL,
-      GH_APP_ID:
-        process.env.GH_APP_ID || (isTest ? "test_github_app_id" : undefined),
-      GH_APP_PRIVATE_KEY:
-        process.env.GH_APP_PRIVATE_KEY ||
-        (isTest ? "test_private_key_placeholder" : undefined),
-      GH_WEBHOOK_SECRET:
-        process.env.GH_WEBHOOK_SECRET ||
-        (isTest ? "test_github_webhook_secret" : undefined),
-      CLAUDE_TOKEN_ENCRYPTION_KEY:
-        process.env.CLAUDE_TOKEN_ENCRYPTION_KEY ||
-        (isTest
-          ? "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-          : undefined),
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
-        process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ||
-        (isTest ? "pk_test_mock_instance.clerk.accounts.dev$" : undefined),
+      GH_APP_ID: isTest ? "test_github_app_id" : process.env.GH_APP_ID,
+      GH_APP_PRIVATE_KEY: isTest
+        ? "test_private_key_placeholder"
+        : process.env.GH_APP_PRIVATE_KEY,
+      GH_WEBHOOK_SECRET: isTest
+        ? "test_github_webhook_secret"
+        : process.env.GH_WEBHOOK_SECRET,
+      CLAUDE_TOKEN_ENCRYPTION_KEY: isTest
+        ? "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        : process.env.CLAUDE_TOKEN_ENCRYPTION_KEY,
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: isTest
+        ? "pk_test_mock_instance.clerk.accounts.dev$"
+        : process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
     },
     emptyStringAsUndefined: true,
   });


### PR DESCRIPTION
Previously, test environment variables were checked as fallbacks after process.env values, which meant tests could accidentally use real environment variables instead of test values. This defeats the purpose of test isolation.

**Changed pattern from:**
```typescript
process.env.VAR || (isTest ? 'testValue' : undefined)
```

**To correct pattern:**
```typescript
isTest ? 'testValue' : process.env.VAR
```

**This ensures:**
- Tests always use test values for proper isolation
- Production uses real environment variables  
- No accidental cross-environment contamination

**Affected environment variables:**
- CLERK_SECRET_KEY
- BLOB_READ_WRITE_TOKEN
- GH_APP_ID
- GH_APP_PRIVATE_KEY
- GH_WEBHOOK_SECRET
- CLAUDE_TOKEN_ENCRYPTION_KEY
- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

This fix improves test reliability and security by ensuring tests never accidentally connect to real services.