### PR TITLE
chore(e2b): update uspark cli from 0.11.3 to 0.11.4

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y git curl
 RUN npm install -g @anthropic-ai/claude-code@2.0.14
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.11.3
+RUN npm install -g @uspark/cli@0.11.4
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary
- Update `@uspark/cli` from version 0.11.3 to 0.11.4 in E2B Dockerfile
- `@anthropic-ai/claude-code` remains at latest version 2.0.14

## Test plan
- [ ] Verify Dockerfile builds successfully
- [ ] Test E2B sandbox initialization with updated CLI version
- [ ] Confirm `uspark --version` returns 0.11.4 in the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)