### PR TITLE
fix(ci): improve deployment cleanup to match all preview environments

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -29,15 +29,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Get all deployments for this PR
-            const deployments = await github.rest.repos.listDeployments({
+            const branchName = context.payload.pull_request.head.ref;
+            const sha = context.payload.pull_request.head.sha;
+
+            console.log(`Cleaning up deployments for branch: ${branchName}, sha: ${sha}`);
+
+            // Get all deployments and filter by branch name
+            const allDeployments = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha
+              per_page: 100
             });
 
+            // Filter deployments that belong to this branch
+            const branchDeployments = allDeployments.data.filter(deployment => {
+              // Match by ref or environment name containing branch
+              return deployment.ref === branchName ||
+                     deployment.ref === `refs/heads/${branchName}` ||
+                     deployment.ref === sha ||
+                     deployment.environment?.includes(`preview/${branchName}`);
+            });
+
+            console.log(`Found ${branchDeployments.length} deployments to clean up`);
+
             // Mark each deployment as inactive
-            for (const deployment of deployments.data) {
+            for (const deployment of branchDeployments) {
+              console.log(`Marking deployment ${deployment.id} (${deployment.environment}) as inactive`);
               await github.rest.repos.createDeploymentStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Improves the deployment cleanup workflow to properly clean up all preview environment deployments when a PR is closed or merged.

**Problem:**
- Previously, the cleanup only searched for deployments by commit SHA
- Many deployments using branch refs or environment names were not found and remained active
- This left orphaned deployment records in GitHub

**Solution:**
- Fetch all deployments and filter by multiple criteria
- Match deployments by:
  - Branch name (e.g., `fix/projects-ui-improvements`)
  - Full ref (e.g., `refs/heads/fix/projects-ui-improvements`)
  - Commit SHA
  - Environment name patterns (e.g., `preview/fix/projects-ui-improvements`)
- Add logging for better debugging and transparency

**Impact:**
- All preview deployments (web, docs, workspace, neon) are now properly cleaned up
- No more orphaned deployment records
- Better visibility into cleanup process through logs

## Test plan

- [ ] Create a test PR with preview deployments
- [ ] Close/merge the PR
- [ ] Verify all preview deployments are marked as inactive
- [ ] Check GitHub Actions logs for cleanup messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)