### PR TITLE
feat(workspace): handle github repository 404 as normal state

### DIFF
--- a/turbo/apps/workspace/src/signals/utils.ts
+++ b/turbo/apps/workspace/src/signals/utils.ts
@@ -166,6 +166,12 @@ function throwIfNotAbort(e: unknown) {
   }
 }
 
+export function throwIfAbort(e: unknown) {
+  if (isAbortError(e)) {
+    throw e
+  }
+}
+
 type GeometryStyle = Pick<
   CSSProperties,
   | 'width'


### PR DESCRIPTION
## Summary

Converts 404 errors from the GitHub repository API into `null` values at the signal layer, enabling the UI to properly differentiate between "repository doesn't exist yet" (normal state requiring a create button) and actual errors (network issues, auth failures, etc.).

## Changes

- **project-detail.ts**: 
  - Import `ContractFetchError` and `GitHubRepository` type
  - Wrap `githubRepository` signal with try-catch to handle 404 responses
  - Return `{ repository: null }` for 404 instead of throwing error
  - Add explicit return type `Promise<{ repository: GitHubRepository | null }>`
  - Re-throw non-404 errors (network, auth, etc.)

- **utils.ts**:
  - Add `throwIfAbort` utility function for proper abort signal handling in catch blocks
  - Complies with custom ESLint rule `custom/no-catch-abort`

## Benefits

1. **RESTful API semantics preserved**: 404 remains "resource not found" at API layer
2. **Better UX**: UI can show "Create Repository" button instead of error message
3. **Type safety**: Explicit nullable type makes it clear repository can be null
4. **Proper error handling**: Only 404 is treated as normal state; other errors propagate

## Test Plan

- [x] Modified files pass lint checks
- [x] workspace package passes type checking
- [x] Code formatting is correct
- [x] Related signal tests pass (project-detail.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)