### PR TITLE
fix: specify chrome executable path in mcp configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,12 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["chrome-devtools-mcp@latest", "--headless"],
+      "args": [
+        "chrome-devtools-mcp@latest",
+        "--headless",
+        "--executablePath",
+        "/opt/google/chrome/chrome"
+      ],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary
- Add `--executablePath` argument to Chrome DevTools MCP configuration
- Point explicitly to `/opt/google/chrome/chrome` symlink created in Dockerfile
- Ensures MCP can reliably locate and launch Chromium in devcontainer

## Test plan
- [x] Tested Chrome MCP tools work correctly (new_page, take_snapshot, list_console_messages, take_screenshot)
- [x] Verified Chromium is installed at `/opt/google/chrome/chrome`
- [x] Confirmed symlink points to Playwright Chromium installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)