### PR TITLE
fix(e2b): use home directory workspace to avoid permission issues

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -13,10 +13,6 @@ RUN npm install -g @uspark/cli@0.11.3
 RUN claude --version
 RUN uspark --version
 
-# Create workspace directory with proper permissions
-# E2B runs as user 'user' (uid 1000), so we need to set ownership
-RUN mkdir -p /workspace && chown -R 1000:1000 /workspace
-
 # Add initialization script
 COPY init.sh /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/init.sh
@@ -24,8 +20,11 @@ RUN chmod +x /usr/local/bin/init.sh
 # Switch to non-root user
 USER 1000
 
-# Set working directory
-WORKDIR /workspace
+# Create workspace in home directory (guaranteed writable)
+RUN mkdir -p $HOME/workspace
+
+# Set working directory to user's home workspace
+WORKDIR /home/user/workspace
 
 # Set entrypoint to initialization script
 ENTRYPOINT ["/usr/local/bin/init.sh"]

--- a/e2b/init.sh
+++ b/e2b/init.sh
@@ -3,14 +3,24 @@ set -e
 
 echo "🚀 Initializing E2B container for Claude Code execution..."
 
-# Ensure workspace directory exists and is writable
-if [ ! -w /workspace ]; then
-  echo "⚠️ Warning: /workspace is not writable, attempting to fix permissions..."
-  # Try to fix permissions if running as root or with sudo
-  if [ "$EUID" -eq 0 ] || sudo -n true 2>/dev/null; then
-    sudo chown -R "$(id -u):$(id -g)" /workspace 2>/dev/null || true
-  fi
+# Use workspace in home directory (always writable for current user)
+WORKSPACE_DIR="$HOME/workspace"
+echo "📁 Using workspace directory: $WORKSPACE_DIR"
+
+# Ensure workspace directory exists
+if [ ! -d "$WORKSPACE_DIR" ]; then
+  echo "⚠️ Creating workspace directory..."
+  mkdir -p "$WORKSPACE_DIR"
 fi
+
+# Verify workspace is writable
+if [ ! -w "$WORKSPACE_DIR" ]; then
+  echo "❌ Error: Workspace directory $WORKSPACE_DIR is not writable!"
+  ls -la "$WORKSPACE_DIR"
+  exit 1
+fi
+
+echo "✅ Workspace is ready at $WORKSPACE_DIR"
 
 # Verify required environment variables
 if [ -z "$PROJECT_ID" ]; then

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.test.ts
@@ -3,12 +3,11 @@ import "../../../../../../../../../src/test/setup";
 import { NextRequest } from "next/server";
 import { POST } from "./route";
 import { POST as createProject } from "../../../../../../route";
+import { DELETE as deleteProject } from "../../../../../route";
 import { POST as createSession } from "../../../../route";
 import { POST as createTurn } from "../../route";
 import { initServices } from "../../../../../../../../../src/lib/init-services";
-import { PROJECTS_TBL } from "../../../../../../../../../src/db/schema/projects";
 import {
-  SESSIONS_TBL,
   TURNS_TBL,
   BLOCKS_TBL,
 } from "../../../../../../../../../src/db/schema/sessions";
@@ -116,7 +115,10 @@ async function createTestTurnContext(userId: string, cliToken: string) {
   const sessionData = await sessionResponse.json();
   const sessionId = sessionData.id;
 
-  // Add Claude token (no API endpoint, direct DB acceptable)
+  // NOTE: Direct DB operation for Claude token
+  // Exception justified: No public API exists for token management (security sensitive).
+  // Creating APIs just for tests violates YAGNI and could expose security risks.
+  // This is authentication setup, not business logic testing.
   await globalThis.services.db
     .insert(CLAUDE_TOKENS_TBL)
     .values({
@@ -143,7 +145,10 @@ async function createTestTurnContext(userId: string, cliToken: string) {
   const turnData = await turnResponse.json();
   const turnId = turnData.id;
 
-  // Create CLI token (no API endpoint, direct DB acceptable)
+  // NOTE: Direct DB operation for CLI token
+  // Exception justified: No public API exists for token management (security sensitive).
+  // Creating APIs just for tests violates YAGNI and could expose security risks.
+  // This is authentication setup, not business logic testing.
   const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
   await globalThis.services.db
     .insert(CLI_TOKENS_TBL)
@@ -182,16 +187,16 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns/:turnId/on-claude-s
   });
 
   afterEach(async () => {
-    // Clean up in correct order (sessions -> project)
-    // Note: turns and blocks cascade delete from sessions
-    await globalThis.services.db
-      .delete(SESSIONS_TBL)
-      .where(eq(SESSIONS_TBL.id, sessionId));
-    await globalThis.services.db
-      .delete(PROJECTS_TBL)
-      .where(eq(PROJECTS_TBL.id, projectId));
+    // Clean up project via DELETE API (cascades to sessions, turns, blocks)
+    const deleteRequest = new NextRequest("http://localhost:3000", {
+      method: "DELETE",
+    });
+    const deleteContext = { params: Promise.resolve({ projectId }) };
+    await deleteProject(deleteRequest, deleteContext);
 
-    // Clean up tokens (no cascade, must delete directly)
+    // NOTE: Direct DB operation for token cleanup
+    // Exception justified: No DELETE API exists for tokens (security sensitive).
+    // This is authentication teardown, not business logic testing.
     await globalThis.services.db
       .delete(CLI_TOKENS_TBL)
       .where(eq(CLI_TOKENS_TBL.token, cliToken));
@@ -408,5 +413,323 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns/:turnId/on-claude-s
     expect(response.status).toBe(401);
     const data = await response.json();
     expect(data.error).toBe("unauthorized");
+  });
+
+  it("should process complete Claude Code execution flow", async () => {
+    const context = {
+      params: Promise.resolve({ projectId, sessionId, turnId }),
+    };
+
+    // 1. System init message (should be skipped - no block created)
+    const systemInit = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      cwd: "/home/user/workspace",
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      tools: [
+        "Task",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "BashOutput",
+        "KillShell",
+        "SlashCommand",
+      ],
+      mcp_servers: [],
+      model: "claude-sonnet-4-5-20250929",
+      permissionMode: "bypassPermissions",
+      slash_commands: [
+        "compact",
+        "context",
+        "cost",
+        "init",
+        "output-style:new",
+        "pr-comments",
+        "release-notes",
+        "todos",
+        "review",
+        "security-review",
+      ],
+      apiKeySource: "none",
+      output_style: "default",
+      agents: ["general-purpose", "statusline-setup", "output-style-setup"],
+      uuid: "36c6e251-9909-4d40-837e-ad581282f8db",
+    });
+    const req1 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: systemInit }),
+    });
+    const res1 = await POST(req1, context);
+    expect(res1.status).toBe(200);
+
+    // 2. Assistant message with text content
+    const assistantText = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-sonnet-4-5-20250929",
+        id: "msg_01EwmJfbTp8b38ZoYcnRimVz",
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "I'll list the files in the current working directory.",
+          },
+        ],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 3,
+          cache_creation_input_tokens: 8439,
+          cache_read_input_tokens: 5432,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 8439,
+            ephemeral_1h_input_tokens: 0,
+          },
+          output_tokens: 3,
+          service_tier: "standard",
+        },
+      },
+      parent_tool_use_id: null,
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      uuid: "1e843266-09b6-431e-b3f5-e206c9bbbf46",
+    });
+    const req2 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: assistantText }),
+    });
+    const res2 = await POST(req2, context);
+    expect(res2.status).toBe(200);
+
+    // 3. Assistant message with tool_use (Bash command)
+    const assistantToolUse = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-sonnet-4-5-20250929",
+        id: "msg_01EwmJfbTp8b38ZoYcnRimVz",
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_01Cy4woYq9zaAz56Uz79fPtv",
+            name: "Bash",
+            input: {
+              command: "ls -la",
+              description: "List files in current directory",
+            },
+          },
+        ],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 3,
+          cache_creation_input_tokens: 8439,
+          cache_read_input_tokens: 5432,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 8439,
+            ephemeral_1h_input_tokens: 0,
+          },
+          output_tokens: 3,
+          service_tier: "standard",
+        },
+      },
+      parent_tool_use_id: null,
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      uuid: "b1a67cef-51e3-4f2d-8ec3-6492e8923384",
+    });
+    const req3 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: assistantToolUse }),
+    });
+    const res3 = await POST(req3, context);
+    expect(res3.status).toBe(200);
+
+    // 4. User message with tool_result (Bash output) - treated as tool_result type
+    const userToolResult = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            tool_use_id: "toolu_01Cy4woYq9zaAz56Uz79fPtv",
+            type: "tool_result",
+            content:
+              "total 124\ndrwxr-xr-x 7 user user  4096 Oct 11 18:40 .\ndrwxr-xr-x 4 user user  4096 Oct 11 18:40 ..\n-rw-r--r-- 1 user user  6162 Oct 11 18:40 .DS_Store\ndrwxr-xr-x 2 user user  4096 Oct 11 18:40 archived\n-rw-r--r-- 1 user user 11876 Oct 11 18:40 bad-smell.md",
+            is_error: false,
+          },
+        ],
+      },
+      parent_tool_use_id: null,
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      uuid: "d2b13a2e-6186-4d5b-b333-482c9ecc9200",
+    });
+    const req4 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: userToolResult }),
+    });
+    const res4 = await POST(req4, context);
+    expect(res4.status).toBe(200);
+
+    // 5. Assistant final response
+    const assistantFinal = JSON.stringify({
+      type: "assistant",
+      message: {
+        model: "claude-sonnet-4-5-20250929",
+        id: "msg_01DDzVdTupB4n58uWWHw4DZL",
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "The workspace contains several markdown documentation files and directories:\n\n**Files:**\n- `bad-smell.md` - likely code smell documentation\n- `claude-code-output.md` - output documentation",
+          },
+        ],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 6,
+          cache_creation_input_tokens: 681,
+          cache_read_input_tokens: 13871,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 681,
+            ephemeral_1h_input_tokens: 0,
+          },
+          output_tokens: 1,
+          service_tier: "standard",
+        },
+      },
+      parent_tool_use_id: null,
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      uuid: "f4b84afe-c7d3-4dae-b4fb-2e4133e6b0db",
+    });
+    const req5 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: assistantFinal }),
+    });
+    const res5 = await POST(req5, context);
+    expect(res5.status).toBe(200);
+
+    // 6. Result message (should mark turn as completed)
+    const resultMessage = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 9896,
+      duration_api_ms: 10858,
+      num_turns: 4,
+      result:
+        "The workspace contains several markdown documentation files and directories...",
+      session_id: "d75cbfa8-1d13-48b8-938f-694df2fd296d",
+      total_cost_usd: 0.044974099999999996,
+      usage: {
+        input_tokens: 9,
+        cache_creation_input_tokens: 9120,
+        cache_read_input_tokens: 19303,
+        output_tokens: 275,
+        server_tool_use: {
+          web_search_requests: 0,
+        },
+        service_tier: "standard",
+        cache_creation: {
+          ephemeral_1h_input_tokens: 0,
+          ephemeral_5m_input_tokens: 9120,
+        },
+      },
+      modelUsage: {
+        "claude-sonnet-4-5-20250929": {
+          inputTokens: 9,
+          outputTokens: 275,
+          cacheReadInputTokens: 19303,
+          cacheCreationInputTokens: 9120,
+          webSearchRequests: 0,
+          costUSD: 0.0441429,
+          contextWindow: 200000,
+        },
+        "claude-3-5-haiku-20241022": {
+          inputTokens: 879,
+          outputTokens: 32,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+          webSearchRequests: 0,
+          costUSD: 0.0008312,
+          contextWindow: 200000,
+        },
+      },
+      permission_denials: [],
+      uuid: "78c4034f-cf55-4d3a-a1ee-780dea285000",
+    });
+    const req6 = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ line: resultMessage }),
+    });
+    const res6 = await POST(req6, context);
+    expect(res6.status).toBe(200);
+
+    // Verify all blocks were created with correct sequence numbers
+    const blocks = await globalThis.services.db
+      .select()
+      .from(BLOCKS_TBL)
+      .where(eq(BLOCKS_TBL.turnId, turnId))
+      .orderBy(BLOCKS_TBL.sequenceNumber);
+
+    // Should have 4 blocks now (system init and result are skipped)
+    // Block 0: assistant text content
+    // Block 1: assistant tool_use
+    // Block 2: user tool_result
+    // Block 3: assistant final response
+    expect(blocks).toHaveLength(4);
+
+    // Verify first block (text content)
+    expect(blocks[0]!.type).toBe("content");
+    expect(blocks[0]!.content).toMatchObject({
+      text: "I'll list the files in the current working directory.",
+    });
+    expect(blocks[0]!.sequenceNumber).toBe(0);
+
+    // Verify second block (tool_use)
+    expect(blocks[1]!.type).toBe("tool_use");
+    expect(blocks[1]!.content).toMatchObject({
+      tool_name: "Bash",
+      tool_use_id: "toolu_01Cy4woYq9zaAz56Uz79fPtv",
+      parameters: {
+        command: "ls -la",
+        description: "List files in current directory",
+      },
+    });
+    expect(blocks[1]!.sequenceNumber).toBe(1);
+
+    // Verify third block (tool_result from user message)
+    expect(blocks[2]!.type).toBe("tool_result");
+    expect(blocks[2]!.content).toMatchObject({
+      tool_use_id: "toolu_01Cy4woYq9zaAz56Uz79fPtv",
+      error: null,
+    });
+    expect(blocks[2]!.content.result).toContain("total 124");
+    expect(blocks[2]!.sequenceNumber).toBe(2);
+
+    // Verify fourth block (final response)
+    expect(blocks[3]!.type).toBe("content");
+    expect(blocks[3]!.content.text).toContain(
+      "The workspace contains several markdown",
+    );
+    expect(blocks[3]!.sequenceNumber).toBe(3);
+
+    // Verify turn was marked as completed
+    const [turn] = await globalThis.services.db
+      .select()
+      .from(TURNS_TBL)
+      .where(eq(TURNS_TBL.id, turnId));
+
+    expect(turn!.status).toBe("completed");
+    expect(turn!.completedAt).not.toBeNull();
   });
 });

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
@@ -193,6 +193,24 @@ async function saveBlock(
       // Skip unknown assistant content types
       return;
     }
+  } else if (blockData.type === "user") {
+    // User message with tool results
+    const message = blockData.message as {
+      content?: Array<Record<string, unknown>>;
+    };
+    const content = message?.content?.[0];
+
+    if (content?.type === "tool_result") {
+      blockType = "tool_result";
+      blockContent = {
+        tool_use_id: content.tool_use_id as string,
+        result: content.content,
+        error: content.is_error ? content.content : null,
+      };
+    } else {
+      // Skip unknown user content types
+      return;
+    }
   } else if (blockData.type === "tool_result") {
     // Tool execution result
     blockType = "tool_result";

--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -178,9 +178,9 @@ export class E2BExecutor {
   ): Promise<void> {
     console.log(`Initializing sandbox for project ${projectId}`);
 
-    // Pull all project files using uspark CLI in /workspace directory
+    // Pull all project files using uspark CLI in home workspace directory
     const result = await sandbox.commands.run(
-      `cd /workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
+      `cd ~/workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
     );
 
     // Always log the output for debugging
@@ -264,8 +264,8 @@ export class E2BExecutor {
     await sandbox.files.write(promptFile, prompt);
 
     // Pipeline: prompt → claude (skip permissions) → watch-claude (sync files + callback API)
-    // Execute in /workspace directory where project files are located
-    const command = `cd /workspace && cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
+    // Execute in ~/workspace directory where project files are located
+    const command = `cd ~/workspace && cat "${promptFile}" | claude --print --verbose --output-format stream-json --dangerously-skip-permissions | uspark watch-claude --project-id ${effectiveProjectId} --turn-id ${effectiveTurnId} --session-id ${effectiveSessionId} 2>&1 | tee /tmp/claude_exec.log`;
 
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {


### PR DESCRIPTION
## Summary
- Fix E2B workspace permission issues by using home directory instead of /workspace
- Improve test quality and API usage in on-claude-stdout tests

## Changes

### E2B Workspace Fix
- Change workspace from `/workspace` to `~/workspace` (user's HOME directory)
- Guaranteed writable by the current user without sudo/chmod
- Fixes `EACCES: permission denied` errors when uspark pull writes files

### Test Quality Improvements  
- Replace direct database operations with DELETE API for project cleanup
- Add comprehensive test for complete Claude Code execution flow
- Document justified exceptions for token management (security-sensitive)
- Fix bad-smell.md violations following Section 12 guidelines

## Test plan
- [x] All tests passing (7/7 tests in route.test.ts)
- [x] Pre-commit hooks passing (prettier, lint, knip, commitlint)
- [x] E2B workspace operations work without permission errors
- [x] Token management properly isolated with clear justifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Capture and persist tool results submitted within user messages, ensuring they appear in the correct order in session turns.
- Improvements
  - Standardized the workspace to a writable directory in the user’s home for more reliable execution.
  - Initialization and execution now run in the home-based workspace with clearer startup status messages.
- Tests
  - Expanded end-to-end coverage for a full execution flow, validating block sequencing and turn completion.
  - Test cleanup now uses the public API for project deletion; sensitive token cleanup remains restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->