### PR TITLE
feat: add nested file navigation and content display

### DIFF
--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -2,6 +2,7 @@ import { useLastResolved, useLoadable } from 'ccstate-react'
 import {
   projectFiles$,
   projectSessions$,
+  selectedFileContent$,
   selectedSession$,
   turns$,
 } from '../../signals/project/project'
@@ -12,6 +13,7 @@ export function ProjectPage() {
   const projectSessions = useLastResolved(projectSessions$)
   const selectedSession = useLastResolved(selectedSession$)
   const turns = useLastResolved(turns$)
+  const fileContent = useLastResolved(selectedFileContent$)
 
   if (projectFiles.state === 'loading') {
     return <div>Loading...</div>
@@ -28,6 +30,7 @@ export function ProjectPage() {
       <pre>{JSON.stringify(projectSessions)}</pre>
       <pre>{JSON.stringify(selectedSession)}</pre>
       <pre>turns: {JSON.stringify(turns, null, 4)}</pre>
+      <pre>file content: {fileContent}</pre>
       <Link pathname="/">Go to Workspace</Link>
     </>
   )


### PR DESCRIPTION
## Summary
- Implement recursive file tree traversal to support nested directories
- Add `selectedFileContent$` signal to fetch and display file content from blob storage  
- Handle directory vs file distinction when selecting files
- Add fallback to first file when no file path is specified

## Technical Details
The previous implementation only searched the top-level `files.files` array and couldn't handle nested file structures like:
```
files/
  archived/
    20250904.md
    20250905.md
  issues/
    README.md
```

### Changes
1. **Added `findFileInTree()` helper** - Recursively searches through the file tree to find files in nested directories
2. **Added `findFirstFile()` helper** - Finds the first actual file (not directory) in the tree for use as a default
3. **Added `selectedFileContent$` computed signal** - Fetches file content from Vercel Blob storage based on the selected file path
4. **Updated file selection logic** - Uses recursive search instead of flat array find

## Test Plan
- [ ] Verify file selection works for top-level files
- [ ] Verify file selection works for nested files (e.g., `archived/20250904.md`)
- [ ] Verify default file selection returns first file, not first directory
- [ ] Verify file content displays correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)