### PR TITLE
refactor: remove delete confirmation dialog for projects

### DIFF
--- a/turbo/apps/web/app/projects/page.tsx
+++ b/turbo/apps/web/app/projects/page.tsx
@@ -32,9 +32,6 @@ export default function ProjectsListPage() {
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newProjectName, setNewProjectName] = useState("");
   const [creating, setCreating] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
-  const [deleting, setDeleting] = useState(false);
 
   // Load projects from API
   useEffect(() => {
@@ -98,13 +95,9 @@ export default function ProjectsListPage() {
     }
   };
 
-  const handleDeleteProject = async () => {
-    if (!projectToDelete) return;
-
-    setDeleting(true);
-
+  const handleDeleteProject = async (project: Project) => {
     try {
-      const response = await fetch(`/api/projects/${projectToDelete.id}`, {
+      const response = await fetch(`/api/projects/${project.id}`, {
         method: "DELETE",
       });
 
@@ -113,13 +106,9 @@ export default function ProjectsListPage() {
       }
 
       // Remove from projects list
-      setProjects((prev) => prev.filter((p) => p.id !== projectToDelete.id));
-      setShowDeleteDialog(false);
-      setProjectToDelete(null);
+      setProjects((prev) => prev.filter((p) => p.id !== project.id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete project");
-    } finally {
-      setDeleting(false);
     }
   };
 
@@ -270,8 +259,7 @@ export default function ProjectsListPage() {
                       className="text-red-600 hover:text-red-700 hover:bg-red-50"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setProjectToDelete(project);
-                        setShowDeleteDialog(true);
+                        handleDeleteProject(project);
                       }}
                     >
                       Delete
@@ -354,39 +342,6 @@ export default function ProjectsListPage() {
               disabled={!newProjectName.trim() || creating}
             >
               {creating ? "Creating..." : "Create Project"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Project Dialog */}
-      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Project</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete &quot;{projectToDelete?.name}
-              &quot;? This action cannot be undone. All files, sessions, and
-              related data will be permanently deleted.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setShowDeleteDialog(false);
-                setProjectToDelete(null);
-              }}
-              disabled={deleting}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteProject}
-              disabled={deleting}
-            >
-              {deleting ? "Deleting..." : "Delete Project"}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- Remove confirmation dialog when deleting projects
- Delete projects immediately on button click
- Simplify delete handler implementation

## Changes
- Removed `showDeleteDialog`, `projectToDelete`, and `deleting` state variables
- Updated `handleDeleteProject` to accept project parameter directly
- Removed delete confirmation dialog UI component
- Delete button now triggers immediate deletion

## Test plan
- [x] All 330 tests passing
- [x] Lint checks passing
- [x] Type checks passing
- [x] Delete functionality verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)