### PR TITLE
test(e2e): add test for manual project creation with mocked api

### DIFF
--- a/e2e/web/mocks/handlers.ts
+++ b/e2e/web/mocks/handlers.ts
@@ -1,0 +1,60 @@
+import type { Page, Route } from "@playwright/test";
+
+/**
+ * Mock handler for POST /api/projects - Create project
+ */
+export const createProjectHandler = async (route: Route) => {
+  if (route.request().method() !== "POST") {
+    await route.continue();
+    return;
+  }
+
+  const body = await route.request().postDataJSON();
+  const mockProjectId = `proj_mock_${Date.now()}`;
+
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      id: mockProjectId,
+      name: body.name || "Test Project",
+      user_id: "test_user",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      source_repo_url: body.sourceRepoUrl || null,
+      installation_id: body.installationId || null,
+    }),
+  });
+};
+
+/**
+ * Setup mock handlers for the page
+ * Returns the mock project ID for verification in tests
+ */
+export async function setupMockHandlers(page: Page): Promise<string> {
+  const mockProjectId = `proj_mock_${Date.now()}`;
+
+  // Mock POST /api/projects
+  await page.route("**/api/projects", async (route) => {
+    if (route.request().method() === "POST") {
+      const body = await route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: mockProjectId,
+          name: body.name || "Test Project",
+          user_id: "test_user",
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          source_repo_url: body.sourceRepoUrl || null,
+          installation_id: body.installationId || null,
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  return mockProjectId;
+}

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -1,5 +1,6 @@
 import test, { expect } from "@playwright/test";
 import { clerk, clerkSetup } from "@clerk/testing/playwright";
+import { setupMockHandlers } from "../mocks/handlers";
 
 test.describe("New Project Multi-Step Flow", () => {
   test.beforeAll(async () => {
@@ -334,25 +335,8 @@ test.describe("New Project Multi-Step Flow", () => {
     const readyHeading = page.getByText("You're All Set!");
     await expect(readyHeading).toBeVisible();
 
-    // Mock the API response for project creation
-    const mockProjectId = "proj_mock_123456";
-    await page.route("**/api/projects", async (route) => {
-      if (route.request().method() === "POST") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            id: mockProjectId,
-            name: "E2E Mocked Test Project",
-            user_id: "test_user",
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          }),
-        });
-      } else {
-        await route.continue();
-      }
-    });
+    // Setup MSW-style mock handlers for API
+    const mockProjectId = await setupMockHandlers(page);
 
     // Track navigation to verify redirect
     let navigatedToWorkspace = false;


### PR DESCRIPTION
## Summary
- Add e2e test that completes the manual project creation flow by clicking "Create Project" button
- Use Playwright's native `page.route()` to mock POST /api/projects API response
- Verify redirect to workspace project details page (app subdomain with project ID)
- Prevents creating test data in the database while testing the full user flow

## Test plan
- CI will run this test against the deployed preview environment
- Test verifies:
  - Manual project creation flow from start to finish
  - API mocking works correctly
  - Navigation to workspace happens with correct URL structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)