### PR TITLE
fix: improve CLI sync reliability and CORS handling

### DIFF
--- a/turbo/apps/web/middleware.cors.ts
+++ b/turbo/apps/web/middleware.cors.ts
@@ -10,16 +10,35 @@ const allowedOrigins = [
   "https://app.uspark.ai",
   "https://www.uspark.ai",
   "https://workspace.uspark.ai",
+
+  // Allow same-origin API calls from any uspark.ai subdomain
+  "https://uspark.ai",
 ];
+
+function isOriginAllowed(origin: string | null): boolean {
+  if (!origin) return false;
+
+  // Check exact match
+  if (allowedOrigins.includes(origin)) return true;
+
+  // Allow any *.uspark.ai or *.uspark.dev subdomain
+  const url = new URL(origin);
+  return (
+    url.hostname.endsWith(".uspark.ai") || url.hostname.endsWith(".uspark.dev")
+  );
+}
 
 export function handleCors(request: NextRequest) {
   const origin = request.headers.get("origin");
   const response = NextResponse.next();
 
-  // Check if the origin is allowed
-  if (origin && allowedOrigins.includes(origin)) {
+  // Check if the origin is allowed or if there's no origin (CLI requests)
+  if (origin && isOriginAllowed(origin)) {
     response.headers.set("Access-Control-Allow-Origin", origin);
     response.headers.set("Access-Control-Allow-Credentials", "true");
+  } else if (!origin) {
+    // Allow requests without origin (CLI, server-to-server)
+    response.headers.set("Access-Control-Allow-Origin", "*");
   }
 
   // Handle preflight requests


### PR DESCRIPTION
## Summary
- Fix blob duplicate upload errors in CLI push operations
- Fix watch-claude timing to sync after file creation
- Enhance CORS to support wildcard subdomains

## Changes

### CLI: Skip duplicate blob uploads
**Problem**: Running `uspark push --all` multiple times throws `BlobError: This blob already exists`

**Solution**: 
- Add try-catch in `pushFile` and `pushFiles` methods
- Gracefully skip re-uploading blobs that already exist in Vercel Blob Storage
- Maintains idempotency for push operations

**Files**: `apps/cli/src/project-sync.ts`

### CLI: Fix watch-claude file sync timing
**Problem**: `watch-claude` tries to sync files immediately when detecting `tool_use`, but files don't exist yet, causing `ENOENT` errors

**Solution**:
- Track `tool_use` events with their IDs and file paths
- Defer sync until `tool_result` event arrives (file is now created)
- Prevents race condition between file creation and sync

**Files**: `apps/cli/src/commands/watch-claude.ts`

### Web: Enhance CORS for subdomain support
**Problem**: Cross-origin API calls from `app.uspark.ai` to `www.uspark.ai` fail with CORS errors

**Solution**:
- Add wildcard subdomain matching for `*.uspark.ai` and `*.uspark.dev`
- Allow CLI requests without origin header (server-to-server)
- More flexible domain matching using URL parsing

**Files**: `apps/web/middleware.cors.ts`

## Test Results
- ✅ All lint checks pass
- ✅ All type checks pass  
- ✅ All knip checks pass
- ✅ Tested `uspark push --all` idempotency (runs successfully multiple times)
- ✅ Tested Claude + watch-claude pipeline with file creation

## Test Plan
- [ ] Verify `uspark push --all` can be run multiple times without errors
- [ ] Verify `watch-claude` successfully syncs files created by Claude
- [ ] Verify API calls work from all uspark subdomains
- [ ] Check CORS headers in browser dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)