### PR TITLE
refactor(workspace): move github sync to bottom statusbar with independent panel scrolling

### DIFF
--- a/turbo/apps/workspace/src/views/project/github-sync-button.tsx
+++ b/turbo/apps/workspace/src/views/project/github-sync-button.tsx
@@ -22,9 +22,9 @@ export function GitHubSyncButton() {
   // Loading state
   if (repository.state === 'loading') {
     return (
-      <div className="flex items-center gap-2 px-3 py-1.5">
-        <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-[#3e3e42] border-t-[#007acc]" />
-        <span className="text-[13px] text-[#969696]">
+      <div className="flex items-center gap-2 px-2 py-0.5">
+        <div className="h-3 w-3 animate-spin rounded-full border-2 border-[#005a9e] border-t-white" />
+        <span className="text-[11px] text-white/90">
           Checking repository...
         </span>
       </div>
@@ -34,7 +34,7 @@ export function GitHubSyncButton() {
   // Error state
   if (repository.state === 'hasError') {
     return (
-      <div className="px-3 py-1.5 text-[13px] text-[#f48771]">
+      <div className="px-2 py-0.5 text-[11px] text-[#ff6b6b]">
         Error loading repository
       </div>
     )
@@ -43,9 +43,9 @@ export function GitHubSyncButton() {
   // Has repository - show sync button
   if (repository.data) {
     return (
-      <div className="flex items-center gap-2.5 px-3 py-1.5">
-        <div className="flex items-center gap-2 rounded bg-[#0e639c]/20 px-2.5 py-1 text-[13px] text-[#4daafc]">
-          <svg className="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor">
+      <div className="flex items-center gap-2 px-2 py-0.5">
+        <div className="flex items-center gap-1.5 rounded bg-white/10 px-2 py-0.5 text-[11px] text-white">
+          <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
           </svg>
           <span>{repository.data.repository.fullName}</span>
@@ -54,7 +54,7 @@ export function GitHubSyncButton() {
           onClick={() => {
             detach(handleSync(signal), Reason.DomCallback)
           }}
-          className="rounded bg-[#0e639c] px-2.5 py-1 text-[13px] font-medium text-[#ffffff] transition-colors hover:bg-[#1177bb]"
+          className="rounded bg-white/20 px-2 py-0.5 text-[11px] font-medium text-white transition-colors hover:bg-white/30"
         >
           Sync to GitHub
         </button>
@@ -67,7 +67,7 @@ export function GitHubSyncButton() {
     installations.state === 'hasData' ? installations.data : undefined
 
   return (
-    <div className="flex items-center gap-2.5 px-3 py-1.5">
+    <div className="flex items-center gap-2 px-2 py-0.5">
       {installationsList && installationsList.installations.length > 0 ? (
         <>
           <select
@@ -76,7 +76,7 @@ export function GitHubSyncButton() {
               const value = e.target.value
               handleSelectInstallation(value ? Number(value) : null)
             }}
-            className="rounded border border-[#3e3e42] bg-[#3c3c3c] px-2.5 py-1 text-[13px] text-[#cccccc] transition-colors hover:bg-[#505050] focus:border-[#007acc] focus:outline-none"
+            className="rounded border border-white/20 bg-white/10 px-2 py-0.5 text-[11px] text-white transition-colors hover:bg-white/15 focus:border-white/40 focus:outline-none"
           >
             <option value="">Select GitHub account...</option>
             {installationsList.installations.map((installation) => (
@@ -90,13 +90,13 @@ export function GitHubSyncButton() {
               detach(handleCreateAndSync(signal), Reason.DomCallback)
             }}
             disabled={!selectedInstallationId}
-            className="rounded bg-[#16825d] px-2.5 py-1 text-[13px] font-medium text-[#ffffff] transition-colors hover:bg-[#1a9870] disabled:cursor-not-allowed disabled:bg-[#3e3e42] disabled:text-[#6a6a6a]"
+            className="rounded bg-white/20 px-2 py-0.5 text-[11px] font-medium text-white transition-colors hover:bg-white/30 disabled:cursor-not-allowed disabled:bg-white/5 disabled:text-white/40"
           >
             Create & Sync Repository
           </button>
         </>
       ) : (
-        <div className="rounded border border-[#be1100]/30 bg-[#be1100]/10 px-2.5 py-1 text-[13px] text-[#f48771]">
+        <div className="rounded border border-[#ff6b6b]/40 bg-[#ff6b6b]/20 px-2 py-0.5 text-[11px] text-white">
           Please connect your GitHub account in Settings
         </div>
       )}

--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -1,18 +1,13 @@
 import { ChatWindow } from './chat-window'
 import { FileContent } from './file-content'
 import { FileTree } from './file-tree'
-import { GitHubSyncButton } from './github-sync-button'
+import { Statusbar } from './statusbar'
 
 export function ProjectPage() {
   return (
     <div className="flex h-screen flex-col bg-[#1e1e1e] text-[#cccccc]">
-      {/* Top toolbar - GitHub sync */}
-      <div className="border-b border-[#3e3e42]">
-        <GitHubSyncButton />
-      </div>
-
       {/* Main content */}
-      <div className="flex flex-1">
+      <div className="flex min-h-0 flex-1">
         {/* Left sidebar - File tree */}
         <div className="w-64 flex-shrink-0 border-r border-[#3e3e42]">
           <FileTree />
@@ -28,6 +23,9 @@ export function ProjectPage() {
           <ChatWindow />
         </div>
       </div>
+
+      {/* Bottom statusbar */}
+      <Statusbar />
     </div>
   )
 }

--- a/turbo/apps/workspace/src/views/project/statusbar.tsx
+++ b/turbo/apps/workspace/src/views/project/statusbar.tsx
@@ -1,0 +1,9 @@
+import { GitHubSyncButton } from './github-sync-button'
+
+export function Statusbar() {
+  return (
+    <div className="flex h-6 flex-shrink-0 items-center border-t border-[#3e3e42] bg-[#007acc]">
+      <GitHubSyncButton />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Move GitHub sync functionality from top toolbar to bottom statusbar for better layout organization
- Fix layout to prevent global page scrolling and enable independent scrolling in left/center/right panels
- Update GitHubSyncButton styling to match blue statusbar theme with white text and compact sizing

## Test plan
- [ ] Verify statusbar appears at bottom with GitHub sync controls
- [ ] Test GitHub sync button functionality (create, sync, account selection)
- [ ] Confirm no global page scrolling occurs
- [ ] Verify file tree (left), file content (center), and chat window (right) scroll independently
- [ ] Check statusbar styling and color scheme
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)