### PR TITLE
chore(e2b): upgrade claude code and uspark cli to latest versions

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -4,10 +4,10 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y git curl
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code@2.0.14
+RUN npm install -g @anthropic-ai/claude-code@2.0.15
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.11.4
+RUN npm install -g @uspark/cli@0.11.5
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary
- Upgrade @anthropic-ai/claude-code from 2.0.14 to 2.0.15
- Upgrade @uspark/cli from 0.11.4 to 0.11.5

## Test plan
- [ ] Verify E2B template builds successfully with new CLI versions
- [ ] Confirm Claude Code CLI runs correctly in E2B environment
- [ ] Confirm uspark CLI runs correctly in E2B environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)