### PR TITLE
test: fix blob url mocks to include project path prefix

### DIFF
--- a/turbo/apps/web/app/projects/[id]/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/[id]/__tests__/page.test.tsx
@@ -124,11 +124,11 @@ describe("Project Detail Page", () => {
         hash4: `# README.md\n\nThis is a markdown file.\n\n## Features\n\n- Feature 1\n- Feature 2\n- Feature 3`,
       };
 
-      // Mock direct blob storage URLs
+      // Mock direct blob storage URLs with correct project path (wildcard for any project ID)
       Object.entries(contentMap).forEach(([hash, content]) => {
         server.use(
           http.get(
-            `https://test-store.public.blob.vercel-storage.com/${hash}`,
+            `https://test-store.public.blob.vercel-storage.com/projects/:projectId/${hash}`,
             () => {
               return new HttpResponse(content, {
                 headers: {


### PR DESCRIPTION
## Summary
This PR fixes test failures caused by incorrect blob URL mocking in the project detail page tests after the blob URL format was corrected in PR #363.

## Root Cause
PR #363 fixed the web interface to use the correct blob URL format:
```
https://{storeId}.public.blob.vercel-storage.com/projects/{projectId}/{hash}
```

However, the test mocks were still using the old format:
```
https://test-store.public.blob.vercel-storage.com/{hash}
```

This mismatch caused 4 test failures where tests could not find expected file content.

## Changes Made
- **Updated test mocks** to use correct blob URL format with `projects/:projectId/` prefix
- **Used wildcard pattern** `:projectId` to handle different project IDs in tests
- **Maintained all existing test functionality** while fixing URL format

## Impact
- Resolves test failures in GitHub Actions CI
- Ensures test mocks align with production blob URL format
- No functional changes to test coverage or behavior

## Related
- Fixes test failures introduced by PR #363
- Complements the blob URL format fix in the main application

🤖 Generated with [Claude Code](https://claude.ai/code)