### PR TITLE
fix: change turbo ui mode from tui to stream to prevent hanging

### DIFF
--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "globalEnv": [
     "DATABASE_URL",
     "CLERK_SECRET_KEY",


### PR DESCRIPTION
## Summary

Fixed `pnpm lint` hanging issue by changing Turbo's UI mode from `tui` to `stream` in `turbo.json`.

## Problem

The TUI (Terminal UI) mode was causing `pnpm lint` to hang intermittently in certain terminal environments. TUI mode requires terminal interaction and can wait indefinitely for terminal refresh events, especially in:
- Background execution
- CI/CD environments
- Non-standard terminals
- Remote shells

## Solution

Changed `turbo.json` from:
```json
"ui": "tui"
```

To:
```json
"ui": "stream"
```

## Benefits

✅ **No more hanging** - Stream mode uses simple line-by-line output without terminal dependencies
✅ **Better compatibility** - Works consistently across all terminal types
✅ **CI/CD friendly** - More reliable in automated environments
✅ **Simpler output** - Clear, streaming logs without interactive UI overhead

## Testing

Verified the fix resolves the hanging issue:
- ✅ `pnpm lint` completes in ~80ms (using cache)
- ✅ All 6 packages pass linting
- ✅ No hanging or terminal interaction issues

## Test Plan

- [x] Format check passed
- [x] Lint check passed (6 successful tasks)
- [x] Type check passed (6 successful tasks)
- [x] All 484 tests passed
- [x] Verified no hanging during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)