### PR TITLE
docs: add dev server command documentation and mkcert support

### DIFF
--- a/.claude/commands/dev-logs.md
+++ b/.claude/commands/dev-logs.md
@@ -1,0 +1,38 @@
+---
+command: dev-logs
+description: View development server logs with optional filtering
+---
+
+Views the output from the background development server.
+
+Usage:
+- `/dev-logs` - Show all new logs since last check
+- `/dev-logs [pattern]` - Show only logs matching the pattern (regex)
+
+Examples:
+- `/dev-logs error` - Show only error messages
+- `/dev-logs "web|workspace"` - Show logs from web or workspace packages
+- `/dev-logs "compiled|ready"` - Show compilation status
+
+## What to do:
+
+1. **Find the dev server shell ID:**
+   Use `/bashes` command to list all background shells, or look for the shell running "pnpm dev".
+
+2. **If no filter pattern provided:**
+   ```javascript
+   BashOutput({ bash_id: "<shell-id>" })
+   ```
+
+3. **If filter pattern provided:**
+   ```javascript
+   BashOutput({ bash_id: "<shell-id>", filter: "<pattern>" })
+   ```
+
+4. **Display the logs:**
+   Show the output in a readable format. If empty, mention that no new logs since last check.
+
+## Important notes:
+- This only shows **NEW** output since the last time logs were checked
+- The filter parameter uses regex patterns
+- If no dev server is running, show error and suggest using `/dev-start`

--- a/.claude/commands/dev-start.md
+++ b/.claude/commands/dev-start.md
@@ -1,0 +1,37 @@
+---
+command: dev-start
+description: Start the development server in background mode
+---
+
+Starts the Turbo development server in the background with stream UI mode.
+
+Usage: `/dev-start`
+
+## What to do:
+
+1. **Check if dev server is already running:**
+   ```bash
+   pgrep -f "pnpm dev"
+   ```
+   If running, show warning and suggest using `/dev-stop` first.
+
+2. **Start dev server in background:**
+   Use Bash tool with `run_in_background: true`:
+   ```bash
+   cd /workspaces/uspark2/turbo && pnpm dev --ui=stream
+   ```
+
+3. **Show the shell ID:**
+   Display the shell_id returned by the Bash tool so user knows which process to monitor.
+
+4. **Show next steps:**
+   ```
+   ✅ Dev server started in background (shell_id: <id>)
+
+   Next steps:
+   - Use `/dev-logs` to view server output
+   - Use `/dev-logs [pattern]` to filter logs (e.g., `/dev-logs error`)
+   - Use `/dev-stop` to stop the server
+   ```
+
+Note: The `--ui=stream` flag ensures non-interactive output suitable for background monitoring.

--- a/.claude/commands/dev-stop.md
+++ b/.claude/commands/dev-stop.md
@@ -1,0 +1,46 @@
+---
+command: dev-stop
+description: Stop the background development server
+---
+
+Stops the background development server gracefully.
+
+Usage: `/dev-stop`
+
+## What to do:
+
+1. **Find the dev server shell ID:**
+   Use `/bashes` command to list all background shells and identify the one running "pnpm dev".
+
+2. **Stop the server:**
+   ```javascript
+   KillShell({ shell_id: "<shell-id>" })
+   ```
+
+3. **Verify it's stopped:**
+   ```bash
+   pgrep -f "pnpm dev"
+   ```
+
+4. **Show appropriate message:**
+
+   If stopped successfully:
+   ```
+   ✅ Dev server stopped successfully
+
+   You can start it again with `/dev-start`
+   ```
+
+   If process still detected:
+   ```
+   ⚠️ Warning: Dev server process still detected
+
+   Try manual cleanup: pkill -f "pnpm dev"
+   ```
+
+   If no dev server was running:
+   ```
+   ℹ️ No dev server is currently running
+
+   Use `/dev-start` to start one
+   ```

--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -82,6 +82,19 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Install mkcert for local SSL certificates
+RUN apt-get update && apt-get install -y \
+    libnss3-tools \
+    && ARCH=$(dpkg --print-architecture) \
+    && if [ "$ARCH" = "arm64" ]; then \
+        curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/arm64"; \
+    else \
+        curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"; \
+    fi \
+    && chmod +x mkcert-v*-linux-* \
+    && mv mkcert-v*-linux-* /usr/local/bin/mkcert \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create vscode user with standard UID/GID for devcontainer compatibility
 # Following Microsoft's devcontainer pattern for better feature compatibility
 RUN groupadd --gid 1000 vscode \


### PR DESCRIPTION
## Summary

- Added three new Claude command files for development server management:
  - `dev-start`: Start development server in background with stream UI mode
  - `dev-logs`: View and filter development server logs with regex support
  - `dev-stop`: Stop the background development server gracefully
- Updated Dockerfile to install mkcert for local SSL certificate generation with multi-arch support (amd64/arm64)

## Test plan

- [ ] Verify new Claude command files are properly formatted and contain correct instructions
- [ ] Test that Dockerfile builds successfully with mkcert installation
- [ ] Validate mkcert installs correctly for both amd64 and arm64 architectures
- [ ] Confirm dev commands follow project documentation standards

Generated with [Claude Code](https://claude.com/claude-code)