### PR TITLE
feat: redirect to /projects/:id/init page after GitHub project creation

### DIFF
--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -172,8 +172,7 @@ test.describe("New Project Multi-Step Flow", () => {
     // Step 9: Verify redirect to /projects/:id/init page
     await page.waitForURL(/\/projects\/[a-z0-9-]{36}\/init/, { timeout: 10000 });
 
-    const currentUrl = page.url();
-    expect(currentUrl).toMatch(/\/projects\/[a-z0-9-]{36}\/init$/);
+    expect(page.url()).toMatch(/\/projects\/[a-z0-9-]{36}\/init$/);
 
     // Step 10: Verify init page shows scan progress
     await page.waitForLoadState("domcontentloaded");

--- a/e2e/web/tests/new-project-multi-step-flow.spec.ts
+++ b/e2e/web/tests/new-project-multi-step-flow.spec.ts
@@ -166,7 +166,29 @@ test.describe("New Project Multi-Step Flow", () => {
       fullPage: true,
     });
 
-    // Note: We don't actually click "Start Scanning" to avoid creating projects in test environment
+    // Click "Start Scanning" to create project
+    await startButton.click();
+
+    // Step 9: Verify redirect to /projects/:id/init page
+    await page.waitForURL(/\/projects\/[a-z0-9-]{36}\/init/, { timeout: 10000 });
+
+    const currentUrl = page.url();
+    expect(currentUrl).toMatch(/\/projects\/[a-z0-9-]{36}\/init$/);
+
+    // Step 10: Verify init page shows scan progress
+    await page.waitForLoadState("domcontentloaded");
+
+    // Should show "Scanning {projectName}" heading
+    const scanningHeading = page.locator("h3").filter({ hasText: /Scanning/i });
+    await expect(scanningHeading).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({
+      path: "test-results/multi-step-10-init-page.png",
+      fullPage: true,
+    });
+
+    // Note: The init page will auto-redirect to workspace when scan completes,
+    // but we don't wait for that in this test to avoid long waits
   });
 
   test("shows error when token is invalid", async ({ page }) => {

--- a/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
@@ -1,0 +1,261 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import { server, http, HttpResponse } from "../../../../../src/test/msw-setup";
+import ProjectInitPage from "../page";
+
+// Mock useParams
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "project-123" }),
+}));
+
+describe("ProjectInitPage", () => {
+  beforeEach(() => {
+    // Set up default handlers for this test suite
+    server.use(
+      // Projects endpoint - GET (list)
+      http.get("*/api/projects", () => {
+        return HttpResponse.json({
+          projects: [
+            {
+              id: "project-123",
+              name: "test-repo",
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              initial_scan_status: "running",
+              initial_scan_progress: {
+                todos: [
+                  {
+                    content: "Clone repository",
+                    status: "in_progress",
+                    activeForm: "Cloning repository",
+                  },
+                ],
+              },
+            },
+          ],
+        });
+      }),
+    );
+  });
+
+  afterEach(() => server.resetHandlers());
+
+  it("should display loading state initially", async () => {
+    render(<ProjectInitPage />);
+
+    expect(screen.getByText("Loading project...")).toBeInTheDocument();
+  });
+
+  it("should display scan progress for running scan", async () => {
+    render(<ProjectInitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Scanning test-repo")).toBeInTheDocument();
+      expect(screen.getByText("Cloning repository")).toBeInTheDocument();
+    });
+  });
+
+  it("should display error when project not found", async () => {
+    server.use(
+      http.get("*/api/projects", () => {
+        return HttpResponse.json({
+          projects: [],
+        });
+      }),
+    );
+
+    render(<ProjectInitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Project not found")).toBeInTheDocument();
+    });
+  });
+
+  it("should display error when fetch fails", async () => {
+    server.use(
+      http.get("*/api/projects", () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    render(<ProjectInitPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load project")).toBeInTheDocument();
+    });
+  });
+
+  it("should auto-redirect when scan completes successfully", async () => {
+    // Mock window.location.href
+    Object.defineProperty(window, "location", {
+      value: { href: "https://www.example.com" },
+      writable: true,
+    });
+
+    let pollCount = 0;
+
+    server.use(
+      http.get("*/api/projects", () => {
+        pollCount++;
+        if (pollCount === 1) {
+          // First fetch: get project with running scan
+          return HttpResponse.json({
+            projects: [
+              {
+                id: "project-123",
+                name: "test-repo",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                initial_scan_status: "running",
+                initial_scan_progress: {
+                  todos: [
+                    {
+                      content: "Clone repository",
+                      status: "in_progress",
+                      activeForm: "Cloning repository",
+                    },
+                  ],
+                },
+              },
+            ],
+          });
+        } else {
+          // Subsequent polls: scan completed
+          return HttpResponse.json({
+            projects: [
+              {
+                id: "project-123",
+                name: "test-repo",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                initial_scan_status: "completed",
+                initial_scan_progress: null,
+              },
+            ],
+          });
+        }
+      }),
+    );
+
+    render(<ProjectInitPage />);
+
+    // Wait for initial scan progress
+    await waitFor(() => {
+      expect(screen.getByText("Cloning repository")).toBeInTheDocument();
+    });
+
+    // Should auto-redirect when scan completes
+    await waitFor(
+      () => {
+        expect(window.location.href).toBe(
+          "https://app.example.com/projects/project-123",
+        );
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("should auto-redirect when scan fails", async () => {
+    // Mock window.location.href
+    Object.defineProperty(window, "location", {
+      value: { href: "https://www.example.com" },
+      writable: true,
+    });
+
+    let pollCount = 0;
+
+    server.use(
+      http.get("*/api/projects", () => {
+        pollCount++;
+        if (pollCount === 1) {
+          // First fetch: get project with running scan
+          return HttpResponse.json({
+            projects: [
+              {
+                id: "project-123",
+                name: "test-repo",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                initial_scan_status: "running",
+                initial_scan_progress: {
+                  todos: [
+                    {
+                      content: "Analyze code",
+                      status: "in_progress",
+                      activeForm: "Analyzing code",
+                    },
+                  ],
+                },
+              },
+            ],
+          });
+        } else {
+          // Subsequent polls: scan failed
+          return HttpResponse.json({
+            projects: [
+              {
+                id: "project-123",
+                name: "test-repo",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                initial_scan_status: "failed",
+                initial_scan_progress: null,
+              },
+            ],
+          });
+        }
+      }),
+    );
+
+    render(<ProjectInitPage />);
+
+    // Wait for initial scan progress
+    await waitFor(() => {
+      expect(screen.getByText("Analyzing code")).toBeInTheDocument();
+    });
+
+    // Should auto-redirect even when scan fails
+    await waitFor(
+      () => {
+        expect(window.location.href).toBe(
+          "https://app.example.com/projects/project-123",
+        );
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  it("should redirect immediately if scan is already completed on mount", async () => {
+    // Mock window.location.href
+    Object.defineProperty(window, "location", {
+      value: { href: "https://www.example.com" },
+      writable: true,
+    });
+
+    server.use(
+      http.get("*/api/projects", () => {
+        return HttpResponse.json({
+          projects: [
+            {
+              id: "project-123",
+              name: "test-repo",
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              initial_scan_status: "completed",
+              initial_scan_progress: null,
+            },
+          ],
+        });
+      }),
+    );
+
+    render(<ProjectInitPage />);
+
+    // Should redirect immediately without showing scan progress
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://app.example.com/projects/project-123",
+      );
+    });
+  });
+});

--- a/turbo/apps/web/app/projects/[id]/init/page.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { InitialScanProgress } from "../../../components/initial-scan-progress";
+import type { Project } from "@uspark/core";
+
+// Poll interval for checking scan progress (milliseconds)
+const SCAN_POLL_INTERVAL_MS = 3000;
+
+export default function ProjectInitPage() {
+  const params = useParams();
+  const projectId = params.id as string;
+  const [project, setProject] = useState<Project | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  // Navigate to project in app subdomain (workspace)
+  const navigateToProject = (id: string) => {
+    const currentUrl = new URL(window.location.href);
+    const newUrl =
+      currentUrl.origin.replace("www.", "app.") + `/projects/${id}`;
+    window.location.href = newUrl;
+  };
+
+  // Fetch project details on mount
+  useEffect(() => {
+    const fetchProject = async () => {
+      try {
+        const response = await fetch("/api/projects");
+        if (!response.ok) {
+          setError("Failed to fetch project details");
+          setLoading(false);
+          return;
+        }
+
+        const data = await response.json();
+        const foundProject = data.projects.find(
+          (p: Project) => p.id === projectId,
+        );
+
+        if (!foundProject) {
+          setError("Project not found");
+          setLoading(false);
+          return;
+        }
+
+        setProject(foundProject);
+        setLoading(false);
+
+        // If scan is already completed or failed, redirect immediately
+        if (
+          foundProject.initial_scan_status === "completed" ||
+          foundProject.initial_scan_status === "failed"
+        ) {
+          navigateToProject(foundProject.id);
+        }
+      } catch {
+        setError("Failed to load project");
+        setLoading(false);
+      }
+    };
+
+    fetchProject();
+  }, [projectId]);
+
+  // Poll for scan completion and auto-redirect when done
+  useEffect(() => {
+    if (!project || loading) {
+      return;
+    }
+
+    // Don't poll if scan is already completed or failed
+    if (
+      project.initial_scan_status === "completed" ||
+      project.initial_scan_status === "failed"
+    ) {
+      return;
+    }
+
+    const interval = setInterval(async () => {
+      try {
+        const response = await fetch("/api/projects");
+        if (response.ok) {
+          const data = await response.json();
+          const updatedProject = data.projects.find(
+            (p: Project) => p.id === projectId,
+          );
+          if (updatedProject) {
+            setProject(updatedProject);
+            // Auto-redirect when scan completes (both success and failure)
+            if (
+              updatedProject.initial_scan_status === "completed" ||
+              updatedProject.initial_scan_status === "failed"
+            ) {
+              clearInterval(interval);
+              navigateToProject(updatedProject.id);
+            }
+          }
+        }
+      } catch {
+        // Ignore polling errors
+      }
+    }, SCAN_POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [project, projectId, loading]);
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="mb-4 h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent mx-auto" />
+          <p className="text-muted-foreground">Loading project...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !project) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <p className="text-destructive">{error || "Project not found"}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-2xl">
+        <InitialScanProgress
+          progress={project.initial_scan_progress || null}
+          projectName={project.name}
+        />
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
@@ -249,14 +249,14 @@ describe("NewProjectPage", () => {
     expect(continueButton).toBeDisabled();
   });
 
-  it("should auto-redirect when scan completes successfully", async () => {
+  it("should redirect to init page after GitHub project creation", async () => {
     // Mock window.location.href
-    delete (window as { location?: unknown }).location;
-    window.location = { href: "https://www.example.com" } as Location;
+    Object.defineProperty(window, "location", {
+      value: { href: "https://www.example.com" },
+      writable: true,
+    });
 
-    let pollCount = 0;
-
-    // Mock project creation and scanning
+    // Mock project creation
     server.use(
       http.post("*/api/projects", () => {
         return HttpResponse.json({
@@ -265,47 +265,6 @@ describe("NewProjectPage", () => {
           created_at: new Date().toISOString(),
         });
       }),
-      // Initial fetch after project creation and polling
-      http.get("*/api/projects", () => {
-        pollCount++;
-        if (pollCount === 1) {
-          // First fetch: get created project with scanning status
-          return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "running",
-                initial_scan_progress: {
-                  todos: [
-                    {
-                      content: "Clone repository",
-                      status: "in_progress",
-                      activeForm: "Cloning repository",
-                    },
-                  ],
-                },
-              },
-            ],
-          });
-        } else {
-          // Subsequent polls: scan completed
-          return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "completed",
-                initial_scan_progress: null,
-              },
-            ],
-          });
-        }
-      }),
     );
 
     render(<NewProjectPage />);
@@ -323,115 +282,12 @@ describe("NewProjectPage", () => {
       expect(screen.getByText("You're All Set!")).toBeInTheDocument();
     });
 
-    // Start scanning
+    // Start scanning - should redirect to init page
     fireEvent.click(screen.getByRole("button", { name: /Start Scanning/i }));
 
-    // Wait for scanning UI
+    // Should redirect to init page
     await waitFor(() => {
-      expect(screen.getByText("Cloning repository")).toBeInTheDocument();
+      expect(window.location.href).toBe("/projects/project-123/init");
     });
-
-    // Should auto-redirect when scan completes
-    await waitFor(
-      () => {
-        expect(window.location.href).toBe(
-          "https://app.example.com/projects/project-123",
-        );
-      },
-      { timeout: 5000 },
-    );
-  });
-
-  it("should auto-redirect when scan fails", async () => {
-    // Mock window.location.href
-    delete (window as { location?: unknown }).location;
-    window.location = { href: "https://www.example.com" } as Location;
-
-    let pollCount = 0;
-
-    // Mock project creation and scanning
-    server.use(
-      http.post("*/api/projects", () => {
-        return HttpResponse.json({
-          id: "project-456",
-          name: "test-repo",
-          created_at: new Date().toISOString(),
-        });
-      }),
-      // Initial fetch after project creation and polling
-      http.get("*/api/projects", () => {
-        pollCount++;
-        if (pollCount === 1) {
-          // First fetch: get created project with scanning status
-          return HttpResponse.json({
-            projects: [
-              {
-                id: "project-456",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "running",
-                initial_scan_progress: {
-                  todos: [
-                    {
-                      content: "Analyze code",
-                      status: "in_progress",
-                      activeForm: "Analyzing code",
-                    },
-                  ],
-                },
-              },
-            ],
-          });
-        } else {
-          // Subsequent polls: scan failed
-          return HttpResponse.json({
-            projects: [
-              {
-                id: "project-456",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "failed",
-                initial_scan_progress: null,
-              },
-            ],
-          });
-        }
-      }),
-    );
-
-    render(<NewProjectPage />);
-
-    // Navigate through the flow
-    await waitFor(() => {
-      expect(screen.getByRole("combobox")).toBeInTheDocument();
-    });
-
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "test-user/test-repo" } });
-    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("You're All Set!")).toBeInTheDocument();
-    });
-
-    // Start scanning
-    fireEvent.click(screen.getByRole("button", { name: /Start Scanning/i }));
-
-    // Wait for scanning UI
-    await waitFor(() => {
-      expect(screen.getByText("Analyzing code")).toBeInTheDocument();
-    });
-
-    // Should auto-redirect even when scan fails
-    await waitFor(
-      () => {
-        expect(window.location.href).toBe(
-          "https://app.example.com/projects/project-456",
-        );
-      },
-      { timeout: 5000 },
-    );
   });
 });


### PR DESCRIPTION
## Summary

Refactors the project creation flow to redirect GitHub projects to a dedicated initialization page (`/projects/:id/init`) instead of displaying scan progress on the `/projects/new` page. This provides better separation of concerns and a cleaner user experience.

## Changes

### New Features
- **Created `/projects/[id]/init` page**: New dedicated page for displaying scan progress
  - Fetches project details on mount
  - Polls scan status every 3 seconds
  - Auto-redirects to workspace when scan completes or fails
  - Handles loading and error states

### Refactoring
- **Updated `/projects/new` page**: Simplified project creation flow
  - Removed "scanning" step from creation wizard
  - Immediately redirects to `/projects/:id/init` after GitHub project creation
  - Removed scan polling logic (now in init page)
  - Cleaned up unused imports and state variables
  - Manual projects continue to redirect directly to workspace (unchanged)

### Testing
- **Unit tests**: 
  - Added comprehensive tests for new init page (7 tests)
  - Updated `/projects/new` tests to verify redirect behavior
  - All 15 tests passing
- **E2E tests**: 
  - Updated flow to verify redirect to init page
  - Tests init page displays scan progress correctly

## Files Changed

- `turbo/apps/web/app/projects/[id]/init/page.tsx` (+140 lines) - New init page
- `turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx` (+261 lines) - New tests
- `turbo/apps/web/app/projects/new/page.tsx` (-87 lines) - Simplified
- `turbo/apps/web/app/projects/new/__tests__/page.test.tsx` (-162 lines) - Updated
- `e2e/web/tests/new-project-multi-step-flow.spec.ts` (+24/-0 lines) - Enhanced

## Flow Comparison

### Before
1. User completes project creation on `/projects/new`
2. Page stays on `/projects/new` showing "scanning" step
3. Polls for completion
4. Redirects to workspace

### After
1. User completes project creation on `/projects/new`
2. **Immediately redirects to `/projects/:id/init`**
3. Init page displays scan progress
4. Polls for completion
5. Redirects to workspace

## Test Results

✅ All unit tests passing (15/15)
✅ All e2e tests updated and passing
✅ Type checking passed
✅ Linting passed
✅ Formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)