### PR TITLE
refactor: improve contract type inference and simplify error handling

### DIFF
--- a/turbo/apps/web/app/api/blob-store/route.ts
+++ b/turbo/apps/web/app/api/blob-store/route.ts
@@ -8,9 +8,6 @@ import { env } from "../../../src/env";
 type BlobStoreResponse = z.infer<
   (typeof projectDetailContract.getBlobStore.responses)[200]
 >;
-type UnauthorizedResponse = z.infer<
-  (typeof projectDetailContract.getBlobStore.responses)[401]
->;
 
 /**
  * GET /api/blob-store
@@ -23,11 +20,13 @@ export async function GET() {
   const userId = await getUserId();
 
   if (!userId) {
-    const response: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(response, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   const readWriteToken = env().BLOB_READ_WRITE_TOKEN;

--- a/turbo/apps/web/app/api/github/installations/route.ts
+++ b/turbo/apps/web/app/api/github/installations/route.ts
@@ -8,9 +8,6 @@ import { projectDetailContract } from "@uspark/core";
 type GitHubInstallationsResponse = z.infer<
   (typeof projectDetailContract.listGitHubInstallations.responses)[200]
 >;
-type UnauthorizedResponse = z.infer<
-  (typeof projectDetailContract.listGitHubInstallations.responses)[401]
->;
 
 /**
  * GET /api/github/installations
@@ -22,11 +19,13 @@ type UnauthorizedResponse = z.infer<
 export async function GET() {
   const { userId } = await auth();
   if (!userId) {
-    const error: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(error, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   const installations = await getUserInstallations(userId);

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/updates/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/updates/route.ts
@@ -15,9 +15,6 @@ import { projectDetailContract } from "@uspark/core";
 type SessionUpdateResponse = z.infer<
   (typeof projectDetailContract.getSessionUpdates.responses)[200]
 >;
-type UnauthorizedResponse = z.infer<
-  (typeof projectDetailContract.getSessionUpdates.responses)[401]
->;
 
 /**
  * GET /api/projects/:projectId/sessions/:sessionId/updates
@@ -33,11 +30,13 @@ export async function GET(
   const { userId } = await auth();
 
   if (!userId) {
-    const error: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(error, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   initServices();

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/route.ts
@@ -1,23 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import type { z } from "zod";
 import { projectDetailContract } from "@uspark/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { SESSIONS_TBL } from "../../../../../src/db/schema/sessions";
 import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
 import { eq, and, desc, count } from "drizzle-orm";
 import { randomUUID } from "crypto";
-
-// Extract types from contracts
-type UnauthorizedResponse = z.infer<
-  (typeof projectDetailContract.listSessions.responses)[401]
->;
-type NotFoundResponse = z.infer<
-  (typeof projectDetailContract.listSessions.responses)[404]
->;
-type BadRequestResponse = z.infer<
-  (typeof projectDetailContract.createSession.responses)[400]
->;
 
 /**
  * POST /api/projects/:projectId/sessions
@@ -32,11 +20,13 @@ export async function POST(
   const { userId } = await auth();
 
   if (!userId) {
-    const error: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(error, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   initServices();
@@ -51,11 +41,13 @@ export async function POST(
     );
 
   if (!project) {
-    const error: NotFoundResponse = {
-      error: "project_not_found",
-      error_description: "Project not found",
-    };
-    return NextResponse.json(error, { status: 404 });
+    return NextResponse.json(
+      {
+        error: "project_not_found",
+        error_description: "Project not found",
+      },
+      { status: 404 },
+    );
   }
 
   // Parse and validate request body using contract schema
@@ -63,10 +55,12 @@ export async function POST(
   const parseResult = projectDetailContract.createSession.body.safeParse(body);
 
   if (!parseResult.success) {
-    const error: BadRequestResponse = {
-      error: parseResult.error.issues[0]?.message || "Invalid request",
-    };
-    return NextResponse.json(error, { status: 400 });
+    return NextResponse.json(
+      {
+        error: parseResult.error.issues[0]?.message || "Invalid request",
+      },
+      { status: 400 },
+    );
   }
 
   const { title } = parseResult.data;
@@ -114,11 +108,13 @@ export async function GET(
   const { userId } = await auth();
 
   if (!userId) {
-    const error: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(error, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   initServices();
@@ -133,11 +129,13 @@ export async function GET(
     );
 
   if (!project) {
-    const error: NotFoundResponse = {
-      error: "project_not_found",
-      error_description: "Project not found",
-    };
-    return NextResponse.json(error, { status: 404 });
+    return NextResponse.json(
+      {
+        error: "project_not_found",
+        error_description: "Project not found",
+      },
+      { status: 404 },
+    );
   }
 
   // Parse pagination parameters

--- a/turbo/apps/web/app/api/share/[token]/route.test.ts
+++ b/turbo/apps/web/app/api/share/[token]/route.test.ts
@@ -58,7 +58,7 @@ describe("/api/share/:token", () => {
           file_path: testFilePath,
         },
       );
-      expect(shareResponse.status).toBe(201);
+      expect(shareResponse.status).toBe(200);
       shareToken = shareResponse.data.token;
       createdShareIds.push(shareResponse.data.id);
     });

--- a/turbo/apps/web/app/api/share/route.test.ts
+++ b/turbo/apps/web/app/api/share/route.test.ts
@@ -60,7 +60,7 @@ describe("/api/share", () => {
         },
       );
 
-      expect(response.status).toBe(201);
+      expect(response.status).toBe(200);
       expect(response.data).toMatchObject({
         id: expect.any(String),
         url: expect.stringMatching(/^https?:\/\/.+\/share\/.+/),

--- a/turbo/apps/web/app/api/share/route.ts
+++ b/turbo/apps/web/app/api/share/route.ts
@@ -14,12 +14,6 @@ import { eq, and } from "drizzle-orm";
 type ShareResponse = z.infer<
   (typeof projectDetailContract.shareFile.responses)[200]
 >;
-type BadRequestResponse = z.infer<
-  (typeof projectDetailContract.shareFile.responses)[400]
->;
-type UnauthorizedResponse = z.infer<
-  (typeof projectDetailContract.shareFile.responses)[401]
->;
 
 /**
  * Generate a cryptographically secure share token
@@ -39,11 +33,13 @@ export async function POST(request: NextRequest) {
   const { userId } = await auth();
 
   if (!userId) {
-    const errorResponse: UnauthorizedResponse = {
-      error: "unauthorized",
-      error_description: "Authentication required",
-    };
-    return NextResponse.json(errorResponse, { status: 401 });
+    return NextResponse.json(
+      {
+        error: "unauthorized",
+        error_description: "Authentication required",
+      },
+      { status: 401 },
+    );
   }
 
   initServices();
@@ -77,10 +73,12 @@ export async function POST(request: NextRequest) {
     );
 
   if (!project) {
-    const errorResponse: BadRequestResponse = {
-      error: "project_not_found",
-    };
-    return NextResponse.json(errorResponse, { status: 404 });
+    return NextResponse.json(
+      {
+        error: "project_not_found",
+      },
+      { status: 404 },
+    );
   }
 
   // Generate unique token and ID
@@ -106,5 +104,5 @@ export async function POST(request: NextRequest) {
     token,
   };
 
-  return NextResponse.json(response, { status: 201 });
+  return NextResponse.json(response, { status: 200 });
 }

--- a/turbo/apps/web/app/api/shares/route.test.ts
+++ b/turbo/apps/web/app/api/shares/route.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/shares", () => {
       {},
       { project_id: projectId, file_path: "src/file1.ts" },
     );
-    expect(share1Response.status).toBe(201);
+    expect(share1Response.status).toBe(200);
     createdShareIds.push(share1Response.data.id);
 
     const share2Response = await apiCall(
@@ -68,7 +68,7 @@ describe("GET /api/shares", () => {
       {},
       { project_id: projectId, file_path: "src/file2.ts" },
     );
-    expect(share2Response.status).toBe(201);
+    expect(share2Response.status).toBe(200);
     createdShareIds.push(share2Response.data.id);
 
     const response = await apiCall(GET, "GET");
@@ -115,7 +115,7 @@ describe("GET /api/shares", () => {
       {},
       { project_id: myProjectId, file_path: "my-file.ts" },
     );
-    expect(myShareResponse.status).toBe(201);
+    expect(myShareResponse.status).toBe(200);
     createdShareIds.push(myShareResponse.data.id);
 
     // Create project and shares for other user using utility functions

--- a/turbo/apps/workspace/src/signals/external/project-detail.ts
+++ b/turbo/apps/workspace/src/signals/external/project-detail.ts
@@ -11,10 +11,10 @@ interface ProjectFilesData {
   fileCount: number
 }
 
-export const blobStore$ = computed((get) => {
+export const blobStore$ = computed(async (get) => {
   const workspaceFetch = get(fetch$)
 
-  return contractFetch(projectDetailContract.getBlobStore, {
+  return await contractFetch(projectDetailContract.getBlobStore, {
     fetch: workspaceFetch,
   })
 })
@@ -28,7 +28,7 @@ export const projectFiles = function (projectId: string) {
       fetch: workspaceFetch,
     })
 
-    const yjsData = new Uint8Array(response as ArrayBuffer)
+    const yjsData = new Uint8Array(response)
 
     return parseYjsFileSystem(yjsData)
   })
@@ -54,10 +54,10 @@ export const shareFile$ = command(
 )
 
 export const projectSessions = function (projectId: string) {
-  return computed((get) => {
+  return computed(async (get) => {
     const workspaceFetch = get(fetch$)
 
-    return contractFetch(projectDetailContract.listSessions, {
+    return await contractFetch(projectDetailContract.listSessions, {
       params: { projectId },
       fetch: workspaceFetch,
     })
@@ -107,10 +107,10 @@ export const sessionUpdates = function (params: {
   state: string
   timeout?: string
 }) {
-  return computed((get) => {
+  return computed(async (get) => {
     const workspaceFetch = get(fetch$)
 
-    return contractFetch(projectDetailContract.getSessionUpdates, {
+    return await contractFetch(projectDetailContract.getSessionUpdates, {
       params: {
         projectId: params.projectId,
         sessionId: params.sessionId,
@@ -125,20 +125,20 @@ export const sessionUpdates = function (params: {
 }
 
 export const githubRepository = function (projectId: string) {
-  return computed((get) => {
+  return computed(async (get) => {
     const workspaceFetch = get(fetch$)
 
-    return contractFetch(projectDetailContract.getGitHubRepository, {
+    return await contractFetch(projectDetailContract.getGitHubRepository, {
       params: { projectId },
       fetch: workspaceFetch,
     })
   })
 }
 
-export const githubInstallations$ = computed((get) => {
+export const githubInstallations$ = computed(async (get) => {
   const workspaceFetch = get(fetch$)
 
-  return contractFetch(projectDetailContract.listGitHubInstallations, {
+  return await contractFetch(projectDetailContract.listGitHubInstallations, {
     fetch: workspaceFetch,
   })
 })

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -1,12 +1,42 @@
 import { computed } from 'ccstate'
-import { projectFiles } from '../external/project-detail'
-import { pathParams$ } from '../route'
+import { projectFiles, projectSessions } from '../external/project-detail'
+import { pathParams$, searchParams$ } from '../route'
+
+const projectId$ = computed((get) => {
+  const pathParams = get(pathParams$)
+  return pathParams?.projectId as string | undefined
+})
 
 export const projectFiles$ = computed((get) => {
-  const pathParams = get(pathParams$)
-  if (!pathParams?.projectId) {
+  const projectId = get(projectId$)
+  if (!projectId) {
     return undefined
   }
 
-  return get(projectFiles(pathParams.projectId as string))
+  return get(projectFiles(projectId))
+})
+
+export const projectSessions$ = computed((get) => {
+  const projectId = get(projectId$)
+  if (!projectId) {
+    return Promise.resolve(undefined)
+  }
+
+  return get(projectSessions(projectId))
+})
+
+export const selectedSession$ = computed(async (get) => {
+  const searchParams = get(searchParams$)
+  const sessionsResponse = await get(projectSessions$)
+  if (!sessionsResponse) {
+    return undefined
+  }
+
+  const sessions = sessionsResponse.sessions
+  const sessionId = searchParams.get('sessionId')
+  if (!sessionId) {
+    return undefined
+  }
+
+  return sessions.find((s) => s.id === sessionId)
 })

--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -1,9 +1,16 @@
-import { useLoadable } from 'ccstate-react'
-import { projectFiles$ } from '../../signals/project/project'
+import { useLastResolved, useLoadable } from 'ccstate-react'
+import {
+  projectFiles$,
+  projectSessions$,
+  selectedSession$,
+} from '../../signals/project/project'
 import { Link } from '../router/navigate'
 
 export function ProjectPage() {
   const projectFiles = useLoadable(projectFiles$)
+  const projectSessions = useLastResolved(projectSessions$)
+  const selectedSession = useLastResolved(selectedSession$)
+
   if (projectFiles.state === 'loading') {
     return <div>Loading...</div>
   }
@@ -16,6 +23,8 @@ export function ProjectPage() {
     <>
       <div>Project Page</div>
       <pre>{JSON.stringify(projectFiles.data)}</pre>
+      <pre>{JSON.stringify(projectSessions)}</pre>
+      <pre>{JSON.stringify(selectedSession)}</pre>
       <Link pathname="/">Go to Workspace</Link>
     </>
   )

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -30,7 +30,12 @@
       "project": ["**/*.{ts,tsx,mdx,js,mjs}"]
     },
     "apps/workspace": {
-      "entry": ["src/main.ts", "**/*.{test,btest}.ts?(x)", "vitest.setup.*.ts"],
+      "entry": [
+        "src/main.ts",
+        "src/views/**/*.tsx",
+        "**/*.{test,btest}.ts?(x)",
+        "vitest.setup.*.ts"
+      ],
       "project": ["**/*.{ts,tsx}!"],
       "ignore": ["src/views/shadcn/components/ui/**/*.tsx", "scripts/**"],
       "ignoreDependencies": ["@typescript-eslint/parser", "tailwindcss"]

--- a/turbo/packages/core/src/contracts/project-detail.contract.ts
+++ b/turbo/packages/core/src/contracts/project-detail.contract.ts
@@ -96,10 +96,6 @@ export const projectDetailContract = c.router({
     path: "/api/blob-store",
     responses: {
       200: BlobStoreResponseSchema,
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
     },
     summary: "Get blob store ID",
     description:
@@ -116,13 +112,6 @@ export const projectDetailContract = c.router({
     }),
     responses: {
       200: ShareResponseSchema,
-      400: z.object({
-        error: z.string(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
     },
     summary: "Create share link",
     description: "Creates a shareable read-only link for a project file",
@@ -141,14 +130,6 @@ export const projectDetailContract = c.router({
     }),
     responses: {
       200: SessionsResponseSchema,
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
-      404: z.object({
-        error: z.literal("project_not_found"),
-        error_description: z.string(),
-      }),
     },
     summary: "List project sessions",
     description:
@@ -166,17 +147,6 @@ export const projectDetailContract = c.router({
     }),
     responses: {
       200: SessionSchema,
-      400: z.object({
-        error: z.string(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
-      404: z.object({
-        error: z.literal("project_not_found"),
-        error_description: z.string(),
-      }),
     },
     summary: "Create new session",
     description: "Creates a new chat session for a project",
@@ -193,20 +163,8 @@ export const projectDetailContract = c.router({
       user_message: z.string(),
     }),
     responses: {
-      201: z.object({
+      200: z.object({
         id: z.string(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
-      404: z.object({
-        error: z.literal("not_found"),
-        error_description: z.string(),
-      }),
-      500: z.object({
-        error: z.literal("server_error"),
-        error_description: z.string(),
       }),
     },
     summary: "Send message",
@@ -227,14 +185,6 @@ export const projectDetailContract = c.router({
     responses: {
       200: ProjectSessionUpdateResponseSchema,
       204: z.void(), // No content - no updates
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
-      404: z.object({
-        error: z.literal("not_found"),
-        error_description: z.string(),
-      }),
     },
     summary: "Get session updates",
     description: "Long polling endpoint for session updates",
@@ -249,14 +199,6 @@ export const projectDetailContract = c.router({
     }),
     responses: {
       200: GitHubRepositoryResponseSchema,
-      404: z.object({
-        error: z.literal("repository_not_linked"),
-        error_description: z.string(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
     },
     summary: "Get GitHub repository",
     description: "Returns the linked GitHub repository for a project",
@@ -267,10 +209,6 @@ export const projectDetailContract = c.router({
     path: "/api/github/installations",
     responses: {
       200: GitHubInstallationsResponseSchema,
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
     },
     summary: "List GitHub installations",
     description: "Returns user's GitHub app installations",
@@ -286,15 +224,7 @@ export const projectDetailContract = c.router({
       installationId: z.number(),
     }),
     responses: {
-      201: GitHubRepositoryResponseSchema,
-      400: z.object({
-        error: z.enum(["repository_already_exists", "github_not_connected"]),
-        message: z.string().optional(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
+      200: GitHubRepositoryResponseSchema,
     },
     summary: "Create GitHub repository",
     description: "Creates and links a GitHub repository to a project",
@@ -309,14 +239,6 @@ export const projectDetailContract = c.router({
     body: z.object({}), // Empty body for POST request
     responses: {
       200: GitHubSyncResponseSchema,
-      400: z.object({
-        error: z.enum(["repository_not_linked", "sync_in_progress"]),
-        message: z.string().optional(),
-      }),
-      401: z.object({
-        error: z.literal("unauthorized"),
-        error_description: z.string(),
-      }),
     },
     summary: "Sync to GitHub",
     description: "Syncs project files to the linked GitHub repository",


### PR DESCRIPTION
## Summary

This PR improves TypeScript type inference in `contractFetch` and simplifies contract definitions by removing redundant error response types.

## Changes

### 1. Improved Type Inference in contractFetch
- Updated `InferSuccessResponse` to properly handle Zod schemas
- Added special handling for `z.any()` types (binary responses) → `ArrayBuffer`
- Simplified to only support 200 status codes for consistency

### 2. Simplified Contract Definitions  
- Removed all error response definitions (401, 404, 400, 500)
- Contracts now only define success responses (200, 204)
- Standardized on 200 for all POST endpoints (instead of 201)
- Reduced project-detail.contract.ts from 316 to 247 lines (-22%)

### 3. Fixed Type Issues in Workspace
- Added `async/await` to all `computed` calls using `contractFetch`
- Fixed `projectSessions$` type inference (was returning `never`)
- Updated `sessionId$` to properly handle response structure
- Removed unnecessary type assertions (ArrayBuffer)
- Added `projectSessions$` usage in project-page for debugging

### 4. Updated API Routes
- Removed contract-derived error response types
- Simplified error handling with inline object literals
- Maintained type safety for success responses

### 5. Updated Knip Configuration
- Added `src/views/**/*.tsx` to workspace entry points
- Fixed false positive unused export warnings

## Benefits
- ✅ Automatic type inference from contracts
- ✅ Simpler, more maintainable contracts  
- ✅ Better type safety (ArrayBuffer vs any)
- ✅ All lint and type checks passing

## Testing
- [x] All unit tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)