### PR TITLE
fix(e2b): fix workspace directory permissions and execution context

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -13,12 +13,19 @@ RUN npm install -g @uspark/cli@0.11.3
 RUN claude --version
 RUN uspark --version
 
-# Create workspace directory
-WORKDIR /workspace
+# Create workspace directory with proper permissions
+# E2B runs as user 'user' (uid 1000), so we need to set ownership
+RUN mkdir -p /workspace && chown -R 1000:1000 /workspace
 
 # Add initialization script
 COPY init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
+
+# Switch to non-root user
+USER 1000
+
+# Set working directory
+WORKDIR /workspace
 
 # Set entrypoint to initialization script
 ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/e2b/init.sh
+++ b/e2b/init.sh
@@ -8,7 +8,7 @@ if [ ! -w /workspace ]; then
   echo "⚠️ Warning: /workspace is not writable, attempting to fix permissions..."
   # Try to fix permissions if running as root or with sudo
   if [ "$EUID" -eq 0 ] || sudo -n true 2>/dev/null; then
-    sudo chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true
+    sudo chown -R "$(id -u):$(id -g)" /workspace 2>/dev/null || true
   fi
 fi
 

--- a/e2b/init.sh
+++ b/e2b/init.sh
@@ -3,6 +3,15 @@ set -e
 
 echo "🚀 Initializing E2B container for Claude Code execution..."
 
+# Ensure workspace directory exists and is writable
+if [ ! -w /workspace ]; then
+  echo "⚠️ Warning: /workspace is not writable, attempting to fix permissions..."
+  # Try to fix permissions if running as root or with sudo
+  if [ "$EUID" -eq 0 ] || sudo -n true 2>/dev/null; then
+    sudo chown -R $(id -u):$(id -g) /workspace 2>/dev/null || true
+  fi
+fi
+
 # Verify required environment variables
 if [ -z "$PROJECT_ID" ]; then
   echo "❌ Error: PROJECT_ID environment variable is required"
@@ -14,26 +23,16 @@ if [ -z "$USPARK_TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$CLAUDE_API_KEY" ]; then
-  echo "❌ Error: CLAUDE_API_KEY environment variable is required"
+if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+  echo "❌ Error: CLAUDE_CODE_OAUTH_TOKEN environment variable is required"
   exit 1
 fi
 
 echo "✅ Environment variables validated"
 echo "📁 Project ID: $PROJECT_ID"
 
-# Pull project files from uSpark
-echo "📥 Pulling project files..."
-if uspark pull --project-id "$PROJECT_ID"; then
-  echo "✅ Project files pulled successfully"
-else
-  echo "❌ Failed to pull project files"
-  exit 1
-fi
-
-# List pulled files for verification
-echo "📋 Project files:"
-find /workspace -type f -name "*.md" | head -10
+# Note: Project files will be pulled by the E2B executor
+# This init script just validates the environment
 
 echo "🎯 Container initialized successfully. Ready for Claude Code execution."
 

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -178,9 +178,9 @@ export class E2BExecutor {
   ): Promise<void> {
     console.log(`Initializing sandbox for project ${projectId}`);
 
-    // Pull all project files using uspark CLI
+    // Pull all project files using uspark CLI in /workspace directory
     const result = await sandbox.commands.run(
-      `uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
+      `cd /workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
     );
 
     // Always log the output for debugging
@@ -264,7 +264,8 @@ export class E2BExecutor {
     await sandbox.files.write(promptFile, prompt);
 
     // Pipeline: prompt → claude (skip permissions) → watch-claude (sync files + callback API)
-    const command = `cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
+    // Execute in /workspace directory where project files are located
+    const command = `cd /workspace && cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
 
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {


### PR DESCRIPTION
## Summary
- Fix /workspace directory permissions for E2B sandbox
- Execute commands in correct working directory (/workspace)
- Fix environment variable naming inconsistency
- Remove duplicate uspark pull logic

## Problem
The E2B sandbox was experiencing permission issues where the `/workspace` directory was owned by root, but the container runs as a non-root user (uid 1000). Additionally, commands were not executing in the `/workspace` directory where project files are located.

## Changes

### E2B Dockerfile (`e2b/e2b.Dockerfile`)
- Create `/workspace` directory with proper ownership (uid 1000)
- Switch to non-root user (`USER 1000`) before setting WORKDIR
- This ensures the container runs with correct permissions from the start

### Init Script (`e2b/init.sh`)
- Add runtime permission check for `/workspace` directory
- Attempt to fix permissions if directory is not writable
- Fix environment variable: `CLAUDE_API_KEY` → `CLAUDE_CODE_OAUTH_TOKEN` (matches e2b-executor.ts)
- Remove duplicate `uspark pull` execution (handled by e2b-executor.ts)

### E2B Executor (`turbo/apps/web/src/lib/e2b-executor.ts`)
- Execute `uspark pull` in `/workspace` directory: `cd /workspace && uspark pull ...`
- Execute Claude commands in `/workspace` directory: `cd /workspace && cat ... | claude ...`
- This ensures Claude Code can access project files pulled by uspark CLI

## Test Plan
- [ ] Build and deploy new E2B template
- [ ] Test sandbox creation with new permissions
- [ ] Verify `uspark pull` creates files in `/workspace` 
- [ ] Verify Claude can read/write files in `/workspace`
- [ ] Test both dev and production environments

## Related Issues
Resolves the "workspace directory owned by root" error when running Claude Code in E2B sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Container can execute provided commands on startup; otherwise remains running for interactive use.
  - Project file retrieval is delegated to the executor and runs from the workspace directory.

- **Bug Fixes**
  - All runtime operations consistently run from /workspace.
  - Added writability preflight check and automatic permission fix for /workspace.

- **Refactor**
  - Container now runs as a non-root user with working directory aligned to that user.

- **Chores**
  - Replaced CLAUDE_API_KEY with CLAUDE_CODE_OAUTH_TOKEN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->