### PR TITLE
fix(workspace): add documentation for clerk authentication signals

### DIFF
--- a/turbo/apps/workspace/src/signals/auth.ts
+++ b/turbo/apps/workspace/src/signals/auth.ts
@@ -3,6 +3,11 @@ import { command, computed, state } from 'ccstate'
 
 const reload$ = state(0)
 
+/**
+ * Clerk instance signal that initializes the Clerk SDK with the publishable key.
+ * The VITE_CLERK_PUBLISHABLE_KEY environment variable must be set at build time
+ * via .env.production.local file for production deployments.
+ */
 export const clerk$ = computed(async () => {
   const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as
     | string
@@ -17,6 +22,11 @@ export const clerk$ = computed(async () => {
   return clerkInstance
 })
 
+/**
+ * Command to setup Clerk authentication listeners.
+ * This command initializes the Clerk instance and sets up a listener
+ * for authentication state changes.
+ */
 export const setupClerk$ = command(
   async ({ set, get }, signal: AbortSignal) => {
     const clerk = await get(clerk$)
@@ -30,6 +40,10 @@ export const setupClerk$ = command(
   },
 )
 
+/**
+ * User signal that provides the current authenticated user from Clerk.
+ * Returns undefined if no user is authenticated.
+ */
 export const user$ = computed(async (get) => {
   get(reload$)
   const clerk = await get(clerk$)


### PR DESCRIPTION
## Summary

Add JSDoc documentation to Clerk authentication signals to improve code maintainability and clarify environment variable requirements.

## Changes

- Add JSDoc comment for `clerk$` signal explaining VITE_CLERK_PUBLISHABLE_KEY requirement
- Add JSDoc comment for `setupClerk$` command explaining listener setup
- Add JSDoc comment for `user$` signal explaining user access

## Purpose

This documentation clarifies that `VITE_CLERK_PUBLISHABLE_KEY` must be provided via `.env.production.local` file during production builds (as implemented in PR #527).

## Test Plan

- [x] Pre-commit hooks passed (lint, format, knip)
- [x] No functional changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)