### PR TITLE
fix(e2b): update cli versions and add command logging

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -4,10 +4,10 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y git curl
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code@2.0.13
+RUN npm install -g @anthropic-ai/claude-code@2.0.14
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.11.2
+RUN npm install -g @uspark/cli@0.11.3
 
 # Verify installations
 RUN claude --version

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -180,7 +180,7 @@ export class E2BExecutor {
 
     // Pull all project files using uspark CLI
     const result = await sandbox.commands.run(
-      `uspark pull --all --project-id ${projectId} --verbose`,
+      `uspark pull --all --project-id ${projectId} --verbose 2>&1 | tee /tmp/pull.log`,
     );
 
     // Always log the output for debugging
@@ -264,7 +264,7 @@ export class E2BExecutor {
     await sandbox.files.write(promptFile, prompt);
 
     // Pipeline: prompt → claude (skip permissions) → watch-claude (sync files + callback API)
-    const command = `cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId}`;
+    const command = `cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
 
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -180,7 +180,7 @@ export class E2BExecutor {
 
     // Pull all project files using uspark CLI
     const result = await sandbox.commands.run(
-      `uspark pull --all --project-id ${projectId} --verbose 2>&1 | tee /tmp/pull.log`,
+      `uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
     );
 
     // Always log the output for debugging


### PR DESCRIPTION
## Summary
- Update Claude Code CLI from 2.0.13 to 2.0.14
- Update uspark CLI from 0.11.2 to 0.11.3 (includes --turn-id support)
- Add logging to pull and exec commands for better debugging

## Changes
This PR updates the E2B Docker image to use the latest CLI versions and adds command logging for better observability.

### Dockerfile Updates
- **Claude Code CLI**: 2.0.13 → 2.0.14 (latest version)
- **uspark CLI**: 0.11.2 → 0.11.3 (includes --turn-id and --session-id support for watch-claude)

### E2B Executor Enhancements
- Added command logging with `tee` for pull and exec operations
- Logs are saved to `/tmp/pull.log` and `/tmp/claude_exec.log` in the sandbox for debugging

## Why
The uspark CLI 0.11.3 includes support for `--turn-id` and `--session-id` flags which are required by the watch-claude command. Without this update, sandbox execution fails with "unknown option --turn-id" error.

## Test Plan
- [ ] Build and deploy new E2B template
- [ ] Test sandbox creation with new CLI versions
- [ ] Verify watch-claude command works with turn-id and session-id flags
- [ ] Check that logs are properly written to /tmp files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved execution logging: stdout and stderr are now captured and mirrored to persistent log files to aid troubleshooting while preserving normal console output.

- **Chores**
  - Updated global tooling to latest patch releases (claude-code and uspark) for improved stability and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## EntelligenceAI PR Summary 
 This PR updates npm dependencies in the Dockerfile and improves logging in the E2BExecutor class.
- Updated @anthropic-ai/claude-code from v2.0.13 to v2.0.14 and @uspark/cli from v0.11.2 to v0.11.3
- Added logging to /tmp/pull.log for uspark pull command output
- Added logging to /tmp/claude_exec.log for Claude AI execution output
- Used tee command to maintain console output while capturing logs 

