### PR TITLE
feat(web): add verbose logging for e2b sandbox initialization

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -144,8 +144,14 @@ export class E2BExecutor {
 
     // Pull all project files using uspark CLI
     const result = await sandbox.commands.run(
-      `uspark pull --all --project-id ${projectId}`,
+      `uspark pull --all --project-id ${projectId} --verbose`,
     );
+
+    // Always log the output for debugging
+    console.log("Pull command stdout:", result.stdout);
+    if (result.stderr) {
+      console.log("Pull command stderr:", result.stderr);
+    }
 
     if (result.exitCode !== 0) {
       const errorDetails = {


### PR DESCRIPTION
## Summary
- Enable `--verbose` flag for `uspark pull` command in E2B sandbox initialization
- Add detailed stdout/stderr logging to help diagnose production environment issues
- Helps identify why blocks may not be created in production vs development

## Problem
In production environments, blocks are not being created during Claude execution. We need detailed logs to diagnose:
- Whether `uspark pull --all` executes successfully
- File synchronization status in E2B sandbox
- Differences between production and development environments

## Changes
1. Added `--verbose` flag to `uspark pull --all` command
2. Always log `stdout` and `stderr` from pull command
3. Improved debugging visibility for production issues

## Test Plan
- [x] CI checks passed (lint, format, database migration)
- [ ] Deploy to preview environment and verify logs appear in Vercel Function Logs
- [ ] Test in production to diagnose block creation issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)