### PR TITLE
chore: filter .DS_Store files in cli push command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ dist
 
 # End of https://www.toptal.com/developers/gitignore/api/node
 
+# macOS system files
+.DS_Store
+
 settings.local.json
 
 .pnpm-store

--- a/turbo/apps/cli/src/commands/__tests__/sync.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/sync.test.ts
@@ -115,6 +115,8 @@ describe("sync commands", () => {
       await fs.writeFile("node_modules/test.js", "should be ignored");
       await fs.mkdir(".git");
       await fs.writeFile(".git/config", "should be ignored");
+      await fs.writeFile(".DS_Store", "should be ignored");
+      await fs.writeFile("subdir/.DS_Store", "should be ignored");
 
       await pushCommand(undefined, {
         projectId: "proj-123",
@@ -128,6 +130,8 @@ describe("sync commands", () => {
         false,
       );
       expect(mockServer.hasFile("proj-123", ".git/config")).toBe(false);
+      expect(mockServer.hasFile("proj-123", ".DS_Store")).toBe(false);
+      expect(mockServer.hasFile("proj-123", "subdir/.DS_Store")).toBe(false);
 
       // Verify total file count
       const allFiles = mockServer.getAllFiles("proj-123");

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -78,6 +78,11 @@ export async function pushCommand(
           }
           files.push(...(await getAllFiles(fullPath)));
         } else {
+          // Skip system files
+          if (entry.name === ".DS_Store") {
+            continue;
+          }
+
           // Get relative path from current directory
           const relativePath = fullPath.startsWith("./")
             ? fullPath.slice(2)


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` to prevent tracking macOS system files
- Filter `.DS_Store` files when using `uspark push --all` command
- Add test coverage to verify `.DS_Store` files are properly filtered

## Changes
- **`.gitignore`**: Added `.DS_Store` pattern to ignore macOS system files
- **`apps/cli/src/commands/sync.ts`**: Added filtering logic in `getAllFiles()` to skip `.DS_Store` files
- **`apps/cli/src/commands/__tests__/sync.test.ts`**: Added test assertions to verify `.DS_Store` filtering works correctly

## Test Plan
- [x] All CLI tests pass (296 tests total)
- [x] CLI package lint check passes
- [x] CLI package type check passes
- [x] Added specific test cases for `.DS_Store` filtering

## Notes
The workspace package has pre-existing lint errors that are unrelated to this change. This PR only modifies the CLI package, which passes all quality checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)