### PR TITLE
feat(web): streamline initial scan progress display

### DIFF
--- a/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { InitialScanProgress } from "../initial-scan-progress";
+
+describe("InitialScanProgress", () => {
+  it("should show initializing message when no progress", () => {
+    render(<InitialScanProgress progress={null} projectName="Test Project" />);
+
+    expect(
+      screen.getByText("Initializing scan for Test Project..."),
+    ).toBeInTheDocument();
+  });
+
+  it("should only show in_progress tasks", () => {
+    const progress = {
+      todos: [
+        {
+          content: "Clone repository",
+          status: "completed" as const,
+          activeForm: "Cloning repository",
+        },
+        {
+          content: "Analyze code structure",
+          status: "in_progress" as const,
+          activeForm: "Analyzing code structure",
+        },
+        {
+          content: "Generate report",
+          status: "pending" as const,
+          activeForm: "Generating report",
+        },
+      ],
+    };
+
+    render(
+      <InitialScanProgress progress={progress} projectName="Test Project" />,
+    );
+
+    // Should only show the in_progress task
+    expect(screen.getByText("Analyzing code structure")).toBeInTheDocument();
+
+    // Should NOT show completed tasks
+    expect(screen.queryByText("Clone repository")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cloning repository")).not.toBeInTheDocument();
+
+    // Should NOT show pending tasks
+    expect(screen.queryByText("Generate report")).not.toBeInTheDocument();
+  });
+
+  it("should show generic message when no in_progress tasks", () => {
+    const progress = {
+      todos: [
+        {
+          content: "Clone repository",
+          status: "completed" as const,
+          activeForm: "Cloning repository",
+        },
+        {
+          content: "Generate report",
+          status: "pending" as const,
+          activeForm: "Generating report",
+        },
+      ],
+    };
+
+    render(
+      <InitialScanProgress progress={progress} projectName="Test Project" />,
+    );
+
+    // Should show generic scanning message
+    expect(screen.getByText("Scanning Test Project...")).toBeInTheDocument();
+
+    // Should NOT show any task details
+    expect(screen.queryByText("Clone repository")).not.toBeInTheDocument();
+    expect(screen.queryByText("Generate report")).not.toBeInTheDocument();
+  });
+
+  it("should show last block content when no todos available", () => {
+    const progress = {
+      lastBlock: {
+        type: "content",
+        content: {
+          text: "Initializing repository scan...",
+        },
+      },
+    };
+
+    render(
+      <InitialScanProgress progress={progress} projectName="Test Project" />,
+    );
+
+    expect(
+      screen.getByText("Initializing repository scan..."),
+    ).toBeInTheDocument();
+  });
+
+  it("should show multiple in_progress tasks", () => {
+    const progress = {
+      todos: [
+        {
+          content: "Analyze code structure",
+          status: "in_progress" as const,
+          activeForm: "Analyzing code structure",
+        },
+        {
+          content: "Scan dependencies",
+          status: "in_progress" as const,
+          activeForm: "Scanning dependencies",
+        },
+      ],
+    };
+
+    render(
+      <InitialScanProgress progress={progress} projectName="Test Project" />,
+    );
+
+    // Should show both in_progress tasks
+    expect(screen.getByText("Analyzing code structure")).toBeInTheDocument();
+    expect(screen.getByText("Scanning dependencies")).toBeInTheDocument();
+  });
+});

--- a/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { InitialScanProgress } from "../initial-scan-progress";
 
 describe("InitialScanProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("should show initializing message when no progress", () => {
     render(<InitialScanProgress progress={null} projectName="Test Project" />);
 

--- a/turbo/apps/web/app/components/initial-scan-progress.tsx
+++ b/turbo/apps/web/app/components/initial-scan-progress.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle, Badge } from "@uspark/ui";
-import { CheckCircle2, Circle, Loader2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@uspark/ui";
+import { Loader2 } from "lucide-react";
 
 interface TodoItem {
   content: string;
@@ -37,8 +37,26 @@ export function InitialScanProgress({
     );
   }
 
-  // Show todos if available
+  // Show todos if available - only show in_progress tasks
   if (progress.todos && progress.todos.length > 0) {
+    const inProgressTodos = progress.todos.filter(
+      (todo) => todo.status === "in_progress",
+    );
+
+    // If no in_progress tasks, show a generic scanning message
+    if (inProgressTodos.length === 0) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Loader2 className="h-5 w-5 animate-spin text-primary" />
+              Scanning {projectName}...
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      );
+    }
+
     return (
       <Card>
         <CardHeader>
@@ -49,38 +67,14 @@ export function InitialScanProgress({
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {progress.todos.map((todo, index) => (
+            {inProgressTodos.map((todo, index) => (
               <div
                 key={index}
                 className="flex items-start gap-3 rounded-lg border p-3"
               >
-                {todo.status === "completed" ? (
-                  <CheckCircle2 className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
-                ) : todo.status === "in_progress" ? (
-                  <Loader2 className="h-5 w-5 animate-spin text-primary mt-0.5 flex-shrink-0" />
-                ) : (
-                  <Circle className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
-                )}
+                <Loader2 className="h-5 w-5 animate-spin text-primary mt-0.5 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium">
-                    {todo.status === "in_progress"
-                      ? todo.activeForm
-                      : todo.content}
-                  </p>
-                  <div className="mt-1">
-                    <Badge
-                      variant={
-                        todo.status === "completed"
-                          ? "default"
-                          : todo.status === "in_progress"
-                            ? "secondary"
-                            : "outline"
-                      }
-                      className="text-xs"
-                    >
-                      {todo.status.replace("_", " ")}
-                    </Badge>
-                  </div>
+                  <p className="text-sm font-medium">{todo.activeForm}</p>
                 </div>
               </div>
             ))}

--- a/turbo/apps/web/app/projects/new/page.tsx
+++ b/turbo/apps/web/app/projects/new/page.tsx
@@ -188,7 +188,7 @@ export default function NewProjectPage() {
     setCreating(false);
   };
 
-  // Poll for scan completion
+  // Poll for scan completion and auto-redirect when done
   useEffect(() => {
     if (!createdProject || currentStep !== "scanning") {
       return;
@@ -204,11 +204,13 @@ export default function NewProjectPage() {
           );
           if (project) {
             setCreatedProject(project);
-            // Stop polling when scan completes
-            if (
-              project.initial_scan_status === "completed" ||
-              project.initial_scan_status === "failed"
-            ) {
+            // Auto-redirect when scan completes successfully
+            if (project.initial_scan_status === "completed") {
+              clearInterval(interval);
+              navigateToProject(project.id);
+            }
+            // Stop polling on failure but don't auto-redirect (show error UI)
+            if (project.initial_scan_status === "failed") {
               clearInterval(interval);
             }
           }
@@ -472,19 +474,6 @@ export default function NewProjectPage() {
               progress={createdProject.initial_scan_progress || null}
               projectName={createdProject.name}
             />
-            {createdProject.initial_scan_status === "completed" && (
-              <Card>
-                <CardContent className="pt-6">
-                  <Button
-                    onClick={() => navigateToProject(createdProject.id)}
-                    className="w-full"
-                    size="lg"
-                  >
-                    Enter Project Workspace
-                  </Button>
-                </CardContent>
-              </Card>
-            )}
             {createdProject.initial_scan_status === "failed" && (
               <Card className="border-destructive">
                 <CardContent className="pt-6">

--- a/turbo/apps/web/app/projects/new/page.tsx
+++ b/turbo/apps/web/app/projects/new/page.tsx
@@ -204,14 +204,13 @@ export default function NewProjectPage() {
           );
           if (project) {
             setCreatedProject(project);
-            // Auto-redirect when scan completes successfully
-            if (project.initial_scan_status === "completed") {
+            // Auto-redirect when scan completes (both success and failure)
+            if (
+              project.initial_scan_status === "completed" ||
+              project.initial_scan_status === "failed"
+            ) {
               clearInterval(interval);
               navigateToProject(project.id);
-            }
-            // Stop polling on failure but don't auto-redirect (show error UI)
-            if (project.initial_scan_status === "failed") {
-              clearInterval(interval);
             }
           }
         }
@@ -469,30 +468,10 @@ export default function NewProjectPage() {
 
         {/* Step 3: Scanning */}
         {currentStep === "scanning" && createdProject && (
-          <div className="space-y-6">
-            <InitialScanProgress
-              progress={createdProject.initial_scan_progress || null}
-              projectName={createdProject.name}
-            />
-            {createdProject.initial_scan_status === "failed" && (
-              <Card className="border-destructive">
-                <CardContent className="pt-6">
-                  <p className="text-sm text-destructive mb-4">
-                    Initial scan failed. You can still access the project, but
-                    it may not have been fully analyzed.
-                  </p>
-                  <Button
-                    onClick={() => navigateToProject(createdProject.id)}
-                    className="w-full"
-                    size="lg"
-                    variant="outline"
-                  >
-                    Continue Anyway
-                  </Button>
-                </CardContent>
-              </Card>
-            )}
-          </div>
+          <InitialScanProgress
+            progress={createdProject.initial_scan_progress || null}
+            projectName={createdProject.name}
+          />
         )}
 
         {/* Step 4: Ready */}


### PR DESCRIPTION
## Summary

Simplifies the initial scan progress UI to show only active tasks and automatically redirects to the project workspace when the scan completes (regardless of success or failure).

## Changes

### Initial Scan Progress Component (`initial-scan-progress.tsx`)
- **Filter tasks**: Only display `in_progress` tasks (hide completed and pending)
- **Simplified UI**: Removed status badges and completion icons
- **Cleaner imports**: Removed unused components (CheckCircle2, Circle, Badge)

### New Project Page (`projects/new/page.tsx`)
- **Auto-redirect**: Automatically navigate to project detail page when scan completes (both success and failure)
- **Better UX**: Users no longer need to manually click any button to proceed
- **Simplified UI**: Removed error card and "Continue Anyway" button for failed scans

## Benefits

1. **Reduced visual clutter**: Users see only what's currently happening
2. **Faster workflow**: No extra click needed to access the project
3. **Better focus**: Only active task is shown, reducing cognitive load
4. **Consistent behavior**: Same automatic redirect for all completion states

## Testing

- ✅ Lint checks passed
- ✅ Type checks passed
- ✅ Code formatting passed
- ✅ Knip analysis passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)