### PR TITLE
chore: add vscode extensions to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,16 @@
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "oxc.oxc-vscode",
+        "vitest.explorer",
+        "mtxr.sqltools-driver-pg",
+        "ms-playwright.playwright",
+        "foxundermoon.shell-format"
+      ],
       "settings": {
         "sqltools.connections": [
           {


### PR DESCRIPTION
## Summary
- Add automatic VSCode extension installation in devcontainer configuration
- Consolidate extensions from workspace and extensions.json files
- Extensions will auto-install on container rebuild

## Extensions Added
- anthropic.claude-code
- esbenp.prettier-vscode
- dbaeumer.vscode-eslint
- oxc.oxc-vscode
- vitest.explorer
- mtxr.sqltools-driver-pg
- ms-playwright.playwright
- foxundermoon.shell-format

## Test plan
- [ ] Rebuild dev container
- [ ] Verify all extensions are automatically installed
- [ ] Confirm workspace and extensions.json recommendations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)