### PR TITLE
fix: add permissions skip and file sync to e2b executor

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -183,7 +183,8 @@ export class E2BExecutor {
       let buffer = "";
 
       // Use pipe method with real-time streaming
-      const command = `cat "${promptFile}" | claude --print --verbose --output-format stream-json`;
+      // Pipeline: prompt → claude (skip permissions) → watch-claude (sync files)
+      const command = `cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${projectId}`;
 
       const result = await sandbox.commands.run(command, {
         onStdout: async (data: string) => {


### PR DESCRIPTION
## Summary
- Add `--dangerously-skip-permissions` flag to Claude command to allow file operations in non-interactive E2B environment
- Pipe Claude output through `uspark watch-claude` to sync file changes back to the server in real-time

## Changes
**Before:**
```bash
cat "${promptFile}" | claude --print --verbose --output-format stream-json
```

**After:**
```bash
cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${projectId}
```

## Problem Solved
1. **Permission blocking**: Claude was unable to execute file operations because it couldn't get user permission in non-interactive E2B sandbox
2. **File sync missing**: File changes made by Claude stayed in the sandbox and were not synced back to uSpark server

## Test plan
- [ ] Verify Claude can create/modify files in E2B sandbox without permission prompts
- [ ] Confirm file changes are synced back to uSpark server in real-time
- [ ] Test complete workflow: pull files → execute Claude → sync changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)