### PR TITLE
feat: add project name field with unique constraint per user

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -131,7 +131,7 @@ describe("/api/projects/[projectId]/github/sync", () => {
       // Insert test data into real database
       await db.insert(PROJECTS_TBL).values({
         id: projectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData,
         version: 0,
@@ -180,7 +180,7 @@ describe("/api/projects/[projectId]/github/sync", () => {
 
       await db.insert(PROJECTS_TBL).values({
         id: projectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData,
         version: 0,

--- a/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/github/sync/route.test.ts
@@ -131,6 +131,7 @@ describe("/api/projects/[projectId]/github/sync", () => {
       // Insert test data into real database
       await db.insert(PROJECTS_TBL).values({
         id: projectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData,
         version: 0,
@@ -179,6 +180,7 @@ describe("/api/projects/[projectId]/github/sync", () => {
 
       await db.insert(PROJECTS_TBL).values({
         id: projectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData,
         version: 0,

--- a/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.test.ts
@@ -84,7 +84,7 @@ describe("/api/projects/:projectId", () => {
       // Create a project using API endpoint first
       const createRequest = new NextRequest("http://localhost:3000", {
         method: "POST",
-        body: JSON.stringify({ name: "test-project" }),
+        body: JSON.stringify({ name: `test-project-existing-${Date.now()}` }),
       });
       const createResponse = await createProject(createRequest);
       const createdProject = await createResponse.json();
@@ -128,7 +128,7 @@ describe("/api/projects/:projectId", () => {
       // Create initial project using API endpoint
       const createRequest = new NextRequest("http://localhost:3000", {
         method: "POST",
-        body: JSON.stringify({ name: "test-project" }),
+        body: JSON.stringify({ name: `test-project-update-${Date.now()}` }),
       });
       const createResponse = await createProject(createRequest);
       const createdProject = await createResponse.json();
@@ -198,7 +198,7 @@ describe("/api/projects/:projectId", () => {
       // Create project using API endpoint
       const createRequest = new NextRequest("http://localhost:3000", {
         method: "POST",
-        body: JSON.stringify({ name: "test-project" }),
+        body: JSON.stringify({ name: `test-project-conflict-${Date.now()}` }),
       });
       const createResponse = await createProject(createRequest);
       const createdProject = await createResponse.json();
@@ -234,7 +234,7 @@ describe("/api/projects/:projectId", () => {
       // Create initial project using API endpoint
       const createRequest = new NextRequest("http://localhost:3000", {
         method: "POST",
-        body: JSON.stringify({ name: "test-project" }),
+        body: JSON.stringify({ name: `test-project-concurrent-${Date.now()}` }),
       });
       const createResponse = await createProject(createRequest);
       const createdProject = await createResponse.json();

--- a/turbo/apps/web/app/api/projects/[projectId]/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/route.ts
@@ -53,6 +53,7 @@ export async function GET(
     // Store in database
     await globalThis.services.db.insert(PROJECTS_TBL).values({
       id: projectId,
+      name: projectId,
       userId,
       ydocData: base64Data,
       version: 0,

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/route.test.ts
@@ -44,7 +44,7 @@ describe("/api/projects/:projectId/sessions/:sessionId", () => {
     // Create test project using API
     const createProjectRequest = new NextRequest("http://localhost:3000", {
       method: "POST",
-      body: JSON.stringify({ name: "Test Project" }),
+      body: JSON.stringify({ name: `Test Project ${Date.now()}` }),
     });
     const projectResponse = await createProject(createProjectRequest);
     expect(projectResponse.status).toBe(201);

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.test.ts
@@ -94,7 +94,7 @@ async function createTestTurnContext(userId: string, cliToken: string) {
   mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
   const createProjectRequest = new NextRequest("http://localhost:3000", {
     method: "POST",
-    body: JSON.stringify({ name: "Test Project" }),
+    body: JSON.stringify({ name: `Test Project ${Date.now()}` }),
   });
   const projectResponse = await createProject(createProjectRequest);
   expect(projectResponse.status).toBe(201);

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/route.test.ts
@@ -53,7 +53,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns", () => {
     // Create test project using API
     const createProjectRequest = new NextRequest("http://localhost:3000", {
       method: "POST",
-      body: JSON.stringify({ name: "Test Project" }),
+      body: JSON.stringify({ name: `Test Project ${Date.now()}` }),
     });
     const projectResponse = await createProject(createProjectRequest);
     expect(projectResponse.status).toBe(201);

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
@@ -67,7 +67,7 @@ describe("Claude Session Management API Integration", () => {
       createProject,
       "POST",
       {},
-      { name: "Test Project" },
+      { name: `Test Project ${Date.now()}` },
     );
     expect(projectResponse.status).toBe(201);
     projectId = projectResponse.data.id;

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/route.api.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/route.api.test.ts
@@ -26,7 +26,7 @@ describe("/api/projects/:projectId/sessions - API Tests", () => {
       createProject,
       "POST",
       {},
-      { name: "Test Project for Sessions" },
+      { name: `Test Project for Sessions ${Date.now()}` },
     );
     expect(projectResponse.status).toBe(201);
     projectId = projectResponse.data.id;

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/route.test.ts
@@ -23,12 +23,12 @@ describe("/api/projects/:projectId/sessions", () => {
     // Mock successful authentication by default
     mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
 
-    // Create test project using API
+    // Create test project using API with unique name
     const projectResponse = await apiCall(
       createProject,
       "POST",
       {},
-      { name: "Test Project for Sessions" },
+      { name: `Test Project for Sessions ${Date.now()}` },
     );
     expect(projectResponse.status).toBe(201);
     projectId = projectResponse.data.id;
@@ -182,7 +182,7 @@ describe("/api/projects/:projectId/sessions", () => {
         createProject,
         "POST",
         {},
-        { name: "Other Test Project" },
+        { name: `Other Test Project ${Date.now()}` },
       );
       expect(otherProjectResponse.status).toBe(201);
       const otherProjectId = otherProjectResponse.data.id;

--- a/turbo/apps/web/app/api/projects/route.ts
+++ b/turbo/apps/web/app/api/projects/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
   const projectsData = await globalThis.services.db
     .select({
       id: PROJECTS_TBL.id,
-      name: PROJECTS_TBL.id, // Using id as name for now, could add a name field later
+      name: PROJECTS_TBL.name,
       created_at: PROJECTS_TBL.createdAt,
       updated_at: PROJECTS_TBL.updatedAt,
       source_repo_url: PROJECTS_TBL.sourceRepoUrl,
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { sourceRepoUrl, installationId } = parseResult.data;
+  const { name, sourceRepoUrl, installationId } = parseResult.data;
 
   // Validate installation access if source repo is provided
   if (sourceRepoUrl && installationId) {
@@ -94,9 +94,6 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Note: We validate the name but don't use it in the ID generation
-  // The project ID is system-generated to ensure uniqueness
-
   // Generate a secure, unique project ID using UUID v4
   const projectId = randomUUID();
 
@@ -106,22 +103,38 @@ export async function POST(request: NextRequest) {
   const base64Data = Buffer.from(state).toString("base64");
 
   // Insert project into database
-  const [newProjectData] = await globalThis.services.db
-    .insert(PROJECTS_TBL)
-    .values({
-      id: projectId,
-      userId,
-      ydocData: base64Data,
-      version: 0,
-      sourceRepoUrl: sourceRepoUrl || null,
-      sourceRepoInstallationId: installationId || null,
-      initialScanStatus: sourceRepoUrl ? "pending" : null,
-    })
-    .returning({
-      id: PROJECTS_TBL.id,
-      name: PROJECTS_TBL.id, // Using id as name for now
-      created_at: PROJECTS_TBL.createdAt,
-    });
+  let newProjectData;
+  try {
+    [newProjectData] = await globalThis.services.db
+      .insert(PROJECTS_TBL)
+      .values({
+        id: projectId,
+        userId,
+        name,
+        ydocData: base64Data,
+        version: 0,
+        sourceRepoUrl: sourceRepoUrl || null,
+        sourceRepoInstallationId: installationId || null,
+        initialScanStatus: sourceRepoUrl ? "pending" : null,
+      })
+      .returning({
+        id: PROJECTS_TBL.id,
+        name: PROJECTS_TBL.name,
+        created_at: PROJECTS_TBL.createdAt,
+      });
+  } catch (error) {
+    // Handle unique constraint violation for duplicate project names
+    if (error instanceof Error && "code" in error && error.code === "23505") {
+      return NextResponse.json(
+        {
+          error: "duplicate_project_name",
+          error_description: `A project named "${name}" already exists. Please choose a different name.`,
+        },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
 
   if (!newProjectData) {
     throw new Error("Failed to create project");

--- a/turbo/apps/web/app/api/projects/route.ts
+++ b/turbo/apps/web/app/api/projects/route.ts
@@ -125,12 +125,9 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     // Handle unique constraint violation for duplicate project names
     // Drizzle wraps PostgreSQL errors, so check both the error and its cause
-    const errorMessage =
-      error instanceof Error ? error.message : String(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
     const causeMessage =
-      error instanceof Error && error.cause
-        ? String(error.cause)
-        : "";
+      error instanceof Error && error.cause ? String(error.cause) : "";
 
     const isUniqueConstraintError =
       errorMessage.includes("projects_user_id_name_unique") ||

--- a/turbo/apps/web/app/api/share/[token]/route.test.ts
+++ b/turbo/apps/web/app/api/share/[token]/route.test.ts
@@ -42,7 +42,7 @@ describe("/api/share/:token", () => {
         createProject,
         "POST",
         {},
-        { name: "Test Project" },
+        { name: `Test Project ${Date.now()}` },
       );
       expect(projectResponse.status).toBe(201);
       projectId = projectResponse.data.id;

--- a/turbo/apps/web/app/api/share/route.test.ts
+++ b/turbo/apps/web/app/api/share/route.test.ts
@@ -37,7 +37,7 @@ describe("/api/share", () => {
         createProject,
         "POST",
         {},
-        { name: "Test Project" },
+        { name: `Test Project ${Date.now()}` },
       );
       expect(projectResponse.status).toBe(201);
       projectId = projectResponse.data.id;

--- a/turbo/apps/web/app/api/shares/[id]/route.test.ts
+++ b/turbo/apps/web/app/api/shares/[id]/route.test.ts
@@ -68,7 +68,7 @@ describe("DELETE /api/shares/[id]", () => {
     // Create project using API
     const createProjectRequest = new NextRequest("http://localhost:3000", {
       method: "POST",
-      body: JSON.stringify({ name: "Test Project" }),
+      body: JSON.stringify({ name: `Test Project ${Date.now()}` }),
     });
     const projectResponse = await createProject(createProjectRequest);
     expect(projectResponse.status).toBe(201);
@@ -126,7 +126,7 @@ describe("DELETE /api/shares/[id]", () => {
     // Direct DB insert needed here because we need to test with a different userId
     await globalThis.services.db.insert(PROJECTS_TBL).values({
       id: projectId,
-      name: "Test Project",
+      name: `Test Project ${Date.now()}`,
       userId: otherUserId,
       ydocData: base64Data,
       version: 0,

--- a/turbo/apps/web/app/api/shares/[id]/route.test.ts
+++ b/turbo/apps/web/app/api/shares/[id]/route.test.ts
@@ -126,6 +126,7 @@ describe("DELETE /api/shares/[id]", () => {
     // Direct DB insert needed here because we need to test with a different userId
     await globalThis.services.db.insert(PROJECTS_TBL).values({
       id: projectId,
+      name: "Test Project",
       userId: otherUserId,
       ydocData: base64Data,
       version: 0,

--- a/turbo/apps/web/app/api/shares/route.test.ts
+++ b/turbo/apps/web/app/api/shares/route.test.ts
@@ -46,7 +46,7 @@ describe("GET /api/shares", () => {
       createProject,
       "POST",
       {},
-      { name: "Test Project" },
+      { name: `Test Project ${Date.now()}` },
     );
     expect(projectResponse.status).toBe(201);
     const projectId = projectResponse.data.id;

--- a/turbo/apps/web/src/db/migrations/0012_illegal_mystique.sql
+++ b/turbo/apps/web/src/db/migrations/0012_illegal_mystique.sql
@@ -1,0 +1,8 @@
+-- Add name column as nullable first
+ALTER TABLE "projects" ADD COLUMN "name" text;--> statement-breakpoint
+-- Fill existing projects with their ID as the name
+UPDATE "projects" SET "name" = "id" WHERE "name" IS NULL;--> statement-breakpoint
+-- Make name NOT NULL after filling in values
+ALTER TABLE "projects" ALTER COLUMN "name" SET NOT NULL;--> statement-breakpoint
+-- Add unique constraint on (user_id, name)
+ALTER TABLE "projects" ADD CONSTRAINT "projects_user_id_name_unique" UNIQUE("user_id","name");

--- a/turbo/apps/web/src/db/migrations/meta/0012_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,819 @@
+{
+  "id": "6c7ba245-156c-4dc5-b60e-a73a18a1335c",
+  "prevId": "abc5fd5c-b926-4ac2-91f6-de5d470b9e95",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_sessions_project_id_projects_id_fk": {
+          "name": "agent_sessions_project_id_projects_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.claude_tokens": {
+      "name": "claude_tokens",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encrypted_token": {
+          "name": "encrypted_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_repos": {
+      "name": "github_repos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_id": {
+          "name": "repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_commit_sha": {
+          "name": "last_sync_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_repos_project_id_unique": {
+          "name": "github_repos_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["project_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ydoc_data": {
+          "name": "ydoc_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_installation_id": {
+          "name": "source_repo_installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scan_status": {
+          "name": "initial_scan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_scan_session_id": {
+          "name": "initial_scan_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_user_id_name_unique": {
+          "name": "projects_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blocks_turn_id_turns_id_fk": {
+          "name": "blocks_turn_id_turns_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "turns",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocks_turn_id_sequence_number_unique": {
+          "name": "blocks_turn_id_sequence_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["turn_id", "sequence_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turns": {
+      "name": "turns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "turns_session_id_sessions_id_fk": {
+          "name": "turns_session_id_sessions_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.share_links": {
+      "name": "share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accessed_count": {
+          "name": "accessed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_share_token": {
+          "name": "idx_share_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_links_project_id_projects_id_fk": {
+          "name": "share_links_project_id_projects_id_fk",
+          "tableFrom": "share_links",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_links_token_unique": {
+          "name": "share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1760213475772,
       "tag": "0011_first_omega_flight",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1760398633991,
+      "tag": "0012_illegal_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/projects.ts
+++ b/turbo/apps/web/src/db/schema/projects.ts
@@ -1,22 +1,30 @@
-import { pgTable, text, timestamp, integer } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, integer, unique } from "drizzle-orm/pg-core";
 
 /**
  * Schema for projects with YDoc storage
  * Stores serialized YDoc data and metadata for file synchronization
  */
-export const PROJECTS_TBL = pgTable("projects", {
-  id: text("id").primaryKey().notNull(), // System-generated unique project ID (UUID v4)
-  userId: text("user_id").notNull(), // Clerk user ID or CLI token owner
-  ydocData: text("ydoc_data").notNull(), // Serialized YDoc binary data (base64 encoded)
-  version: integer("version").notNull().default(0), // Optimistic lock version
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-  // GitHub repository onboarding fields
-  sourceRepoUrl: text("source_repo_url"), // Format: "owner/repo"
-  sourceRepoInstallationId: integer("source_repo_installation_id"), // GitHub App installation ID for access
-  initialScanStatus: text("initial_scan_status"), // 'pending' | 'running' | 'completed' | 'failed' | null
-  initialScanSessionId: text("initial_scan_session_id"), // Links to scanning session
-});
+export const PROJECTS_TBL = pgTable(
+  "projects",
+  {
+    id: text("id").primaryKey().notNull(), // System-generated unique project ID (UUID v4)
+    userId: text("user_id").notNull(), // Clerk user ID or CLI token owner
+    name: text("name").notNull(), // User-defined project name (unique per user)
+    ydocData: text("ydoc_data").notNull(), // Serialized YDoc binary data (base64 encoded)
+    version: integer("version").notNull().default(0), // Optimistic lock version
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    // GitHub repository onboarding fields
+    sourceRepoUrl: text("source_repo_url"), // Format: "owner/repo"
+    sourceRepoInstallationId: integer("source_repo_installation_id"), // GitHub App installation ID for access
+    initialScanStatus: text("initial_scan_status"), // 'pending' | 'running' | 'completed' | 'failed' | null
+    initialScanSessionId: text("initial_scan_session_id"), // Links to scanning session
+  },
+  (table) => ({
+    // Ensure project names are unique per user
+    userProjectNameUnique: unique().on(table.userId, table.name),
+  }),
+);
 
 export type Project = typeof PROJECTS_TBL.$inferSelect;
 export type NewProject = typeof PROJECTS_TBL.$inferInsert;

--- a/turbo/apps/web/src/lib/initial-scan-executor.test.ts
+++ b/turbo/apps/web/src/lib/initial-scan-executor.test.ts
@@ -20,8 +20,8 @@ vi.mock("./github/auth", () => ({
 }));
 
 describe("InitialScanExecutor", () => {
-  const testProjectId = "test-project-123";
-  const testUserId = "test-user-123";
+  const testProjectId = `test-project-${Date.now()}-${process.pid}`;
+  const testUserId = `test-user-${Date.now()}-${process.pid}`;
   const testInstallationId = 12345;
   const testSourceRepoUrl = "owner/repo";
   const testGithubToken = "ghs_test_token_123";
@@ -53,7 +53,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -103,7 +103,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -136,7 +136,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -180,7 +180,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -219,7 +219,7 @@ describe("InitialScanExecutor", () => {
       // Create project with initial scan
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -245,7 +245,7 @@ describe("InitialScanExecutor", () => {
       // Create project with initial scan
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -274,7 +274,7 @@ describe("InitialScanExecutor", () => {
       await db.insert(PROJECTS_TBL).values([
         {
           id: testProjectId,
-          name: "Test Project 1",
+          name: `Test Project 1 ${Date.now()}`,
           userId: testUserId,
           ydocData: "test-data-1",
           version: 0,
@@ -283,7 +283,7 @@ describe("InitialScanExecutor", () => {
         },
         {
           id: projectId2,
-          name: "Test Project 2",
+          name: `Test Project 2 ${Date.now()}`,
           userId: testUserId,
           ydocData: "test-data-2",
           version: 0,
@@ -320,7 +320,7 @@ describe("InitialScanExecutor", () => {
       // Create project without session (startup failure scenario)
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
-        name: "Test Project",
+        name: `Test Project ${Date.now()}`,
         userId: testUserId,
         ydocData: "test-data",
         version: 0,

--- a/turbo/apps/web/src/lib/initial-scan-executor.test.ts
+++ b/turbo/apps/web/src/lib/initial-scan-executor.test.ts
@@ -53,6 +53,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -102,6 +103,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -134,6 +136,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -177,6 +180,7 @@ describe("InitialScanExecutor", () => {
       const db = globalThis.services.db;
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -215,6 +219,7 @@ describe("InitialScanExecutor", () => {
       // Create project with initial scan
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -240,6 +245,7 @@ describe("InitialScanExecutor", () => {
       // Create project with initial scan
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,
@@ -268,6 +274,7 @@ describe("InitialScanExecutor", () => {
       await db.insert(PROJECTS_TBL).values([
         {
           id: testProjectId,
+          name: "Test Project 1",
           userId: testUserId,
           ydocData: "test-data-1",
           version: 0,
@@ -276,6 +283,7 @@ describe("InitialScanExecutor", () => {
         },
         {
           id: projectId2,
+          name: "Test Project 2",
           userId: testUserId,
           ydocData: "test-data-2",
           version: 0,
@@ -312,6 +320,7 @@ describe("InitialScanExecutor", () => {
       // Create project without session (startup failure scenario)
       await db.insert(PROJECTS_TBL).values({
         id: testProjectId,
+        name: "Test Project",
         userId: testUserId,
         ydocData: "test-data",
         version: 0,

--- a/turbo/apps/web/src/lib/sessions/blocks.test.ts
+++ b/turbo/apps/web/src/lib/sessions/blocks.test.ts
@@ -185,6 +185,7 @@ describe("Blocks Database Functions", () => {
 
     await globalThis.services.db.insert(PROJECTS_TBL).values({
       id: projectId,
+      name: "Test Project",
       userId,
       ydocData: base64Data,
       version: 0,

--- a/turbo/apps/web/src/lib/sessions/blocks.test.ts
+++ b/turbo/apps/web/src/lib/sessions/blocks.test.ts
@@ -185,7 +185,7 @@ describe("Blocks Database Functions", () => {
 
     await globalThis.services.db.insert(PROJECTS_TBL).values({
       id: projectId,
-      name: "Test Project",
+      name: `Test Project ${Date.now()}`,
       userId,
       ydocData: base64Data,
       version: 0,

--- a/turbo/apps/web/src/test/db-test-utils.ts
+++ b/turbo/apps/web/src/test/db-test-utils.ts
@@ -24,11 +24,17 @@ import { randomUUID } from "crypto";
  */
 export async function createTestProjectForUser(
   userId: string,
-  options: { id?: string; ydocData?: string; version?: number } = {},
+  options: {
+    id?: string;
+    name?: string;
+    ydocData?: string;
+    version?: number;
+  } = {},
 ) {
   initServices();
 
   const projectId = options.id || randomUUID();
+  const projectName = options.name || `Test Project ${projectId.slice(0, 8)}`;
   const ydoc = new Y.Doc();
   const state = Y.encodeStateAsUpdate(ydoc);
   const base64Data = options.ydocData || Buffer.from(state).toString("base64");
@@ -38,6 +44,7 @@ export async function createTestProjectForUser(
     .values({
       id: projectId,
       userId,
+      name: projectName,
       ydocData: base64Data,
       version: options.version ?? 0,
     })


### PR DESCRIPTION
## Summary
- Add user-defined project name field to PROJECTS_TBL schema
- Replace UUID display with readable project names in UI
- Enforce unique project names per user via database constraint
- Add duplicate name validation with user-friendly error messages

## Changes
### Database Schema
- Add `name` field (text, NOT NULL) to PROJECTS_TBL
- Add unique constraint on `(userId, name)` to ensure uniqueness per user
- Create migration `0012_illegal_mystique.sql` with backward-compatible data backfill

### API Endpoints
- **POST /api/projects**: Save user-provided project names and validate uniqueness
- **GET /api/projects**: Return actual project names instead of IDs
- Add error handling for duplicate project name (HTTP 400)

### Frontend
- Projects page UI already correctly displays `project.name`

### Test Updates
- Update 14 test files to include required `name` field in project inserts
- Update test utility `createTestProjectForUser()` to auto-generate project names

## Test Plan
- [x] All TypeScript type checks pass
- [x] All lint checks pass
- [x] All knip checks pass
- [x] Prettier formatting applied
- [x] Database migration runs successfully
- [x] Existing projects backfilled with names
- [x] Duplicate name detection works correctly
- [x] Project names display in UI instead of UUIDs

## Before/After
**Before:** Projects displayed UUID like `f4375c9c-dd6f-4c88-80ae-b6eed028c08a`  
**After:** Projects display user-provided names like "My Project"

🤖 Generated with [Claude Code](https://claude.com/claude-code)