### PR TITLE
feat: add chromium installation for chrome devtools mcp

### DIFF
--- a/toolchain/Dockerfile
+++ b/toolchain/Dockerfile
@@ -31,6 +31,15 @@ RUN npm install -g pnpm@10.15.0 lefthook@1.12.3 vercel@46.1.1 neonctl@2.15.0
 # This is needed for e2e tests in CI
 RUN npx playwright install-deps chromium
 
+# Install Chromium browser via Playwright to a shared location
+# Required for Chrome DevTools MCP and e2e tests
+RUN PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright npx playwright install chromium
+
+# Create symlink for Chrome DevTools MCP
+# MCP expects Chrome at /opt/google/chrome/chrome by default
+RUN mkdir -p /opt/google/chrome && \
+    ln -s /opt/ms-playwright/chromium-*/chrome-linux/chrome /opt/google/chrome/chrome
+
 # Stage 2: Development environment with additional tools
 FROM toolchain AS development
 


### PR DESCRIPTION
## Summary
- Install Chromium browser via Playwright to a shared location (`/opt/ms-playwright`)
- Create symlink at `/opt/google/chrome/chrome` for Chrome DevTools MCP compatibility
- Enables AI coding assistants to interact with Chrome debugging tools

## Changes
- Modified `toolchain/Dockerfile` to include Chromium installation
- Added symlink for default Chrome path expected by MCP servers

## Benefits
- Chrome DevTools MCP works out of the box in devcontainer
- Shared browser installation accessible by all users
- Supports both e2e tests and MCP tools with single browser instance

## Test Plan
- [ ] Build new Docker image
- [ ] Verify Chromium is installed at `/opt/ms-playwright`
- [ ] Verify symlink exists at `/opt/google/chrome/chrome`
- [ ] Test Chrome DevTools MCP connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)