### PR TITLE
fix(workspace): improve project page component documentation

### DIFF
--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -3,28 +3,30 @@ import { FileContent } from './file-content'
 import { FileTree } from './file-tree'
 import { Statusbar } from './statusbar'
 
+/**
+ * ProjectPage component that provides the main workspace layout.
+ * Features a three-column layout with file tree, content viewer, and chat panel,
+ * plus a bottom status bar for project information.
+ *
+ * @returns The complete project workspace interface
+ */
 export function ProjectPage() {
   return (
     <div className="flex h-screen flex-col bg-[#1e1e1e] text-[#cccccc]">
-      {/* Main content */}
       <div className="flex min-h-0 flex-1">
-        {/* Left sidebar - File tree */}
         <div className="w-64 flex-shrink-0 border-r border-[#3e3e42]">
           <FileTree />
         </div>
 
-        {/* Center panel - File content */}
         <div className="flex-1 border-r border-[#3e3e42]">
           <FileContent />
         </div>
 
-        {/* Right sidebar - Chat window */}
         <div className="w-96 flex-shrink-0">
           <ChatWindow />
         </div>
       </div>
 
-      {/* Bottom statusbar */}
       <Statusbar />
     </div>
   )


### PR DESCRIPTION
## Summary
- Remove inline JSX comments from ProjectPage component
- Add comprehensive JSDoc documentation for better code maintainability

## Context
This PR triggers a workspace release (v1.11.3) to deploy the Vite 6 rollback and environment variable fixes. The documentation improvement is a legitimate enhancement.

## Related
- Deploys Vite 6 rollback from #532
- Fixes VITE_CLERK_PUBLISHABLE_KEY environment variable issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)