### PR TITLE
fix: allow organization selection in github app installation

### DIFF
--- a/turbo/apps/web/app/api/github/install/route.ts
+++ b/turbo/apps/web/app/api/github/install/route.ts
@@ -14,8 +14,8 @@ export async function GET() {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  // GitHub App installation URL
-  const installUrl = `https://github.com/apps/uspark-sync/installations/new`;
+  // GitHub App installation URL - use base URL to allow org selection
+  const installUrl = `https://github.com/apps/uspark-sync`;
 
   // Add state parameter to track the user
   const url = new URL(installUrl);


### PR DESCRIPTION
## Summary
Changed GitHub App installation URL from `/installations/new` to the base app URL (`https://github.com/apps/uspark-sync`). The `/installations/new` path bypasses organization selection and installs directly to the user's personal account. Using the base URL allows users to choose between installing to their personal account or any organization they have access to.

## Test plan
- [ ] Navigate to Settings > GitHub in the web app
- [ ] Click "Connect GitHub" button
- [ ] Verify that the GitHub page allows selecting between personal account and organizations
- [ ] Verify installation completes successfully for both personal and organization accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)