### PR TITLE
test(e2e): add complete manual project creation flow test

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -19,6 +19,7 @@ jobs:
       docs-changed: ${{ steps.detect.outputs.docs-changed }}
       cli-changed: ${{ steps.detect.outputs.cli-changed }}
       workspace-changed: ${{ steps.detect.outputs.workspace-changed }}
+      web-e2e-changed: ${{ steps.detect.outputs.web-e2e-changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,7 @@ jobs:
             echo "docs-changed=true" >> $GITHUB_OUTPUT
             echo "cli-changed=true" >> $GITHUB_OUTPUT
             echo "workspace-changed=true" >> $GITHUB_OUTPUT
+            echo "web-e2e-changed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
           
@@ -81,6 +83,16 @@ jobs:
           else
             echo "Changes detected in workspace app"
             echo "workspace-changed=true" >> $GITHUB_OUTPUT
+          fi
+
+          # Check e2e/web tests
+          cd ../../../e2e/web
+          if git diff --quiet HEAD^ HEAD .; then
+            echo "No changes detected in web e2e tests"
+            echo "web-e2e-changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in web e2e tests"
+            echo "web-e2e-changed=true" >> $GITHUB_OUTPUT
           fi
 
   lint:
@@ -132,8 +144,8 @@ jobs:
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     needs: [change-detection]
-    # Deploy if it's a PR and either web or CLI changed (CLI needs web for e2e tests)
-    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.cli-changed == 'true')
+    # Deploy if it's a PR and either web, CLI, or web-e2e changed (they all need web deployment)
+    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.cli-changed == 'true' || needs.change-detection.outputs.web-e2e-changed == 'true')
     outputs:
       preview-url: ${{ steps.deploy.outputs.url }}
     permissions:
@@ -288,8 +300,8 @@ jobs:
     container:
       image: ghcr.io/uspark-hq/uspark-toolchain:c2b456c
     needs: [change-detection, deploy-web]
-    # Run if web changed and deployment succeeded
-    if: github.event_name == 'pull_request' && needs.change-detection.outputs.web-changed == 'true' && needs.deploy-web.outputs.preview-url != ''
+    # Run if web or web e2e tests changed and deployment succeeded
+    if: github.event_name == 'pull_request' && (needs.change-detection.outputs.web-changed == 'true' || needs.change-detection.outputs.web-e2e-changed == 'true') && needs.deploy-web.outputs.preview-url != ''
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/toolchain-init

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -343,17 +343,17 @@ test.describe("New Project Multi-Step Flow", () => {
     await expect(createButton).toBeEnabled();
     await createButton.click();
 
-    // Step 8: Wait for navigation to workspace (app subdomain)
-    // The app redirects to: app.{domain}/projects/{projectId}
+    // Step 8: Wait for navigation to project page
+    // In production: redirects to app.uspark.ai/projects/{projectId}
+    // In preview: stays on same domain /projects/{projectId}
     await page.waitForURL((url) => {
       const urlString = url.toString();
-      return urlString.includes("app.") && urlString.includes("/projects/");
+      return urlString.includes("/projects/") && !urlString.includes("/projects/new");
     }, { timeout: 30000 });
 
-    // Step 9: Verify we're on the workspace project page
+    // Step 9: Verify we're on the project page with valid UUID
     const currentUrl = page.url();
-    expect(currentUrl).toContain("app.");
-    expect(currentUrl).toMatch(/\/projects\/proj_[a-zA-Z0-9_-]+/);
+    expect(currentUrl).toMatch(/\/projects\/[a-z0-9-]{36}/);
 
     // Verify the project page loads successfully
     await page.waitForLoadState("domcontentloaded");

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -222,78 +222,6 @@ test.describe("New Project Multi-Step Flow", () => {
     }
   });
 
-  test("complete manual project creation without GitHub", async ({ page }) => {
-    // Step 1: Sign in with test user
-    await page.goto("/", { waitUntil: "domcontentloaded" });
-    await clerk.signIn({
-      page,
-      emailAddress: "e2e+clerk_test@uspark.ai",
-    });
-
-    // Step 2: Navigate to project creation page
-    await page.goto("/projects/new");
-    await page.waitForLoadState("networkidle");
-
-    // Step 3: Should see choice step (manual creation option)
-    const choiceHeading = page.getByText("Create a New Project");
-    await expect(choiceHeading).toBeVisible();
-    await page.screenshot({
-      path: "test-results/manual-01-choice-step.png",
-      fullPage: true,
-    });
-
-    // Step 4: Click "Create Project Manually" button
-    const manualButton = page.locator("button").filter({ hasText: /Create Project Manually/i });
-    await expect(manualButton).toBeVisible();
-    await manualButton.click();
-    await page.waitForLoadState("networkidle");
-
-    // Step 5: Enter project name
-    const nameHeading = page.getByText("Name Your Project");
-    await expect(nameHeading).toBeVisible();
-    await page.screenshot({
-      path: "test-results/manual-02-name-input.png",
-      fullPage: true,
-    });
-
-    const projectNameInput = page.getByPlaceholder("My Awesome Project");
-    await expect(projectNameInput).toBeVisible();
-    await projectNameInput.fill("E2E Test Project");
-    await page.screenshot({
-      path: "test-results/manual-03-name-filled.png",
-      fullPage: true,
-    });
-
-    // Step 6: Click Continue
-    const continueButton = page.locator("button").filter({ hasText: /Continue/i });
-    await expect(continueButton).toBeEnabled();
-    await continueButton.click();
-    await page.waitForLoadState("networkidle");
-
-    // Step 7: Verify "You're All Set!" page
-    const readyHeading = page.getByText("You're All Set!");
-    await expect(readyHeading).toBeVisible();
-    await page.screenshot({
-      path: "test-results/manual-04-ready.png",
-      fullPage: true,
-    });
-
-    // Verify project name is displayed
-    await expect(page.getByText("E2E Test Project")).toBeVisible();
-
-    // Verify "Create Project" button (not "Start Scanning")
-    const createButton = page.locator("button").filter({ hasText: /Create Project/i });
-    await expect(createButton).toBeVisible();
-    await expect(createButton).toBeEnabled();
-
-    await page.screenshot({
-      path: "test-results/manual-05-final.png",
-      fullPage: true,
-    });
-
-    // Note: We don't actually click "Create Project" to avoid creating test projects in the database
-  });
-
   test("complete manual project creation and verify workspace redirect", async ({ page }) => {
     // Step 1: Sign in with test user
     await page.goto("/", { waitUntil: "domcontentloaded" });
@@ -346,10 +274,12 @@ test.describe("New Project Multi-Step Flow", () => {
     // Step 8: Wait for navigation to project page
     // In production: redirects to app.uspark.ai/projects/{projectId}
     // In preview: stays on same domain /projects/{projectId}
+    // Note: Uses default timeout (30s from playwright.config.ts) which is sufficient
+    // for database write + page redirect in both production and preview environments
     await page.waitForURL((url) => {
       const urlString = url.toString();
       return urlString.includes("/projects/") && !urlString.includes("/projects/new");
-    }, { timeout: 30000 });
+    });
 
     // Step 9: Verify we're on the project page with valid UUID
     const currentUrl = page.url();

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -293,4 +293,74 @@ test.describe("New Project Multi-Step Flow", () => {
 
     // Note: We don't actually click "Create Project" to avoid creating test projects in the database
   });
+
+  test("complete manual project creation and verify workspace redirect", async ({ page }) => {
+    // Step 1: Sign in with test user
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await clerk.signIn({
+      page,
+      emailAddress: "e2e+clerk_test@uspark.ai",
+    });
+
+    // Step 2: Navigate to project creation page
+    await page.goto("/projects/new");
+    await page.waitForLoadState("networkidle");
+
+    // Step 3: Click "Create Project Manually" button
+    const choiceHeading = page.getByText("Create a New Project");
+    await expect(choiceHeading).toBeVisible();
+
+    const manualButton = page.locator("button").filter({ hasText: /Create Project Manually/i });
+    await expect(manualButton).toBeVisible();
+    await manualButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // Step 4: Enter project name with timestamp to make it unique
+    const nameHeading = page.getByText("Name Your Project");
+    await expect(nameHeading).toBeVisible();
+
+    const projectName = `E2E Test Project ${Date.now()}`;
+    const projectNameInput = page.getByPlaceholder("My Awesome Project");
+    await expect(projectNameInput).toBeVisible();
+    await projectNameInput.fill(projectName);
+
+    // Step 5: Click Continue
+    const continueButton = page.locator("button").filter({ hasText: /Continue/i });
+    await expect(continueButton).toBeEnabled();
+    await continueButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // Step 6: Verify "You're All Set!" page
+    const readyHeading = page.getByText("You're All Set!");
+    await expect(readyHeading).toBeVisible();
+
+    // Verify project name is displayed
+    await expect(page.getByText(projectName)).toBeVisible();
+
+    // Step 7: Click "Create Project" button (real creation, no mock)
+    const createButton = page.locator("button").filter({ hasText: /Create Project/i });
+    await expect(createButton).toBeVisible();
+    await expect(createButton).toBeEnabled();
+    await createButton.click();
+
+    // Step 8: Wait for navigation to workspace (app subdomain)
+    // The app redirects to: app.{domain}/projects/{projectId}
+    await page.waitForURL((url) => {
+      const urlString = url.toString();
+      return urlString.includes("app.") && urlString.includes("/projects/");
+    }, { timeout: 30000 });
+
+    // Step 9: Verify we're on the workspace project page
+    const currentUrl = page.url();
+    expect(currentUrl).toContain("app.");
+    expect(currentUrl).toMatch(/\/projects\/proj_[a-zA-Z0-9_-]+/);
+
+    // Verify the project page loads successfully
+    await page.waitForLoadState("domcontentloaded");
+
+    // The page should have loaded without errors
+    // We can check for common elements like the main content area
+    const mainContent = page.locator('main, [role="main"], body').first();
+    await expect(mainContent).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Add real end-to-end test for manual project creation workflow
- **No mocking or request interception** - tests the complete real flow
- Creates actual test projects in the database
- Verifies redirect to workspace and page load
- Fix CI pipeline to deploy preview when e2e tests change

## Changes

### E2E Test
- Add new test: "complete manual project creation and verify workspace redirect"
- Uses timestamp in project name to ensure uniqueness: `E2E Test Project ${Date.now()}`
- Tests complete user journey: sign in → manual creation → name input → create → workspace redirect
- Validates URL structure and page load success
- Works in both production (with subdomain) and preview (without) environments

### CI Pipeline
- Add `web-e2e-changed` detection to trigger deployments when e2e tests change
- Check `e2e/web` directory for changes using git diff
- Trigger `deploy-web` job when `web-e2e-changed` is true
- Ensures e2e tests always have a preview environment to run against

### Code Quality Improvements (addressing review feedback)
- Remove duplicate test that stopped before clicking "Create Project"
- Remove unnecessary custom timeout (uses default 30s from config)
- Add comment explaining timeout is sufficient for database + redirect

## Test Behavior
This test **creates real data** to ensure true end-to-end integration testing:
- Creates projects with names like "E2E Test Project 1729024567890"
- Tests against deployed preview environment
- Verifies navigation to project page (cross-subdomain in production, same-domain in preview)

## Why No Mocking?
E2E tests should validate the complete system integration, not mock responses. This ensures:
- Real API calls work correctly
- Database operations succeed
- Navigation and redirects function properly
- Full user experience is tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)