### PR TITLE
fix: improve sandbox initialization error logging

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -148,8 +148,16 @@ export class E2BExecutor {
     );
 
     if (result.exitCode !== 0) {
-      console.error("Failed to initialize sandbox:", result.stderr);
-      throw new Error(`Sandbox initialization failed: ${result.stderr}`);
+      const errorDetails = {
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        projectId,
+      };
+      console.error("Failed to initialize sandbox:", errorDetails);
+      throw new Error(
+        `Sandbox initialization failed (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`,
+      );
     }
 
     console.log("Sandbox initialized successfully with project files");


### PR DESCRIPTION
## Summary
Improved error logging for sandbox initialization failures to help diagnose issues when `uspark pull` fails during E2B sandbox setup.

## Changes
- Added detailed error logging that includes exitCode, stdout, stderr, and projectId
- Enhanced exception message to include all available error information
- This will make it easier to diagnose "exit status 1" failures

## Context
Users were encountering "exit status 1" errors during sandbox initialization without enough context to debug the issue. This change ensures we capture and display all available error details.

## Test plan
- [ ] Deploy to production
- [ ] Trigger sandbox initialization with an invalid project or empty project
- [ ] Verify error logs contain detailed information including stdout/stderr
- [ ] Confirm error message helps identify the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)