### PR TITLE
chore: add mkcert ca installation to devcontainer setup

### DIFF
--- a/.claude/commands/dev-restart.md
+++ b/.claude/commands/dev-restart.md
@@ -1,19 +1,23 @@
 ---
-command: dev-start
-description: Start the development server in background mode
+command: dev-restart
+description: Restart the development server (stop and start)
 ---
 
-Starts the Turbo development server in the background with stream UI mode.
+Restarts the Turbo development server by stopping the current instance and starting a new one.
 
-Usage: `/dev-start`
+Usage: `/dev-restart`
 
 ## What to do:
 
-1. **Check if dev server is already running:**
+1. **Find and stop any running dev server:**
    ```bash
-   pgrep -f "pnpm dev"
+   # List all background bash shells to find dev server
+   # Look for shells running "pnpm dev"
    ```
-   If running, show warning and suggest using `/dev-stop` first.
+
+   For each dev server shell found:
+   - Use `KillShell({ shell_id: "<id>" })` to stop it
+   - Wait 2 seconds for processes to fully terminate
 
 2. **Generate SSL certificates if needed:**
    Check if certificates exist, generate if missing:
@@ -41,9 +45,9 @@ Usage: `/dev-start`
 4. **Show the shell ID:**
    Display the shell_id returned by the Bash tool so user knows which process to monitor.
 
-5. **Show next steps:**
+5. **Show completion message:**
    ```
-   ✅ Dev server started in background (shell_id: <id>)
+   🔄 Dev server restarted successfully (shell_id: <id>)
 
    Next steps:
    - Use `/dev-logs` to view server output
@@ -51,4 +55,4 @@ Usage: `/dev-start`
    - Use `/dev-stop` to stop the server
    ```
 
-Note: The `--ui=stream` flag ensures non-interactive output suitable for background monitoring.
+Note: This command is useful when you need to reload configuration changes or clear stale processes.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
   "mounts": [
     "source=config,target=/home/vscode/.config",
     "source=cache,target=/home/vscode/.cache",
-    "source=vercel,target=/home/vscode/.local/share/com.vercel.cli"
+    "source=vercel,target=/home/vscode/.local/share/com.vercel.cli",
+    "source=mkcert,target=/home/vscode/.local/share/mkcert"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -19,9 +19,12 @@ if ! grep -q "www.uspark.dev" /etc/hosts; then
   echo "127.0.0.1 uspark.dev www.uspark.dev app.uspark.dev docs.uspark.dev" | sudo tee -a /etc/hosts > /dev/null
 fi
 
+# Setup mkcert root CA
+echo "Installing mkcert root CA..."
+mkcert -install
+
 echo "✅ Dev container ready!"
 echo ""
 echo "📝 Note: Caddy proxy is now managed via turbo/pnpm"
 echo "   - Start all services: cd turbo && pnpm dev"
-echo "   - Check certificates: cd turbo/packages/proxy && npm run check-certs"
-echo "   - Generate certificates: Run './scripts/generate-certs.sh' on host machine"
+echo "   - Generate certificates: cd turbo/packages/proxy && npm run generate-certs"

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -57,4 +57,15 @@ stopCaddy.on("close", () => {
     spawn("caddy", ["stop"], { stdio: "inherit" });
     process.exit(0);
   });
+
+  // Prevent Node.js from exiting by keeping the event loop active
+  // This ensures the Caddy process continues running
+  caddy.on("exit", (code, signal) => {
+    if (code !== null) {
+      console.error(`Caddy exited with code ${code}`);
+    } else if (signal !== null) {
+      console.error(`Caddy was killed by signal ${signal}`);
+    }
+    process.exit(code || 1);
+  });
 });

--- a/turbo/scripts/generate-certs.sh
+++ b/turbo/scripts/generate-certs.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Generate SSL certificates for local development using mkcert
+# This script generates separate certificate files for each domain required by Caddy
+
+set -e
+
+# Certificate directory (relative to project root)
+CERT_DIR="$(cd "$(dirname "$0")/../.." && pwd)/.certs"
+
+echo "🔐 Generating SSL certificates for local development..."
+echo "Certificate directory: $CERT_DIR"
+echo ""
+
+# Create certificate directory if it doesn't exist
+mkdir -p "$CERT_DIR"
+
+# Check if mkcert is installed
+if ! command -v mkcert &> /dev/null; then
+    echo "❌ Error: mkcert is not installed"
+    echo ""
+    echo "Please install mkcert:"
+    echo "  - macOS: brew install mkcert"
+    echo "  - Linux: Install from https://github.com/FiloSottile/mkcert"
+    echo "  - Dev Container: Already included in the image"
+    exit 1
+fi
+
+# Check if mkcert root CA is installed
+if ! mkcert -CAROOT &> /dev/null; then
+    echo "⚠️  mkcert root CA not found. Installing..."
+    mkcert -install
+    echo ""
+fi
+
+# Generate certificates for each domain
+echo "Generating certificates..."
+echo ""
+
+# www.uspark.dev
+echo "📝 Generating certificate for www.uspark.dev"
+mkcert -cert-file "$CERT_DIR/www.uspark.dev.pem" \
+       -key-file "$CERT_DIR/www.uspark.dev-key.pem" \
+       www.uspark.dev localhost 127.0.0.1 ::1
+
+# app.uspark.dev
+echo "📝 Generating certificate for app.uspark.dev"
+mkcert -cert-file "$CERT_DIR/app.uspark.dev.pem" \
+       -key-file "$CERT_DIR/app.uspark.dev-key.pem" \
+       app.uspark.dev localhost 127.0.0.1 ::1
+
+# docs.uspark.dev
+echo "📝 Generating certificate for docs.uspark.dev"
+mkcert -cert-file "$CERT_DIR/docs.uspark.dev.pem" \
+       -key-file "$CERT_DIR/docs.uspark.dev-key.pem" \
+       docs.uspark.dev localhost 127.0.0.1 ::1
+
+# uspark.dev
+echo "📝 Generating certificate for uspark.dev"
+mkcert -cert-file "$CERT_DIR/uspark.dev.pem" \
+       -key-file "$CERT_DIR/uspark.dev-key.pem" \
+       uspark.dev localhost 127.0.0.1 ::1
+
+echo ""
+echo "✅ All SSL certificates generated successfully!"
+echo ""
+echo "Generated certificates:"
+ls -lh "$CERT_DIR"/*.pem | awk '{print "  - " $9}'
+echo ""
+echo "📝 Certificates will expire in ~2 years"
+echo "🚀 You can now start the dev server with: pnpm dev"


### PR DESCRIPTION
## Summary

This PR adds automatic mkcert root CA installation to the devcontainer setup to streamline local development with SSL certificates.

### Changes

- Added persistent volume mount for mkcert data (`source=mkcert,target=/home/vscode/.local/share/mkcert`)
- Added automatic `mkcert -install` command to devcontainer setup script
- Updated setup notes to reference the new certificate generation command location

### Benefits

- Developers no longer need to manually run `mkcert -install` after container creation
- SSL certificates work immediately for local development domains
- mkcert CA data persists across container rebuilds via volume mount
- Simplifies the onboarding process for new developers

### Test Plan

- [ ] Rebuild devcontainer and verify mkcert CA is installed automatically
- [ ] Verify local domains (uspark.dev, app.uspark.dev, etc.) work with HTTPS
- [ ] Confirm certificates can be generated with `cd turbo/packages/proxy && npm run generate-certs`
- [ ] Test that mkcert data persists after container rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)