### PR TITLE
fix(e2b): disable timeout for sandbox command execution

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -181,6 +181,7 @@ export class E2BExecutor {
     // Pull all project files using uspark CLI in home workspace directory
     const result = await sandbox.commands.run(
       `cd ~/workspace && uspark pull --all --project-id "${projectId}" --verbose 2>&1 | tee /tmp/pull.log`,
+      { timeoutMs: 0 },
     );
 
     // Always log the output for debugging
@@ -270,15 +271,7 @@ export class E2BExecutor {
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {
       background: true,
-      onStdout: (data: string) => {
-        console.log(
-          `[Turn ${effectiveTurnId}] stdout:`,
-          data.substring(0, 100),
-        );
-      },
-      onStderr: (data: string) => {
-        console.error(`[Turn ${effectiveTurnId}] stderr:`, data);
-      },
+      timeoutMs: 0,
     });
 
     // Clean up prompt file


### PR DESCRIPTION
## Summary

- Set `timeoutMs: 0` for `commands.run()` in both `initializeSandbox` and `executeClaude` methods to disable the default 60-second timeout
- Remove unused `onStdout` and `onStderr` callbacks from claude command execution
- Fixes timeout errors (TIMEOUT_ERR: 23) that occurred when `uspark pull` or `claude` execution took longer than 60 seconds

## Changes

1. **initializeSandbox** (line 184): Added `{ timeoutMs: 0 }` to allow unlimited time for `uspark pull --all` to complete
2. **executeClaude** (line 272-275): 
   - Added `timeoutMs: 0` to allow unlimited time for claude execution
   - Removed `onStdout` and `onStderr` callbacks (not needed for background execution)

## Technical Details

E2B SDK's `commands.run()` has a default timeout of 60 seconds. For long-running operations like:
- Pulling large projects with `uspark pull`
- Extended Claude Code execution sessions

The default timeout was causing premature termination. Setting `timeoutMs: 0` allows these commands to run as long as needed, constrained only by the sandbox lifetime (30 minutes).

## Test plan

- [ ] Test with a project that has many files (takes >60s to pull)
- [ ] Test with a complex Claude prompt that takes >60s to execute
- [ ] Verify sandbox still terminates after 30 minutes (sandbox lifetime timeout)
- [ ] Verify error handling still works for actual command failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)