### PR TITLE
fix: remove eslint suppression from use-session-polling hook

### DIFF
--- a/turbo/apps/web/app/components/claude-chat/use-session-polling.tsx
+++ b/turbo/apps/web/app/components/claude-chat/use-session-polling.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 
 interface Block {
   id: string;
@@ -27,6 +27,13 @@ interface SessionUpdate {
   turns: Turn[];
 }
 
+// Helper function to build state string from turns
+function buildStateString(turns: Turn[]): string {
+  return turns
+    .map((turn) => `${turn.id}:${turn.blocks.length}`)
+    .join(",");
+}
+
 export function useSessionPolling(projectId: string, sessionId: string | null) {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [isPolling, setIsPolling] = useState(false);
@@ -38,13 +45,6 @@ export function useSessionPolling(projectId: string, sessionId: string | null) {
   useEffect(() => {
     turnsRef.current = turns;
   }, [turns]);
-
-  // Build state string from the current turns in ref
-  const buildStateString = useCallback(() => {
-    return turnsRef.current
-      .map((turn) => `${turn.id}:${turn.blocks.length}`)
-      .join(",");
-  }, []);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -66,7 +66,7 @@ export function useSessionPolling(projectId: string, sessionId: string | null) {
           }
 
           // Build current state string: turn1:blockCount1,turn2:blockCount2
-          const stateString = buildStateString();
+          const stateString = buildStateString(turnsRef.current);
 
           // Long poll for updates with state comparison
           const response = await fetch(
@@ -182,8 +182,7 @@ export function useSessionPolling(projectId: string, sessionId: string | null) {
         abortControllerRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectId, sessionId]); // Remove buildStateString from deps to avoid infinite loops
+  }, [projectId, sessionId]);
 
   const hasActiveTurns = () => {
     return turns.some(
@@ -196,7 +195,7 @@ export function useSessionPolling(projectId: string, sessionId: string | null) {
 
     try {
       // Build current state for comparison
-      const stateString = buildStateString();
+      const stateString = buildStateString(turnsRef.current);
 
       const response = await fetch(
         `/api/projects/${projectId}/sessions/${sessionId}/updates?state=${encodeURIComponent(stateString)}&timeout=0`,

--- a/turbo/apps/web/app/components/claude-chat/use-session-polling.tsx
+++ b/turbo/apps/web/app/components/claude-chat/use-session-polling.tsx
@@ -29,9 +29,7 @@ interface SessionUpdate {
 
 // Helper function to build state string from turns
 function buildStateString(turns: Turn[]): string {
-  return turns
-    .map((turn) => `${turn.id}:${turn.blocks.length}`)
-    .join(",");
+  return turns.map((turn) => `${turn.id}:${turn.blocks.length}`).join(",");
 }
 
 export function useSessionPolling(projectId: string, sessionId: string | null) {


### PR DESCRIPTION
## Summary
- Removed ESLint suppression comment that violated the project's zero-tolerance policy
- Refactored `buildStateString` from useCallback to a pure function outside the component
- Eliminates react-hooks/exhaustive-deps warning without compromising functionality

## Context
This fix addresses a critical issue found in code review where commit 419f9bf violated the project's strict no-lint-suppression policy by using `// eslint-disable-next-line react-hooks/exhaustive-deps`.

## Solution
Moved `buildStateString` to a pure function that accepts `turns` as a parameter, eliminating the dependency array issue while maintaining the same functionality.

## Test plan
- [x] Lint checks pass without warnings
- [x] TypeScript compilation successful
- [x] No functional changes - polling behavior remains identical

🤖 Generated with [Claude Code](https://claude.ai/code)