### PR TITLE
fix: use standard CLI tokens for E2B sandbox authentication

### DIFF
--- a/spec/bad-smell.md
+++ b/spec/bad-smell.md
@@ -88,3 +88,31 @@ This document defines code quality issues and anti-patterns to identify during c
   await POST("/api/projects", { json: { name } });
   ```
 
+## 13. Avoid Fallback Patterns - Fail Fast
+- **No fallback/recovery logic** - errors should fail immediately and visibly
+- Fallback patterns increase complexity and hide configuration problems
+- When critical dependencies are missing, throw errors instead of falling back
+- Examples of bad fallback patterns:
+  ```typescript
+  // ❌ Bad: Fallback to another secret
+  const jwtSecret = process.env.JWT_SECRET ||
+                    process.env.SOME_OTHER_SECRET ||
+                    "default-secret";
+
+  // ❌ Bad: Silent fallback behavior
+  if (!config) {
+    config = getDefaultConfig(); // Hides misconfiguration
+  }
+
+  // ✅ Good: Fail fast with clear error
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    throw new Error("JWT_SECRET not configured");
+  }
+  ```
+- Rationale:
+  - Fallbacks make debugging harder - you don't know which path was taken
+  - Configuration errors should be caught during deployment, not hidden
+  - Explicit failures are easier to fix than subtle wrong behavior
+  - Less code paths = simpler code = easier to maintain
+

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -40,9 +40,7 @@ export class E2BExecutor {
     initServices();
 
     // Generate secure token same as regular CLI tokens
-    const randomBytes = await import("crypto").then((m) =>
-      m.randomBytes(32),
-    );
+    const randomBytes = await import("crypto").then((m) => m.randomBytes(32));
     const token = `usp_live_${randomBytes.toString("base64url")}`;
 
     // Store token in database with 2 hour expiration (longer than sandbox timeout)

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -138,11 +138,15 @@ export class E2BExecutor {
   ): Promise<void> {
     console.log(`Initializing sandbox for project ${projectId}`);
 
-    // Skip initialization in non-production environments
-    const isProduction = process.env.NODE_ENV === "production";
+    // Skip initialization in non-production and preview environments
+    const vercelEnv = process.env.VERCEL_ENV;
+    const isProductionDeployment = vercelEnv === "production";
+    const isDevelopment = process.env.NODE_ENV === "development";
 
-    if (!isProduction) {
-      console.log("Skipping uspark CLI initialization in development");
+    if (!isProductionDeployment || isDevelopment) {
+      console.log(
+        `Skipping uspark CLI initialization (VERCEL_ENV: ${vercelEnv}, NODE_ENV: ${process.env.NODE_ENV})`,
+      );
       return;
     }
 

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^6.31.6
-        version: 6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.1
@@ -189,7 +189,7 @@ importers:
         version: 5.1.5
       next:
         specifier: ^15.5.2
-        version: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -259,7 +259,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^5.92.1
-        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@uspark/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -6382,15 +6382,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.2)(zod@4.1.5)
       preact: 10.24.2
-      viem: 2.37.5(typescript@5.9.2)(zod@3.25.76)
+      viem: 2.37.5(typescript@5.9.2)(zod@4.1.5)
       zustand: 5.0.3(@types/react@19.1.12)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -6425,9 +6425,9 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
-      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@clerk/localizations': 3.25.0
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
@@ -6475,13 +6475,13 @@ snapshots:
     dependencies:
       '@clerk/types': 4.85.0
 
-  '@clerk/nextjs@6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@clerk/nextjs@6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@clerk/backend': 2.10.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/clerk-react': 5.45.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
-      next: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       server-only: 0.0.1
@@ -8591,9 +8591,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -8666,10 +8666,10 @@ snapshots:
 
   '@zxcvbn-ts/language-common@3.0.4': {}
 
-  abitype@1.1.0(typescript@5.9.2)(zod@3.25.76):
+  abitype@1.1.0(typescript@5.9.2)(zod@4.1.5):
     optionalDependencies:
       typescript: 5.9.2
-      zod: 3.25.76
+      zod: 4.1.5
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -10927,6 +10927,29 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@next/env': 15.5.2
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001737
+      postcss: 8.4.31
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      styled-jsx: 5.1.6(react@19.1.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.2
+      '@next/swc-darwin-x64': 15.5.2
+      '@next/swc-linux-arm64-gnu': 15.5.2
+      '@next/swc-linux-arm64-musl': 15.5.2
+      '@next/swc-linux-x64-gnu': 15.5.2
+      '@next/swc-linux-x64-musl': 15.5.2
+      '@next/swc-win32-arm64-msvc': 15.5.2
+      '@next/swc-win32-x64-msvc': 15.5.2
+      sharp: 0.34.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-releases@2.0.19: {}
 
   normalize-range@0.1.2: {}
@@ -11002,21 +11025,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.9.2)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@5.9.2)(zod@3.25.76):
+  ox@0.9.3(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -11024,7 +11047,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
@@ -11817,6 +11840,11 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.3
 
+  styled-jsx@5.1.6(react@19.1.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.1
+
   stylis@4.2.0: {}
 
   sucrase@3.35.0:
@@ -12199,15 +12227,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.37.5(typescript@5.9.2)(zod@3.25.76):
+  viem@2.37.5(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.9.3(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.9.3(typescript@5.9.2)(zod@4.1.5)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.2

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -17,7 +17,8 @@
     "GH_APP_ID",
     "GH_APP_PRIVATE_KEY",
     "GH_WEBHOOK_SECRET",
-    "CLAUDE_TOKEN_ENCRYPTION_KEY"
+    "CLAUDE_TOKEN_ENCRYPTION_KEY",
+    "VERCEL_ENV"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Simplify E2B sandbox authentication by using standard CLI tokens instead of JWT
- Remove unnecessary jsonwebtoken dependency and JWT_SECRET environment variable
- Follow fail-fast principle - no fallback patterns

## Changes
- Generate standard `usp_live_` CLI tokens for E2B sandboxes with 2-hour expiration
- Store sandbox tokens in existing CLI_TOKENS_TBL table
- Simplify getUserId() to only handle CLI tokens and Clerk auth
- Document fail-fast principle in bad-smell.md

## Test Plan
- [ ] E2B sandbox creation generates valid CLI token
- [ ] CLI commands in sandbox authenticate successfully
- [ ] Tokens expire after 2 hours
- [ ] getUserId() correctly validates CLI tokens

🤖 Generated with Claude Code