### PR TITLE
feat: add chat input component with auto-session creation

### DIFF
--- a/turbo/apps/workspace/src/signals/page-signal.ts
+++ b/turbo/apps/workspace/src/signals/page-signal.ts
@@ -1,7 +1,17 @@
-import { command, state } from 'ccstate'
+import { command, computed, state } from 'ccstate'
 
 const innerPageSignal$ = state<AbortSignal | undefined>(undefined)
 
 export const setPageSignal$ = command(({ set }, signal: AbortSignal) => {
   set(innerPageSignal$, signal)
+})
+
+export const pageSignal$ = computed((get) => {
+  // global page signal should export by get
+  // eslint-disable-next-line custom/no-get-signal
+  const signal = get(innerPageSignal$)
+  if (!signal) {
+    throw new Error('page signal not set')
+  }
+  return signal
 })

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -106,6 +106,15 @@ export const selectFile$ = command(({ get, set }, filePath: string) => {
   set(updateSearchParams$, newSearchParams)
 })
 
+export const selectSession$ = command(({ get, set }, sessionId: string) => {
+  const currentSearchParams = get(searchParams$)
+  const newSearchParams = new URLSearchParams(currentSearchParams)
+
+  newSearchParams.set('sessionId', sessionId)
+
+  set(updateSearchParams$, newSearchParams)
+})
+
 export const projectSessions$ = computed((get) => {
   const projectId = get(projectId$)
   if (!projectId) {

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -2,9 +2,11 @@ import type { FileItem } from '@uspark/core/yjs-filesystem'
 import { command, computed, state } from 'ccstate'
 import {
   blobStore$,
+  createSession$,
   getFileContentUrl,
   projectFiles,
   projectSessions,
+  sendMessage$,
   sessionTurns,
   turnDetail,
 } from '../external/project-detail'
@@ -167,3 +169,53 @@ export const turns$ = computed(async (get) => {
     }),
   )
 })
+
+const internalChatInput$ = state('')
+
+export const chatInput$ = computed((get) => get(internalChatInput$))
+
+export const updateChatInput$ = command(({ set }, value: string) => {
+  set(internalChatInput$, value)
+})
+
+export const sendChatMessage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const projectId = get(projectId$)
+    let session = await get(selectedSession$)
+    signal.throwIfAborted()
+
+    const message = get(internalChatInput$)
+
+    if (!projectId || !message.trim()) {
+      return
+    }
+
+    if (!session) {
+      const newSession = await set(
+        createSession$,
+        { projectId, title: '' },
+        signal,
+      )
+
+      const searchParams = get(searchParams$)
+      const newSearchParams = new URLSearchParams(searchParams)
+      newSearchParams.set('sessionId', newSession.id)
+      set(updateSearchParams$, newSearchParams)
+
+      session = newSession
+    }
+
+    await set(
+      sendMessage$,
+      {
+        projectId,
+        sessionId: session.id,
+        userMessage: message.trim(),
+      },
+      signal,
+    )
+
+    set(internalChatInput$, '')
+    set(internalReloadTurn$, (x) => x + 1)
+  },
+)

--- a/turbo/apps/workspace/src/views/project/chat-input.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-input.tsx
@@ -1,0 +1,56 @@
+import { useGet, useSet } from 'ccstate-react'
+import type { FormEvent, KeyboardEvent } from 'react'
+import { pageSignal$ } from '../../signals/page-signal'
+import {
+  chatInput$,
+  sendChatMessage$,
+  updateChatInput$,
+} from '../../signals/project/project'
+import { detach, Reason } from '../../signals/utils'
+
+export function ChatInput() {
+  const input = useGet(chatInput$)
+  const setInput = useSet(updateChatInput$)
+  const sendMessage = useSet(sendChatMessage$)
+  const signal = useGet(pageSignal$)
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!input.trim()) {
+      return
+    }
+
+    detach(sendMessage(signal), Reason.DomCallback)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit(e)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border-t border-gray-200 p-4">
+      <div className="flex gap-2">
+        <textarea
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value)
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message... (Enter to send, Shift+Enter for new line)"
+          className="flex-1 resize-none rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none"
+          rows={3}
+        />
+        <button
+          type="submit"
+          disabled={!input.trim()}
+          className="self-end rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-gray-300"
+        >
+          Send
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -1,7 +1,8 @@
-import { useLastResolved } from 'ccstate-react'
+import { useLastResolved, useSet } from 'ccstate-react'
 import {
   projectSessions$,
   selectedSession$,
+  selectSession$,
   turns$,
 } from '../../signals/project/project'
 import { ChatInput } from './chat-input'
@@ -10,10 +11,31 @@ export function ChatWindow() {
   const projectSessions = useLastResolved(projectSessions$)
   const selectedSession = useLastResolved(selectedSession$)
   const turns = useLastResolved(turns$)
+  const handleSelectSession = useSet(selectSession$)
 
   return (
     <div className="flex h-full flex-col border-l border-gray-200">
-      <div className="border-b border-gray-200 p-4 font-semibold">Chat</div>
+      <div className="flex items-center justify-between border-b border-gray-200 p-4">
+        <div className="font-semibold">Chat</div>
+        {projectSessions && projectSessions.sessions.length > 0 && (
+          <select
+            value={selectedSession?.id ?? ''}
+            onChange={(e) => {
+              if (e.target.value) {
+                handleSelectSession(e.target.value)
+              }
+            }}
+            className="rounded border border-gray-300 px-2 py-1 text-sm"
+          >
+            <option value="">Select session</option>
+            {projectSessions.sessions.map((session) => (
+              <option key={session.id} value={session.id}>
+                {session.title ?? 'Untitled Session'}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
 
       <div className="flex-1 overflow-y-auto">
         {!selectedSession && (

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -4,6 +4,7 @@ import {
   selectedSession$,
   turns$,
 } from '../../signals/project/project'
+import { ChatInput } from './chat-input'
 
 export function ChatWindow() {
   const projectSessions = useLastResolved(projectSessions$)
@@ -64,11 +65,7 @@ export function ChatWindow() {
         )}
       </div>
 
-      <div className="border-t border-gray-200 p-4">
-        <div className="text-xs text-gray-500">
-          {projectSessions?.sessions.length ?? 0} session(s)
-        </div>
-      </div>
+      <ChatInput />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Add ChatInput component with message sending functionality
- Implement auto-creation of session when none exists
- Add state management for chat input with proper signal handling
- Export pageSignal$ for global signal access
- Support Enter to send, Shift+Enter for new line

## Technical Details

### New Signals (project.ts)

#### Chat Input State Management
```typescript
const internalChatInput$ = state('')

export const chatInput$ = computed((get) => get(internalChatInput$))

export const updateChatInput$ = command(({ set }, value: string) => {
  set(internalChatInput$, value)
})
```

#### Send Message with Auto-Session Creation
```typescript
export const sendChatMessage$ = command(async ({ get, set }, signal: AbortSignal) => {
  const projectId = get(projectId$)
  let session = await get(selectedSession$)
  signal.throwIfAborted()

  const message = get(internalChatInput$)

  if (!projectId || !message.trim()) {
    return
  }

  // Auto-create session if none exists
  if (!session) {
    const newSession = await set(createSession$, { projectId, title: '' }, signal)
    
    // Update URL to select the new session
    const searchParams = get(searchParams$)
    const newSearchParams = new URLSearchParams(searchParams)
    newSearchParams.set('sessionId', newSession.id)
    set(updateSearchParams$, newSearchParams)
    
    session = newSession
  }

  await set(sendMessage$, {
    projectId,
    sessionId: session.id,
    userMessage: message.trim(),
  }, signal)

  set(internalChatInput$, '')
  set(internalReloadTurn$, (x) => x + 1)
})
```

### Page Signal (page-signal.ts)
```typescript
export const pageSignal$ = computed((get) => {
  const signal = get(innerPageSignal$)
  if (!signal) {
    throw new Error('page signal not set')
  }
  return signal
})
```

### ChatInput Component
- Uses `pageSignal$` for proper signal lifecycle management
- Uses `detach()` to handle async operations from DOM callbacks
- Keyboard shortcuts: Enter to send, Shift+Enter for new line
- Auto-clears input after successful send

### Data Flow
```
User types message
  ↓
updateChatInput$ updates state
  ↓
User presses Enter or clicks Send
  ↓
sendChatMessage$ executes
  ↓
Check if session exists
  ↓
  No → Create new session → Update URL
  ↓
  Yes → Use existing session
  ↓
Send message via API
  ↓
Clear input + reload turns
  ↓
UI updates with new message
```

## Key Design Decisions

1. **Internal State Pattern**: `chatInput$` is exposed as computed, backed by private `internalChatInput$` state (follows project convention)

2. **Auto-Session Creation**: Automatically creates a session when user sends first message, improving UX by removing manual session creation step

3. **Signal Handling**: Uses `pageSignal$` and `detach()` for proper signal management in React event handlers

4. **Signal Check Rules**: Only calls `signal.throwIfAborted()` after awaiting operations that don't accept signal parameter

## Test Plan
- [ ] Verify input text updates correctly
- [ ] Verify Enter sends message, Shift+Enter adds new line
- [ ] Verify auto-session creation when sending first message
- [ ] Verify message appears in chat after sending
- [ ] Verify input clears after successful send
- [ ] Verify URL updates with new sessionId when session is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)