### PR TITLE
feat: add turn and block display components with comprehensive tests

### DIFF
--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -1,0 +1,153 @@
+import type { GetTurnResponse } from '@uspark/core'
+
+type Block = GetTurnResponse['blocks'][number]
+
+interface BlockDisplayProps {
+  block: Block
+}
+
+// Runtime type for block content (schema is incorrect - content can be object)
+type BlockContent = string | Record<string, unknown>
+
+function getTextContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (
+    content &&
+    typeof content === 'object' &&
+    'text' in content &&
+    typeof content.text === 'string'
+  ) {
+    return content.text
+  }
+  return JSON.stringify(content)
+}
+
+export function BlockDisplay({ block }: BlockDisplayProps) {
+  switch (block.type) {
+    case 'text':
+    case 'content': {
+      return (
+        <div className="rounded bg-gray-50 p-3">
+          <div className="mb-1 text-xs text-gray-600">Assistant</div>
+          <div className="text-sm whitespace-pre-wrap">
+            {getTextContent(block.content)}
+          </div>
+        </div>
+      )
+    }
+
+    case 'thinking': {
+      return (
+        <div className="rounded bg-purple-50 p-3">
+          <div className="mb-1 text-xs text-purple-600">💭 Thinking</div>
+          <div className="text-sm whitespace-pre-wrap text-gray-700">
+            {getTextContent(block.content)}
+          </div>
+        </div>
+      )
+    }
+
+    case 'tool_use': {
+      const content = block.content as BlockContent
+      const toolData = typeof content === 'object' ? content : {}
+      const toolName =
+        'tool_name' in toolData && typeof toolData.tool_name === 'string'
+          ? toolData.tool_name
+          : 'Unknown'
+      const parameters =
+        'parameters' in toolData && typeof toolData.parameters === 'object'
+          ? toolData.parameters
+          : {}
+
+      return (
+        <div className="rounded bg-blue-50 p-3">
+          <div className="mb-1 text-xs text-blue-600">🔧 Tool: {toolName}</div>
+          <details className="text-sm">
+            <summary className="cursor-pointer text-gray-600">
+              Parameters
+            </summary>
+            <pre className="mt-2 overflow-x-auto rounded bg-white p-2 text-xs">
+              {JSON.stringify(parameters, null, 2)}
+            </pre>
+          </details>
+        </div>
+      )
+    }
+
+    case 'tool_result': {
+      const content = block.content as BlockContent
+      const resultData = typeof content === 'object' ? content : {}
+      const hasError = 'error' in resultData && Boolean(resultData.error)
+      const result =
+        'result' in resultData && typeof resultData.result === 'string'
+          ? resultData.result
+          : ''
+      const error =
+        'error' in resultData && typeof resultData.error === 'string'
+          ? resultData.error
+          : ''
+
+      return (
+        <div
+          className={`rounded p-3 ${hasError ? 'bg-red-50' : 'bg-green-50'}`}
+        >
+          <div
+            className={`mb-1 text-xs ${hasError ? 'text-red-600' : 'text-green-600'}`}
+          >
+            {hasError ? '❌ Tool Error' : '✅ Tool Result'}
+          </div>
+          <pre className="overflow-x-auto text-xs whitespace-pre-wrap">
+            {error || result || JSON.stringify(block.content)}
+          </pre>
+        </div>
+      )
+    }
+
+    case 'code': {
+      const codeContent =
+        typeof block.content === 'string'
+          ? block.content
+          : JSON.stringify(block.content)
+      return (
+        <div className="rounded bg-gray-900 p-3">
+          <div className="mb-1 text-xs text-gray-400">Code</div>
+          <pre className="overflow-x-auto text-xs text-green-400">
+            <code>{codeContent}</code>
+          </pre>
+        </div>
+      )
+    }
+
+    case 'error': {
+      const errorContent =
+        typeof block.content === 'string'
+          ? block.content
+          : JSON.stringify(block.content)
+      return (
+        <div className="rounded bg-red-50 p-3">
+          <div className="mb-1 text-xs text-red-600">⚠️ Error</div>
+          <div className="text-sm whitespace-pre-wrap text-red-700">
+            {errorContent}
+          </div>
+        </div>
+      )
+    }
+
+    default: {
+      const unknownContent =
+        typeof block.content === 'string'
+          ? block.content
+          : JSON.stringify(block.content)
+      return (
+        <div className="rounded bg-gray-100 p-3">
+          <div className="mb-1 text-xs text-gray-600">
+            Unknown block type: {block.type}
+          </div>
+          <div className="text-sm whitespace-pre-wrap">{unknownContent}</div>
+        </div>
+      )
+    }
+  }
+}

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -6,6 +6,7 @@ import {
   turns$,
 } from '../../signals/project/project'
 import { ChatInput } from './chat-input'
+import { TurnDisplay } from './turn-display'
 
 export function ChatWindow() {
   const projectSessions = useLastResolved(projectSessions$)
@@ -62,26 +63,13 @@ export function ChatWindow() {
             </div>
 
             <div className="space-y-4">
-              {turns?.map((turn) => (
-                <div key={turn.id} className="space-y-2">
-                  {turn.userMessage && (
-                    <div className="rounded bg-blue-50 p-3">
-                      <div className="mb-1 text-xs text-gray-600">User</div>
-                      <div className="text-sm">{turn.userMessage}</div>
-                    </div>
-                  )}
-                  {turn.assistantMessage && (
-                    <div className="rounded bg-gray-50 p-3">
-                      <div className="mb-1 text-xs text-gray-600">
-                        Assistant
-                      </div>
-                      <div className="text-sm whitespace-pre-wrap">
-                        {turn.assistantMessage}
-                      </div>
-                    </div>
-                  )}
+              {turns && turns.length > 0 ? (
+                turns.map((turn) => <TurnDisplay key={turn.id} turn={turn} />)
+              ) : (
+                <div className="text-sm text-gray-500">
+                  No conversation yet. Send a message to start.
                 </div>
-              ))}
+              )}
             </div>
           </div>
         )}

--- a/turbo/apps/workspace/src/views/project/turn-display.tsx
+++ b/turbo/apps/workspace/src/views/project/turn-display.tsx
@@ -1,0 +1,98 @@
+import type { GetTurnResponse } from '@uspark/core'
+import { BlockDisplay } from './block-display'
+
+interface TurnDisplayProps {
+  turn: GetTurnResponse
+}
+
+function TurnStatusBadge({ status }: { status: GetTurnResponse['status'] }) {
+  const statusConfig = {
+    pending: {
+      label: '⏳ Pending',
+      className: 'bg-yellow-100 text-yellow-800',
+    },
+    in_progress: {
+      label: '🔄 In Progress',
+      className: 'bg-blue-100 text-blue-800',
+    },
+    completed: {
+      label: '✅ Completed',
+      className: 'bg-green-100 text-green-800',
+    },
+    failed: { label: '❌ Failed', className: 'bg-red-100 text-red-800' },
+    interrupted: {
+      label: '⚠️ Interrupted',
+      className: 'bg-orange-100 text-orange-800',
+    },
+  }
+
+  const config = statusConfig[status]
+
+  return (
+    <span
+      data-testid="turn-status"
+      className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${config.className}`}
+    >
+      {config.label}
+    </span>
+  )
+}
+
+export function TurnDisplay({ turn }: TurnDisplayProps) {
+  const hasBlocks = (turn.blocks as unknown[] | undefined)?.length > 0
+
+  return (
+    <div className="space-y-2">
+      {/* User message */}
+      <div className="rounded bg-blue-50 p-3">
+        <div className="mb-1 flex items-center justify-between">
+          <div className="text-xs text-gray-600">User</div>
+          <TurnStatusBadge status={turn.status} />
+        </div>
+        <div className="text-sm whitespace-pre-wrap">{turn.user_prompt}</div>
+      </div>
+
+      {/* Assistant blocks */}
+      {hasBlocks ? (
+        <div className="space-y-2 pl-4">
+          {turn.blocks.map((block) => (
+            <BlockDisplay key={block.id} block={block} />
+          ))}
+        </div>
+      ) : turn.status === 'pending' || turn.status === 'in_progress' ? (
+        <div className="rounded bg-gray-50 p-3 pl-7">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500" />
+            <span>
+              {turn.status === 'pending'
+                ? 'Waiting to start...'
+                : 'Processing...'}
+            </span>
+          </div>
+        </div>
+      ) : turn.status === 'failed' ? (
+        <div className="rounded bg-red-50 p-3 pl-7">
+          <div className="text-sm text-red-700">
+            Turn execution failed. Please try again.
+          </div>
+        </div>
+      ) : null}
+
+      {/* Timing info */}
+      {(turn.started_at ?? turn.completed_at) && (
+        <div className="pl-4 text-xs text-gray-400">
+          {turn.started_at && (
+            <span>
+              Started: {new Date(turn.started_at).toLocaleTimeString()}
+            </span>
+          )}
+          {turn.completed_at && (
+            <span className="ml-3">
+              Completed: {new Date(turn.completed_at).toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `BlockDisplay` component to render different block types (text, thinking, tool_use, tool_result, code, error) with proper styling
- Add `TurnDisplay` component with status badges (pending, in_progress, completed, failed, interrupted) and timing information
- Refactor `chat-window` to use new modular display components
- Add comprehensive integration tests for turn and block rendering that verify signal logic

## Changes
### New Components
- **BlockDisplay**: Handles rendering of different Claude response block types
  - Text/content blocks with assistant label
  - Thinking blocks with purple styling
  - Tool use blocks with collapsible parameters
  - Tool result blocks with success/error states
  - Code blocks with syntax highlighting styling
  - Error blocks with red alert styling
  - Unknown block types with graceful fallback

- **TurnDisplay**: Displays complete turn information
  - User message with status badge
  - All associated blocks in sequence
  - Loading states for pending/in-progress turns
  - Error state for failed turns
  - Timing information (started/completed)

### Tests
- Added tests that verify `turns$` signal correctly fetches turn details and blocks
- Added tests for turn status handling (pending, in_progress, failed)
- Tests focus on business logic and API integration, not UI text
- Removed brittle tests that checked specific UI text/structure

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] Tests pass
- [x] Formatted with prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)