### PR TITLE
docs: add lint suppression prohibition to bad smell spec

### DIFF
--- a/spec/bad-smell.md
+++ b/spec/bad-smell.md
@@ -116,3 +116,41 @@ This document defines code quality issues and anti-patterns to identify during c
   - Explicit failures are easier to fix than subtle wrong behavior
   - Less code paths = simpler code = easier to maintain
 
+## 14. Prohibition of Lint/Type Suppressions
+- **ZERO tolerance for suppression comments** - fix the issue, don't hide it
+- **Prohibited comments:**
+  - `// eslint-disable` or `/* eslint-disable */` - Never disable ESLint rules
+  - `// oxlint-disable` or `/* oxlint-disable */` - Never disable OxLint rules
+  - `// @ts-ignore` - Never ignore TypeScript errors
+  - `// @ts-nocheck` - Never skip TypeScript checking for entire files
+  - `// @ts-expect-error` - Don't expect errors, fix them
+  - `// prettier-ignore` - Follow formatting rules consistently
+- **Why suppressions are harmful:**
+  - They accumulate technical debt silently
+  - Hide real problems that could cause runtime failures
+  - Make code reviews less effective
+  - Create inconsistent code quality across the codebase
+- **Always fix the root cause:**
+  ```typescript
+  // ❌ Bad: Suppressing the warning
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = fetchData();
+
+  // ✅ Good: Fix with proper typing
+  const data: unknown = fetchData();
+  if (isValidData(data)) {
+    // Use data with proper type narrowing
+  }
+
+  // ❌ Bad: Ignoring TypeScript error
+  // @ts-ignore
+  window.myGlobalVar = value;
+
+  // ✅ Good: Properly extend global types
+  declare global {
+    interface Window {
+      myGlobalVar: typeof value;
+    }
+  }
+  ```
+


### PR DESCRIPTION
## Summary
- Added section 14 to spec/bad-smell.md documenting zero tolerance for lint/type checking suppressions
- Covers eslint-disable, oxlint-disable, @ts-ignore, @ts-nocheck, and other suppression comments
- Includes examples of bad patterns and proper fixes

## Test plan
- [x] Documentation only change - no code tests needed
- [x] Reviewed formatting and consistency with existing sections

🤖 Generated with [Claude Code](https://claude.ai/code)