### PR TITLE
chore: update devcontainer image to f4c1879

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "USpark Development",
-  "image": "ghcr.io/uspark-hq/uspark-dev:1dacb9c",
+  "image": "ghcr.io/uspark-hq/uspark-dev:f4c1879",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Update devcontainer base image reference from 1dacb9c to f4c1879
- Ensures development environment uses the latest container image with updated tooling and dependencies

## Details
This change updates the devcontainer configuration to reference the latest image tag (f4c1879), which corresponds to the most recent commit in the main branch. This keeps the development environment in sync with the latest environment improvements.

## Test Plan
- Pre-commit checks passed (format, lint, type-check, tests)
- All 480 tests passed successfully
- No code changes, only configuration update

🤖 Generated with [Claude Code](https://claude.com/claude-code)