### PR TITLE
build: pin cli versions in e2b dockerfile

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -4,10 +4,10 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y git curl
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.0.13
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli
+RUN npm install -g @uspark/cli@0.11.2
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary
- Pin @anthropic-ai/claude-code to version 2.0.13
- Pin @uspark/cli to version 0.11.2

## Test plan
- [ ] Verify E2B container builds successfully with pinned versions
- [ ] Confirm Claude Code CLI works at version 2.0.13
- [ ] Confirm uspark CLI works at version 0.11.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)