### PR TITLE
docs: add release triggering guidelines for commit types

### DIFF
--- a/.claude/agents/commit-validator.md
+++ b/.claude/agents/commit-validator.md
@@ -32,17 +32,26 @@ You are a commit message specialist for the uspark project. Your role is to ensu
 - **Use imperative mood** (add, not added/adds)
 
 ### Valid Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, semicolons, etc)
-- `refactor`: Code refactoring
-- `test`: Test additions or changes
-- `chore`: Build process or auxiliary tool changes
-- `ci`: CI configuration changes
-- `perf`: Performance improvements
-- `build`: Build system changes
-- `revert`: Revert previous commit
+- `feat`: New feature (triggers minor version bump)
+- `fix`: Bug fix (triggers patch version bump)
+- `docs`: Documentation changes (no release)
+- `style`: Code style changes (formatting, semicolons, etc) (no release)
+- `refactor`: Code refactoring (no release)
+- `test`: Test additions or changes (no release)
+- `chore`: Build process or auxiliary tool changes (no release)
+- `ci`: CI configuration changes (no release)
+- `perf`: Performance improvements (no release)
+- `build`: Build system changes (no release)
+- `revert`: Revert previous commit (no release)
+
+### Release Triggering:
+**Only certain commit types trigger automated releases:**
+- ✅ `feat` and `fix` trigger version bumps and releases
+- ✅ `deps` (dependency updates) trigger patch releases
+- ✅ Breaking changes (any type with `!`) trigger major releases
+- ❌ Other types (`refactor`, `docs`, `chore`, etc.) appear in changelog but do NOT trigger releases
+
+**Tip:** If you want a refactor to trigger a release, use `fix:` instead (e.g., `fix: refactor authentication logic`)
 
 ## Validation Process
 

--- a/.claude/agents/pr-creator.md
+++ b/.claude/agents/pr-creator.md
@@ -128,17 +128,26 @@ gh pr view --json url -q .url
 ```
 
 ### Valid Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, semicolons, etc)
-- `refactor`: Code refactoring
-- `test`: Test additions or changes
-- `chore`: Build process or auxiliary tool changes
-- `ci`: CI configuration changes
-- `perf`: Performance improvements
-- `build`: Build system changes
-- `revert`: Revert previous commit
+- `feat`: New feature (triggers minor version bump)
+- `fix`: Bug fix (triggers patch version bump)
+- `docs`: Documentation changes (no release)
+- `style`: Code style changes (formatting, semicolons, etc) (no release)
+- `refactor`: Code refactoring (no release)
+- `test`: Test additions or changes (no release)
+- `chore`: Build process or auxiliary tool changes (no release)
+- `ci`: CI configuration changes (no release)
+- `perf`: Performance improvements (no release)
+- `build`: Build system changes (no release)
+- `revert`: Revert previous commit (no release)
+
+### Release Triggering:
+**Only certain commit types trigger automated releases:**
+- ✅ `feat` and `fix` trigger version bumps and releases
+- ✅ `deps` (dependency updates) trigger patch releases
+- ✅ Breaking changes (any type with `!`) trigger major releases
+- ❌ Other types (`refactor`, `docs`, `chore`, etc.) appear in changelog but do NOT trigger releases
+
+**Tip:** If you want a refactor to trigger a release, use `fix:` instead (e.g., `fix: refactor authentication logic`)
 
 ### Strict Requirements:
 - **Type must be lowercase** (feat, not Feat)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,17 +159,29 @@ const handleSubmit = async () => {
 - **Use imperative mood** - Use `add`, not `added` or `adds`
 
 ### Types:
-- `feat:` New feature
-- `fix:` Bug fix  
-- `docs:` Documentation changes
-- `style:` Code style changes (formatting, semicolons, etc)
-- `refactor:` Code refactoring
-- `test:` Test additions or changes
-- `chore:` Build process or auxiliary tool changes
-- `ci:` CI configuration changes
-- `perf:` Performance improvements
-- `build:` Build system changes
-- `revert:` Revert previous commit
+- `feat:` New feature (triggers minor version bump)
+- `fix:` Bug fix (triggers patch version bump)
+- `docs:` Documentation changes (no release)
+- `style:` Code style changes (formatting, semicolons, etc) (no release)
+- `refactor:` Code refactoring (no release)
+- `test:` Test additions or changes (no release)
+- `chore:` Build process or auxiliary tool changes (no release)
+- `ci:` CI configuration changes (no release)
+- `perf:` Performance improvements (no release)
+- `build:` Build system changes (no release)
+- `revert:` Revert previous commit (no release)
+
+### Release Triggering:
+**Only certain commit types trigger automated releases via release-please:**
+- ✅ `feat:` - Triggers a **minor** version bump (e.g., 1.2.0 → 1.3.0)
+- ✅ `fix:` - Triggers a **patch** version bump (e.g., 1.2.0 → 1.2.1)
+- ✅ `deps:` - Dependency updates trigger a **patch** version bump
+- ✅ Breaking changes (any type with `!` or `BREAKING CHANGE:` footer) - Triggers a **major** version bump (e.g., 1.2.0 → 2.0.0)
+- ❌ All other types (`refactor`, `docs`, `chore`, `ci`, etc.) - Will appear in changelog but **will not trigger a release**
+
+**Important:** If you want a `refactor` or other non-release type to trigger a version bump, use `fix:` instead. For example:
+- Use `fix: refactor authentication logic` instead of `refactor: authentication logic`
+- This is acceptable since refactoring often fixes technical debt or improves code quality
 
 ### Examples:
 - ✅ `feat: add user authentication system`


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation about which commit types trigger automated releases via release-please. This information was previously undocumented, leading to potential confusion about when commits would actually trigger version bumps.

### Changes Made

- Added "Release Triggering" section to CLAUDE.md explaining:
  - `feat` and `fix` trigger version bumps and releases
  - `deps` (dependency updates) trigger patch releases  
  - Breaking changes (any type with `!` or `BREAKING CHANGE:` footer) trigger major releases
  - Other types (`refactor`, `docs`, `chore`, `ci`, etc.) appear in changelog but do NOT trigger releases

- Updated `.claude/agents/pr-creator.md` with release triggering guidelines
- Updated `.claude/agents/commit-validator.md` with release triggering guidelines

### Why This Matters

Developers need to understand that:
1. Not all conventional commits trigger releases
2. If you want a refactor to trigger a release, use `fix:` instead
3. This helps set proper expectations about when versions will be bumped

### Files Changed

- `/workspaces/uspark1/CLAUDE.md` - Main project documentation
- `/workspaces/uspark1/.claude/agents/pr-creator.md` - PR creation agent instructions
- `/workspaces/uspark1/.claude/agents/commit-validator.md` - Commit validation agent instructions

Generated with [Claude Code](https://claude.com/claude-code)