### PR TITLE
fix(ci): add runtime env variables for vercel deployments

### DIFF
--- a/.github/actions/vercel-deploy/action.yml
+++ b/.github/actions/vercel-deploy/action.yml
@@ -68,10 +68,10 @@ runs:
           DEPLOY_CMD="$DEPLOY_CMD --prod"
         fi
 
-        # Add environment variables as --build-env flags for Next.js
+        # Add environment variables for both build-time and runtime
         ENV_VARS="${{ inputs.environment-variables }}"
         if [ -n "$ENV_VARS" ]; then
-          echo "Adding environment variables for build..."
+          echo "Adding environment variables for build and runtime..."
           while IFS= read -r line; do
             # Skip empty lines
             line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -79,9 +79,9 @@ runs:
               # Extract key and value
               KEY="${line%%=*}"
               VALUE="${line#*=}"
-              echo "Adding build env: $KEY"
-              # Add as build-time environment variable
-              DEPLOY_CMD="$DEPLOY_CMD --build-env $KEY=\"$VALUE\""
+              echo "Adding env: $KEY"
+              # Add as both build-time and runtime environment variable
+              DEPLOY_CMD="$DEPLOY_CMD --build-env $KEY=\"$VALUE\" --env $KEY=\"$VALUE\""
             fi
           done <<< "$ENV_VARS"
         fi


### PR DESCRIPTION
## Summary
Fixes production environment variable errors by ensuring variables are available at both build-time and runtime.

## Problem
Environment variables were only being set with `--build-env` flag, making them unavailable at runtime. This caused errors like:
```
❌ Invalid environment variables: [
  { path: [ 'E2B_API_KEY' ], message: 'Invalid input' },
  { path: [ 'GH_APP_ID' ], message: 'Invalid input' },
  { path: [ 'GH_APP_PRIVATE_KEY' ], message: 'Invalid input' },
  { path: [ 'GH_WEBHOOK_SECRET' ], message: 'Invalid input' },
  { path: [ 'DEFAULT_CLAUDE_TOKEN' ], message: 'Invalid input' }
]
```

## Solution
Modified `.github/actions/vercel-deploy/action.yml` to use both:
- `--build-env` for build-time access
- `--env` for runtime access (API routes, serverless functions)

## Testing
- [ ] Deploy to preview environment and verify API routes work
- [ ] Verify no environment variable errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)