### PR TITLE
refactor: simplify e2b sandbox initialization and add --all flag

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -105,16 +105,9 @@ export class E2BExecutor {
   ): Promise<void> {
     console.log(`Initializing sandbox for project ${projectId}`);
 
-    // Check if this is a test project
-    if (projectId.startsWith("proj_test_")) {
-      console.log("Test environment detected, skipping project pull");
-      await sandbox.commands.run("mkdir -p /workspace");
-      return;
-    }
-
-    // Pull project files using uspark CLI
+    // Pull all project files using uspark CLI
     const result = await sandbox.commands.run(
-      `uspark pull --project-id ${projectId}`,
+      `uspark pull --all --project-id ${projectId}`,
     );
 
     if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary
- Remove redundant test project check since e2b execution is mocked in tests
- Add --all flag to uspark pull command to ensure complete project sync  
- Simplify initializeSandbox method by removing unnecessary branching logic

## Test plan
- [x] Verify e2b tests still pass with mocked execution
- [x] Confirm lint and pre-commit hooks pass
- [ ] Test actual e2b sandbox initialization in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)