### PR TITLE
fix(e2b): use home directory workspace to avoid permission issues

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -13,10 +13,6 @@ RUN npm install -g @uspark/cli@0.11.3
 RUN claude --version
 RUN uspark --version
 
-# Create workspace directory with proper permissions
-# E2B runs as user 'user' (uid 1000), so we need to set ownership
-RUN mkdir -p /workspace && chown -R 1000:1000 /workspace
-
 # Add initialization script
 COPY init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
@@ -24,8 +20,11 @@ RUN chmod +x /usr/local/bin/init.sh
 # Switch to non-root user
 USER 1000
 
-# Set working directory
-WORKDIR /workspace
+# Create workspace in home directory (guaranteed writable)
+RUN mkdir -p $HOME/workspace
+
+# Set working directory to user's home workspace
+WORKDIR /home/user/workspace
 
 # Set entrypoint to initialization script
 ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/e2b/init.sh
+++ b/e2b/init.sh
@@ -3,14 +3,24 @@ set -e
 
 echo "🚀 Initializing E2B container for Claude Code execution..."
 
-# Ensure workspace directory exists and is writable
-if [ ! -w /workspace ]; then
-  echo "⚠️ Warning: /workspace is not writable, attempting to fix permissions..."
-  # Try to fix permissions if running as root or with sudo
-  if [ "$EUID" -eq 0 ] || sudo -n true 2>/dev/null; then
-    sudo chown -R "$(id -u):$(id -g)" /workspace 2>/dev/null || true
-  fi
+# Use workspace in home directory (always writable for current user)
+WORKSPACE_DIR="$HOME/workspace"
+echo "📁 Using workspace directory: $WORKSPACE_DIR"
+
+# Ensure workspace directory exists
+if [ ! -d "$WORKSPACE_DIR" ]; then
+  echo "⚠️ Creating workspace directory..."
+  mkdir -p "$WORKSPACE_DIR"
 fi
+
+# Verify workspace is writable
+if [ ! -w "$WORKSPACE_DIR" ]; then
+  echo "❌ Error: Workspace directory $WORKSPACE_DIR is not writable!"
+  ls -la "$WORKSPACE_DIR"
+  exit 1
+fi
+
+echo "✅ Workspace is ready at $WORKSPACE_DIR"
 
 # Verify required environment variables
 if [ -z "$PROJECT_ID" ]; then

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -178,9 +178,9 @@ export class E2BExecutor {
   ): Promise<void> {
     console.log(`Initializing sandbox for project ${projectId}`);
 
-    // Pull all project files using uspark CLI in /workspace directory
+    // Pull all project files using uspark CLI in home workspace directory
     const result = await sandbox.commands.run(
-      `cd /workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
+      `cd ~/workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
     );
 
     // Always log the output for debugging
@@ -264,8 +264,8 @@ export class E2BExecutor {
     await sandbox.files.write(promptFile, prompt);
 
     // Pipeline: prompt → claude (skip permissions) → watch-claude (sync files + callback API)
-    // Execute in /workspace directory where project files are located
-    const command = `cd /workspace && cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
+    // Execute in ~/workspace directory where project files are located
+    const command = `cd ~/workspace && cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
 
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {


### PR DESCRIPTION
## Summary
- Change workspace from `/workspace` to `~/workspace` (`/home/user/workspace`)
- Fixes `EACCES: permission denied` errors when writing files

## Problem
The previous fix (#474) tried to set permissions on `/workspace` but E2B still had permission issues when the CLI tried to write files. The error was:
```
Error: EACCES: permission denied, open 'test-time.md'
```

## Root Cause
Using a root-level directory (`/workspace`) requires complex permission management and can be overridden by E2B's runtime. User home directories are guaranteed to be writable by the current user.

## Solution
Use the user's home directory for the workspace:
- **E2B Dockerfile**: Create workspace at `$HOME/workspace` after switching to USER 1000
- **init.sh**: Use `$HOME/workspace` and verify it's writable
- **e2b-executor.ts**: Execute all commands with `cd ~/workspace`

## Changes

### E2B Dockerfile (`e2b/e2b.Dockerfile`)
- Remove `/workspace` creation logic
- Create `$HOME/workspace` after switching to USER 1000
- Set WORKDIR to `/home/user/workspace`

### Init Script (`e2b/init.sh`)
- Use `$HOME/workspace` variable
- Simplified permission checks (no sudo needed)
- Verify workspace is writable before proceeding

### E2B Executor (`turbo/apps/web/src/lib/e2b-executor.ts`)
- `uspark pull`: `cd ~/workspace && uspark pull ...`
- `claude`: `cd ~/workspace && ... | claude ...`

## Benefits
- ✅ No permission errors - home directory is always writable
- ✅ Simpler implementation - no sudo or chown needed
- ✅ More reliable - follows Unix conventions

## Test Plan
- [ ] Build and deploy new E2B template
- [ ] Test `uspark pull` - should write files successfully
- [ ] Test Claude execution - should read/write files in workspace
- [ ] Verify no permission errors

## Related
- Supersedes #474 (previous permission fix attempt)
- Fixes the `EACCES: permission denied` error reported after #474 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace now defaults to ~/workspace, ensuring a writable environment and smoother startup.
  * Prevents permission issues previously seen with /workspace in some environments.
  * Updated initialization checks and messages for clearer errors if the directory isn’t writable.
  * Aligned all execution paths to the new workspace location; no changes to user commands or behavior beyond the default path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->