### PR TITLE
fix(cli,web): improve E2B reliability and token management

### DIFF
--- a/turbo/apps/cli/src/commands/watch-claude.ts
+++ b/turbo/apps/cli/src/commands/watch-claude.ts
@@ -217,7 +217,9 @@ async function sendStdoutCallback(
     );
 
     if (!response.ok) {
-      throw new Error(`API returned ${response.status}: ${response.statusText}`);
+      throw new Error(
+        `API returned ${response.status}: ${response.statusText}`,
+      );
     }
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary
Improved reliability for E2B containers with fixes to both CLI and Web packages.

## Changes

### CLI: Timeout and JSON Validation for watch-claude
- **JSON parsing validation**: Skip non-JSON lines silently to prevent process crashes
- **Request timeout**: Add 10-second timeout to stdout callback API requests  
- **Clean error handling**: Let errors propagate naturally per project guidelines

### Web: Automatic Cleanup for Expired Sandbox Tokens
- **Token cleanup**: Automatically remove expired E2B sandbox CLI tokens
- **Prevent database bloat**: Clean up before creating new tokens
- **Resource management**: Improves long-term database performance

## Why

### CLI Issue
`watch-claude` could crash when encountering:
- Unexpected non-JSON output from Claude CLI
- Network timeout issues in E2B sandbox environments

### Web Issue
E2B sandbox tokens accumulate in database without cleanup:
- Each sandbox creation generates a temporary CLI token
- Tokens expire after 2 hours but were never cleaned up
- Could lead to database bloat over time

## Code Changes

### CLI: Simplified Error Handling
**Before** (defensive programming ❌):
```typescript
try {
  const response = await fetch(url);
  if (!response.ok) {
    const errorBody = await response.text();
    throw new Error(`API returned ${response.status}: ${errorBody}`);
  }
} catch (error) {
  if (error.name === "AbortError") {
    throw new Error("Request timed out");
  }
  throw error;
}
```

**After** (let errors propagate ✅):
```typescript
try {
  const response = await fetch(url, { signal: controller.signal });
  if (!response.ok) {
    throw new Error(`API returned ${response.status}: ${response.statusText}`);
  }
} finally {
  clearTimeout(timeout);
}
```

### Web: Token Cleanup
```typescript
private static async generateSandboxToken(
  userId: string,
  sessionId: string,
): Promise<string> {
  // Clean up expired tokens before creating new one
  await this.cleanupExpiredTokens(userId);
  
  // ... create new token
}

private static async cleanupExpiredTokens(userId: string): Promise<void> {
  await globalThis.services.db
    .delete(CLI_TOKENS_TBL)
    .where(
      and(
        eq(CLI_TOKENS_TBL.userId, userId),
        lt(CLI_TOKENS_TBL.expiresAt, new Date()),
      ),
    );
}
```

## Testing
- ✅ CLI lint passes
- ✅ Web lint passes
- ✅ Follows project "Avoid Defensive Programming" guidelines

## Release Impact
This PR contains `fix:` commits for both CLI and Web packages:
- **CLI**: 0.11.2 → 0.11.3
- **Web**: 0.37.0 → 0.37.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)