### PR TITLE
feat(web): add optional github bootstrap with manual project creation

### DIFF
--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -39,7 +39,24 @@ test.describe("New Project Multi-Step Flow", () => {
       await page.waitForLoadState("networkidle");
     }
 
-    // Step 4: GitHub Connection Step (should auto-skip if already connected)
+    // Step 4: Choice Step (new step - choose between GitHub and Manual)
+    const choiceHeading = page.getByText("Create a New Project");
+    const choiceVisible = await choiceHeading.isVisible().catch(() => false);
+
+    if (choiceVisible) {
+      await page.screenshot({
+        path: "test-results/multi-step-02-choice-step.png",
+        fullPage: true,
+      });
+
+      // Click "Connect GitHub Repository" button
+      const githubButton = page.locator("button").filter({ hasText: /Connect GitHub Repository/i });
+      await expect(githubButton).toBeVisible();
+      await githubButton.click();
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Step 5: GitHub Connection Step (should auto-skip if already connected)
     const githubHeading = page.getByText("Connect Your GitHub Account");
     const repositoryHeading = page.getByText("Select a Repository");
 
@@ -64,7 +81,7 @@ test.describe("New Project Multi-Step Flow", () => {
 
     if (isOnGitHubStep) {
       await page.screenshot({
-        path: "test-results/multi-step-02-github-step.png",
+        path: "test-results/multi-step-03-github-step.png",
         fullPage: true,
       });
 
@@ -74,10 +91,10 @@ test.describe("New Project Multi-Step Flow", () => {
       return;
     }
 
-    // Step 5: Repository Selection Step (only if GitHub already connected)
+    // Step 6: Repository Selection Step (only if GitHub already connected)
     await expect(repositoryHeading).toBeVisible();
     await page.screenshot({
-      path: "test-results/multi-step-03-repository-step.png",
+      path: "test-results/multi-step-04-repository-step.png",
       fullPage: true,
     });
 
@@ -88,7 +105,7 @@ test.describe("New Project Multi-Step Flow", () => {
     // Select first available repository
     await repoSelect.selectOption({ index: 1 }); // Index 0 is the placeholder
     await page.screenshot({
-      path: "test-results/multi-step-04-repository-selected.png",
+      path: "test-results/multi-step-05-repository-selected.png",
       fullPage: true,
     });
 
@@ -98,14 +115,16 @@ test.describe("New Project Multi-Step Flow", () => {
     await continueButton.click();
     await page.waitForLoadState("networkidle");
 
-    // Step 6: Token Step (conditional - only shown if token not configured)
+    // Step 7: Token Step (conditional - only shown if token not configured)
+    // Note: This step was removed in favor of shared DEFAULT_CLAUDE_TOKEN
+    // Keeping the code for backward compatibility during transition
     const tokenHeading = page.getByText("Add Your Claude API Key");
     const readyHeading = page.getByText("You're All Set!");
 
     const isOnTokenStep = await tokenHeading.isVisible();
     if (isOnTokenStep) {
       await page.screenshot({
-        path: "test-results/multi-step-05-token-step.png",
+        path: "test-results/multi-step-06-token-step.png",
         fullPage: true,
       });
 
@@ -113,7 +132,7 @@ test.describe("New Project Multi-Step Flow", () => {
       const tokenInput = page.locator("input[type='password']");
       await tokenInput.fill("sk-ant-test-token-for-e2e-testing");
       await page.screenshot({
-        path: "test-results/multi-step-06-token-filled.png",
+        path: "test-results/multi-step-07-token-filled.png",
         fullPage: true,
       });
 
@@ -124,10 +143,10 @@ test.describe("New Project Multi-Step Flow", () => {
       await page.waitForLoadState("networkidle");
     }
 
-    // Step 7: Ready/Final Step
+    // Step 8: Ready/Final Step
     await expect(readyHeading).toBeVisible();
     await page.screenshot({
-      path: "test-results/multi-step-07-ready-step.png",
+      path: "test-results/multi-step-08-ready-step.png",
       fullPage: true,
     });
 
@@ -143,7 +162,7 @@ test.describe("New Project Multi-Step Flow", () => {
 
     // Take final screenshot before clicking
     await page.screenshot({
-      path: "test-results/multi-step-08-before-start.png",
+      path: "test-results/multi-step-09-before-start.png",
       fullPage: true,
     });
 
@@ -160,6 +179,15 @@ test.describe("New Project Multi-Step Flow", () => {
 
     await page.goto("/projects/new");
     await page.waitForLoadState("networkidle");
+
+    // Handle choice step if present
+    const choiceHeading = page.getByText("Create a New Project");
+    const choiceVisible = await choiceHeading.isVisible().catch(() => false);
+    if (choiceVisible) {
+      const githubButton = page.locator("button").filter({ hasText: /Connect GitHub Repository/i });
+      await githubButton.click();
+      await page.waitForLoadState("networkidle");
+    }
 
     // If we're on the repository step, proceed
     const repositoryHeading = page.getByText("Select a Repository");

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -221,4 +221,76 @@ test.describe("New Project Multi-Step Flow", () => {
       });
     }
   });
+
+  test("complete manual project creation without GitHub", async ({ page }) => {
+    // Step 1: Sign in with test user
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await clerk.signIn({
+      page,
+      emailAddress: "e2e+clerk_test@uspark.ai",
+    });
+
+    // Step 2: Navigate to project creation page
+    await page.goto("/projects/new");
+    await page.waitForLoadState("networkidle");
+
+    // Step 3: Should see choice step (manual creation option)
+    const choiceHeading = page.getByText("Create a New Project");
+    await expect(choiceHeading).toBeVisible();
+    await page.screenshot({
+      path: "test-results/manual-01-choice-step.png",
+      fullPage: true,
+    });
+
+    // Step 4: Click "Create Project Manually" button
+    const manualButton = page.locator("button").filter({ hasText: /Create Project Manually/i });
+    await expect(manualButton).toBeVisible();
+    await manualButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // Step 5: Enter project name
+    const nameHeading = page.getByText("Name Your Project");
+    await expect(nameHeading).toBeVisible();
+    await page.screenshot({
+      path: "test-results/manual-02-name-input.png",
+      fullPage: true,
+    });
+
+    const projectNameInput = page.getByPlaceholder("My Awesome Project");
+    await expect(projectNameInput).toBeVisible();
+    await projectNameInput.fill("E2E Test Project");
+    await page.screenshot({
+      path: "test-results/manual-03-name-filled.png",
+      fullPage: true,
+    });
+
+    // Step 6: Click Continue
+    const continueButton = page.locator("button").filter({ hasText: /Continue/i });
+    await expect(continueButton).toBeEnabled();
+    await continueButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // Step 7: Verify "You're All Set!" page
+    const readyHeading = page.getByText("You're All Set!");
+    await expect(readyHeading).toBeVisible();
+    await page.screenshot({
+      path: "test-results/manual-04-ready.png",
+      fullPage: true,
+    });
+
+    // Verify project name is displayed
+    await expect(page.getByText("E2E Test Project")).toBeVisible();
+
+    // Verify "Create Project" button (not "Start Scanning")
+    const createButton = page.locator("button").filter({ hasText: /Create Project/i });
+    await expect(createButton).toBeVisible();
+    await expect(createButton).toBeEnabled();
+
+    await page.screenshot({
+      path: "test-results/manual-05-final.png",
+      fullPage: true,
+    });
+
+    // Note: We don't actually click "Create Project" to avoid creating test projects in the database
+  });
 });

--- a/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
@@ -55,7 +55,18 @@ describe("NewProjectPage", () => {
     // Should show loading initially
     expect(screen.getByText("Loading...")).toBeInTheDocument();
 
-    // Should auto-advance to repository step
+    // Should show choice step after loading
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click GitHub option
+    const githubButton = screen.getByRole("button", {
+      name: /Connect GitHub Repository/i,
+    });
+    fireEvent.click(githubButton);
+
+    // Should advance to repository step (skipping GitHub setup since already connected)
     await waitFor(() => {
       expect(screen.getByText("Select a Repository")).toBeInTheDocument();
     });
@@ -73,6 +84,18 @@ describe("NewProjectPage", () => {
 
     render(<NewProjectPage />);
 
+    // Should show choice step first
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click GitHub option
+    const githubButton = screen.getByRole("button", {
+      name: /Connect GitHub Repository/i,
+    });
+    fireEvent.click(githubButton);
+
+    // Should show GitHub connection step
     await waitFor(() => {
       expect(
         screen.getByText("Connect Your GitHub Account"),
@@ -86,6 +109,17 @@ describe("NewProjectPage", () => {
 
   it("should navigate to repository selection and continue to ready step", async () => {
     render(<NewProjectPage />);
+
+    // Should show choice step first
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click GitHub option
+    const githubButton = screen.getByRole("button", {
+      name: /Connect GitHub Repository/i,
+    });
+    fireEvent.click(githubButton);
 
     // Wait for repository step and select to load
     await waitFor(() => {
@@ -121,6 +155,17 @@ describe("NewProjectPage", () => {
 
     render(<NewProjectPage />);
 
+    // Should show choice step first
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click GitHub option
+    const githubButton = screen.getByRole("button", {
+      name: /Connect GitHub Repository/i,
+    });
+    fireEvent.click(githubButton);
+
     // Wait for repository step and select to load
     await waitFor(() => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
@@ -148,10 +193,88 @@ describe("NewProjectPage", () => {
   it("should disable continue button when no repository selected", async () => {
     render(<NewProjectPage />);
 
+    // Should show choice step first
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click GitHub option
+    const githubButton = screen.getByRole("button", {
+      name: /Connect GitHub Repository/i,
+    });
+    fireEvent.click(githubButton);
+
+    // Wait for repository step
     await waitFor(() => {
       expect(screen.getByText("Select a Repository")).toBeInTheDocument();
     });
 
+    const continueButton = screen.getByRole("button", { name: /Continue/i });
+    expect(continueButton).toBeDisabled();
+  });
+
+  it("should allow manual project creation without GitHub", async () => {
+    render(<NewProjectPage />);
+
+    // Should show choice step
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    // Click Manual option
+    const manualButton = screen.getByRole("button", {
+      name: /Create Project Manually/i,
+    });
+    fireEvent.click(manualButton);
+
+    // Should show manual project name input
+    await waitFor(() => {
+      expect(screen.getByText("Name Your Project")).toBeInTheDocument();
+    });
+
+    // Enter project name
+    const projectNameInput = screen.getByPlaceholderText("My Awesome Project");
+    fireEvent.change(projectNameInput, {
+      target: { value: "Test Manual Project" },
+    });
+
+    // Click Continue
+    const continueButton = screen.getByRole("button", { name: /Continue/i });
+    fireEvent.click(continueButton);
+
+    // Should reach ready step
+    await waitFor(() => {
+      expect(screen.getByText("You're All Set!")).toBeInTheDocument();
+    });
+
+    // Should show manual project name in the summary
+    expect(screen.getByText("Test Manual Project")).toBeInTheDocument();
+
+    // Should have Create Project button (not Start Scanning)
+    expect(
+      screen.getByRole("button", { name: /Create Project/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should disable continue button when project name is empty in manual mode", async () => {
+    render(<NewProjectPage />);
+
+    // Wait for choice step and click Manual
+    await waitFor(() => {
+      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
+    });
+
+    const manualButton = screen.getByRole("button", {
+      name: /Create Project Manually/i,
+    });
+    fireEvent.click(manualButton);
+
+    // Should show manual project name input
+    await waitFor(() => {
+      expect(screen.getByText("Name Your Project")).toBeInTheDocument();
+    });
+
+    // Continue button should be disabled with empty name
     const continueButton = screen.getByRole("button", { name: /Continue/i });
     expect(continueButton).toBeDisabled();
   });

--- a/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
@@ -55,18 +55,7 @@ describe("NewProjectPage", () => {
     // Should show loading initially
     expect(screen.getByText("Loading...")).toBeInTheDocument();
 
-    // Should show choice step after loading
-    await waitFor(() => {
-      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
-    });
-
-    // Click GitHub option
-    const githubButton = screen.getByRole("button", {
-      name: /Connect GitHub Repository/i,
-    });
-    fireEvent.click(githubButton);
-
-    // Should advance to repository step (skipping GitHub setup since already connected)
+    // Should auto-skip choice step and go directly to repository step
     await waitFor(() => {
       expect(screen.getByText("Select a Repository")).toBeInTheDocument();
     });
@@ -110,18 +99,7 @@ describe("NewProjectPage", () => {
   it("should navigate to repository selection and continue to ready step", async () => {
     render(<NewProjectPage />);
 
-    // Should show choice step first
-    await waitFor(() => {
-      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
-    });
-
-    // Click GitHub option
-    const githubButton = screen.getByRole("button", {
-      name: /Connect GitHub Repository/i,
-    });
-    fireEvent.click(githubButton);
-
-    // Wait for repository step and select to load
+    // Should auto-skip to repository step (GitHub already connected)
     await waitFor(() => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
@@ -155,18 +133,7 @@ describe("NewProjectPage", () => {
 
     render(<NewProjectPage />);
 
-    // Should show choice step first
-    await waitFor(() => {
-      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
-    });
-
-    // Click GitHub option
-    const githubButton = screen.getByRole("button", {
-      name: /Connect GitHub Repository/i,
-    });
-    fireEvent.click(githubButton);
-
-    // Wait for repository step and select to load
+    // Should auto-skip to repository step (GitHub already connected)
     await waitFor(() => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
@@ -193,18 +160,7 @@ describe("NewProjectPage", () => {
   it("should disable continue button when no repository selected", async () => {
     render(<NewProjectPage />);
 
-    // Should show choice step first
-    await waitFor(() => {
-      expect(screen.getByText("Create a New Project")).toBeInTheDocument();
-    });
-
-    // Click GitHub option
-    const githubButton = screen.getByRole("button", {
-      name: /Connect GitHub Repository/i,
-    });
-    fireEvent.click(githubButton);
-
-    // Wait for repository step
+    // Should auto-skip to repository step (GitHub already connected)
     await waitFor(() => {
       expect(screen.getByText("Select a Repository")).toBeInTheDocument();
     });
@@ -214,9 +170,16 @@ describe("NewProjectPage", () => {
   });
 
   it("should allow manual project creation without GitHub", async () => {
+    // Mock no GitHub connection to see choice step
+    server.use(
+      http.get("*/api/github/installation-status", () => {
+        return HttpResponse.json({ installation: null });
+      }),
+    );
+
     render(<NewProjectPage />);
 
-    // Should show choice step
+    // Should show choice step (no GitHub connected)
     await waitFor(() => {
       expect(screen.getByText("Create a New Project")).toBeInTheDocument();
     });
@@ -257,9 +220,16 @@ describe("NewProjectPage", () => {
   });
 
   it("should disable continue button when project name is empty in manual mode", async () => {
+    // Mock no GitHub connection to see choice step
+    server.use(
+      http.get("*/api/github/installation-status", () => {
+        return HttpResponse.json({ installation: null });
+      }),
+    );
+
     render(<NewProjectPage />);
 
-    // Wait for choice step and click Manual
+    // Wait for choice step (no GitHub connected)
     await waitFor(() => {
       expect(screen.getByText("Create a New Project")).toBeInTheDocument();
     });

--- a/turbo/apps/web/app/projects/new/page.tsx
+++ b/turbo/apps/web/app/projects/new/page.tsx
@@ -65,6 +65,12 @@ export default function NewProjectPage() {
   useEffect(() => {
     if (checkingStatus) return;
 
+    // Auto-skip choice step for users with GitHub already connected
+    if (currentStep === "choice" && hasGitHub) {
+      setUseGitHub(true);
+      setCurrentStep("repository");
+    }
+
     // If user chose GitHub and already has it connected, skip to repository
     if (currentStep === "github" && hasGitHub && useGitHub) {
       setCurrentStep("repository");

--- a/turbo/apps/web/app/projects/new/page.tsx
+++ b/turbo/apps/web/app/projects/new/page.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Button, Card, CardContent, CardHeader, CardTitle } from "@uspark/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+} from "@uspark/ui";
 import { GitHubRepoSelector } from "../../components/github-repo-selector";
-import { Check, Github, FolderGit2 } from "lucide-react";
+import { Check, Github, FolderGit2, FileText } from "lucide-react";
 
-type ProjectCreationStep = "github" | "repository" | "ready";
+type ProjectCreationStep =
+  | "choice"
+  | "github"
+  | "repository"
+  | "manual"
+  | "ready";
 
 interface SelectedRepo {
   repo: {
@@ -16,9 +28,11 @@ interface SelectedRepo {
 }
 
 export default function NewProjectPage() {
-  const [currentStep, setCurrentStep] = useState<ProjectCreationStep>("github");
+  const [currentStep, setCurrentStep] = useState<ProjectCreationStep>("choice");
   const [hasGitHub, setHasGitHub] = useState<boolean | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<SelectedRepo | null>(null);
+  const [projectName, setProjectName] = useState("");
+  const [useGitHub, setUseGitHub] = useState<boolean | null>(null);
   const [creating, setCreating] = useState(false);
   const [checkingStatus, setCheckingStatus] = useState(true);
   const [error, setError] = useState<string>();
@@ -51,10 +65,25 @@ export default function NewProjectPage() {
   useEffect(() => {
     if (checkingStatus) return;
 
-    if (currentStep === "github" && hasGitHub) {
+    // If user chose GitHub and already has it connected, skip to repository
+    if (currentStep === "github" && hasGitHub && useGitHub) {
       setCurrentStep("repository");
     }
-  }, [checkingStatus, hasGitHub, currentStep]);
+  }, [checkingStatus, hasGitHub, currentStep, useGitHub]);
+
+  const handleChooseGitHub = () => {
+    setUseGitHub(true);
+    if (hasGitHub) {
+      setCurrentStep("repository");
+    } else {
+      setCurrentStep("github");
+    }
+  };
+
+  const handleChooseManual = () => {
+    setUseGitHub(false);
+    setCurrentStep("manual");
+  };
 
   const handleGitHubSetup = () => {
     window.location.href = "/settings/github";
@@ -75,20 +104,35 @@ export default function NewProjectPage() {
     setCurrentStep("ready");
   };
 
+  const handleContinueFromManual = () => {
+    if (!projectName.trim()) return;
+    setCurrentStep("ready");
+  };
+
   const handleCreateProject = async () => {
-    if (!selectedRepo) return;
+    // GitHub mode: need selectedRepo
+    if (useGitHub && !selectedRepo) return;
+    // Manual mode: need projectName
+    if (!useGitHub && !projectName.trim()) return;
 
     setCreating(true);
     setError(undefined);
 
+    // Build request body based on mode
+    const body = useGitHub
+      ? {
+          name: selectedRepo!.repo.name,
+          sourceRepoUrl: selectedRepo!.repo.fullName,
+          installationId: selectedRepo!.installationId,
+        }
+      : {
+          name: projectName.trim(),
+        };
+
     const response = await fetch("/api/projects", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: selectedRepo.repo.name,
-        sourceRepoUrl: selectedRepo.repo.fullName,
-        installationId: selectedRepo.installationId,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (response.ok) {
@@ -119,18 +163,87 @@ export default function NewProjectPage() {
         <div className="mb-8 flex items-center justify-center gap-2">
           <StepIndicator
             number={1}
-            label="GitHub"
-            active={currentStep === "github"}
-            completed={hasGitHub === true}
+            label={
+              useGitHub === null ? "Setup" : useGitHub ? "GitHub" : "Project"
+            }
+            active={
+              currentStep === "choice" ||
+              currentStep === "github" ||
+              currentStep === "manual"
+            }
+            completed={
+              currentStep === "repository" ||
+              (currentStep === "ready" && useGitHub === false)
+            }
           />
-          <div className="h-px w-12 bg-border" />
-          <StepIndicator
-            number={2}
-            label="Repository"
-            active={currentStep === "repository" || currentStep === "ready"}
-            completed={currentStep === "ready"}
-          />
+          {useGitHub && (
+            <>
+              <div className="h-px w-12 bg-border" />
+              <StepIndicator
+                number={2}
+                label="Repository"
+                active={currentStep === "repository"}
+                completed={currentStep === "ready"}
+              />
+            </>
+          )}
         </div>
+
+        {/* Step 0: Choice */}
+        {currentStep === "choice" && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Create a New Project</CardTitle>
+              <p className="text-sm text-muted-foreground mt-1">
+                Choose how you want to set up your project
+              </p>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {/* GitHub Option */}
+                <button
+                  onClick={handleChooseGitHub}
+                  className="w-full rounded-lg border-2 border-border bg-card p-6 text-left transition-all hover:border-primary hover:bg-accent"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="rounded-lg bg-primary/10 p-3">
+                      <Github className="h-6 w-6 text-primary" />
+                    </div>
+                    <div className="flex-1">
+                      <h3 className="font-semibold mb-1">
+                        Connect GitHub Repository
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        Link an existing GitHub repository for AI-powered code
+                        analysis and automated scanning
+                      </p>
+                    </div>
+                  </div>
+                </button>
+
+                {/* Manual Option */}
+                <button
+                  onClick={handleChooseManual}
+                  className="w-full rounded-lg border-2 border-border bg-card p-6 text-left transition-all hover:border-primary hover:bg-accent"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="rounded-lg bg-primary/10 p-3">
+                      <FileText className="h-6 w-6 text-primary" />
+                    </div>
+                    <div className="flex-1">
+                      <h3 className="font-semibold mb-1">
+                        Create Project Manually
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        Start with a blank project without connecting to GitHub
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Step 1: GitHub */}
         {currentStep === "github" && (
@@ -221,6 +334,58 @@ export default function NewProjectPage() {
           </Card>
         )}
 
+        {/* Step 2b: Manual Project Name */}
+        {currentStep === "manual" && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-primary/10 p-3">
+                  <FileText className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <CardTitle>Name Your Project</CardTitle>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Choose a name for your new project
+                  </p>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div>
+                  <label
+                    htmlFor="project-name"
+                    className="text-sm font-medium mb-2 block"
+                  >
+                    Project Name
+                  </label>
+                  <Input
+                    id="project-name"
+                    type="text"
+                    placeholder="My Awesome Project"
+                    value={projectName}
+                    onChange={(e) => setProjectName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && projectName.trim()) {
+                        handleContinueFromManual();
+                      }
+                    }}
+                    autoFocus
+                  />
+                </div>
+                <Button
+                  onClick={handleContinueFromManual}
+                  disabled={!projectName.trim()}
+                  className="w-full"
+                  size="lg"
+                >
+                  Continue
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         {/* Step 3: Ready */}
         {currentStep === "ready" && (
           <Card>
@@ -251,15 +416,19 @@ export default function NewProjectPage() {
                       <Check className="h-4 w-4 text-primary mt-0.5" />
                       <span>
                         Your project will be created:{" "}
-                        <strong>{selectedRepo?.repo.name}</strong>
+                        <strong>
+                          {useGitHub ? selectedRepo?.repo.name : projectName}
+                        </strong>
                       </span>
                     </li>
-                    <li className="flex items-start gap-2">
-                      <Check className="h-4 w-4 text-primary mt-0.5" />
-                      <span>
-                        Initial repository scan will begin automatically
-                      </span>
-                    </li>
+                    {useGitHub && (
+                      <li className="flex items-start gap-2">
+                        <Check className="h-4 w-4 text-primary mt-0.5" />
+                        <span>
+                          Initial repository scan will begin automatically
+                        </span>
+                      </li>
+                    )}
                     <li className="flex items-start gap-2">
                       <Check className="h-4 w-4 text-primary mt-0.5" />
                       <span>
@@ -274,7 +443,11 @@ export default function NewProjectPage() {
                   className="w-full"
                   size="lg"
                 >
-                  {creating ? "Creating Project..." : "Start Scanning"}
+                  {creating
+                    ? "Creating Project..."
+                    : useGitHub
+                      ? "Start Scanning"
+                      : "Create Project"}
                 </Button>
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary

This PR adds flexibility to the project creation flow by allowing users to **skip GitHub connection** and create projects manually with just a name. This removes the requirement for users to have a GitHub repository to try the platform.

### New User Flow

**Before** (2 steps, GitHub required):
1. GitHub Connection (required)
2. Repository Selection (required)

**After** (flexible, GitHub optional):
1. **Choice**: Connect GitHub OR Create Manually
   - Option A (GitHub users): Auto-skip choice → Select Repository → Ready
   - Option B (Manual): Choose Manual → Input Project Name → Ready

### Key Features

✅ **Smart Auto-Skip**: Users with GitHub already connected automatically skip the choice step (backward compatible)  
✅ **Manual Creation**: New users can create projects without GitHub  
✅ **Dynamic Progress**: Progress indicator adapts based on user choice (1 or 2 steps)  
✅ **Flexible API**: Project creation supports both GitHub and manual modes  
✅ **Complete E2E Tests**: Added real end-to-end test for manual creation flow  

### Changes

#### 1. Core Feature (`apps/web/app/projects/new/page.tsx`)
- Added choice step for GitHub vs Manual selection
- Added manual project name input
- Added auto-skip logic for returning GitHub users
- Updated API call to support both modes

#### 2. Test Updates
- **Unit Tests**: Updated all tests to handle auto-skip behavior
- **E2E Tests**: Added complete manual creation flow test
- Fixed existing tests to work with new choice step

#### 3. Auto-Skip Logic
```typescript
// Users with GitHub already connected skip directly to repository
if (currentStep === "choice" && hasGitHub) {
  setUseGitHub(true);
  setCurrentStep("repository");
}
```

### API Changes

**GitHub mode** (existing, unchanged):
```typescript
POST /api/projects {
  name: "repo-name",
  sourceRepoUrl: "owner/repo",
  installationId: 123
}
```

**Manual mode** (new):
```typescript
POST /api/projects {
  name: "My Project"
}
```

### Test Coverage

#### Unit Tests (7 tests)
- ✅ Auto-skip to repository when GitHub connected
- ✅ Show GitHub connection step when not connected
- ✅ Navigate through repository selection
- ✅ Display errors on project creation failure
- ✅ Disable continue without repository selected
- ✅ Complete manual project creation flow
- ✅ Validate empty project name

#### E2E Tests (3 tests)
- ✅ Complete multi-step GitHub flow with screenshots
- ✅ Show error for invalid tokens
- ✅ **NEW**: Complete manual project creation without GitHub

### Backward Compatibility

✅ **Existing GitHub users**: Auto-skip choice step, no behavior change  
✅ **Existing API**: Fully compatible, no breaking changes  
✅ **Existing tests**: All passing with updates  

### Screenshots

The new flow includes:
- Choice screen for new users
- Manual project name input
- Dynamic "Create Project" vs "Start Scanning" button text
- Adaptive step indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)