### PR TITLE
fix: replace sequencenumber with createdat in blocks query ordering

### DIFF
--- a/turbo/apps/web/app/api/projects/route.ts
+++ b/turbo/apps/web/app/api/projects/route.ts
@@ -89,12 +89,12 @@ async function getInitialScanProgress(
   }
 
   // Get all blocks for the first turn (usually only one turn in initial scan)
-  // Ordered by sequence number descending to get most recent first
+  // Ordered by created_at descending to get most recent first
   const blocks = await globalThis.services.db
     .select()
     .from(BLOCKS_TBL)
     .where(eq(BLOCKS_TBL.turnId, turns[0]!.id))
-    .orderBy(desc(BLOCKS_TBL.sequenceNumber));
+    .orderBy(desc(BLOCKS_TBL.createdAt));
 
   // Find the most recent TodoWrite block
   const todoWriteBlock = blocks.find(


### PR DESCRIPTION
## Summary
Hotfix for SQL error in initial scan progress tracking caused by referencing removed sequenceNumber field.

## Problem
Migration #13 removed the `sequence_number` column from the blocks table, but `getInitialScanProgress()` in `/api/projects` route was still ordering blocks by this non-existent column, causing SQL errors: `order by  desc` (missing column name).

## Solution  
Updated the query to order by `createdAt` instead, which is the new approach for ordering blocks after migration #13.

## Changes
- Updated `apps/web/app/api/projects/route.ts` line 97
- Changed `.orderBy(desc(BLOCKS_TBL.sequenceNumber))` to `.orderBy(desc(BLOCKS_TBL.createdAt))`
- Updated comment to reflect new ordering approach

## Related
- Fixes tests that failed in merged PR #515
- Related to migration #13 (0013_damp_loners) that removed sequenceNumber

🤖 Generated with [Claude Code](https://claude.com/claude-code)