### PR TITLE
feat: improve project init page ux with progress indicator and smart navigation

### DIFF
--- a/turbo/apps/web/app/components/initial-scan-progress.tsx
+++ b/turbo/apps/web/app/components/initial-scan-progress.tsx
@@ -42,6 +42,11 @@ export function InitialScanProgress({
     const inProgressTodos = progress.todos.filter(
       (todo) => todo.status === "in_progress",
     );
+    const completedTodos = progress.todos.filter(
+      (todo) => todo.status === "completed",
+    );
+    const totalTodos = progress.todos.length;
+    const completedCount = completedTodos.length;
 
     // If no in_progress tasks, show a generic scanning message
     if (inProgressTodos.length === 0) {
@@ -60,9 +65,8 @@ export function InitialScanProgress({
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Loader2 className="h-5 w-5 animate-spin text-primary" />
-            Scanning {projectName}
+          <CardTitle>
+            Scanning {projectName} [{completedCount}/{totalTodos}]
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
@@ -22,6 +22,7 @@ describe("ProjectInitPage", () => {
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
               initial_scan_status: "running",
+              initial_scan_turn_status: "in_progress",
               initial_scan_progress: {
                 todos: [
                   {
@@ -50,7 +51,7 @@ describe("ProjectInitPage", () => {
     render(<ProjectInitPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Scanning test-repo")).toBeInTheDocument();
+      expect(screen.getByText(/Scanning test-repo/)).toBeInTheDocument();
       expect(screen.getByText("Cloning repository")).toBeInTheDocument();
     });
   });
@@ -107,6 +108,7 @@ describe("ProjectInitPage", () => {
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 initial_scan_status: "running",
+                initial_scan_turn_status: "in_progress",
                 initial_scan_progress: {
                   todos: [
                     {
@@ -129,6 +131,7 @@ describe("ProjectInitPage", () => {
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 initial_scan_status: "completed",
+                initial_scan_turn_status: "completed",
                 initial_scan_progress: null,
               },
             ],
@@ -177,6 +180,7 @@ describe("ProjectInitPage", () => {
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 initial_scan_status: "running",
+                initial_scan_turn_status: "in_progress",
                 initial_scan_progress: {
                   todos: [
                     {
@@ -199,6 +203,7 @@ describe("ProjectInitPage", () => {
                 created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
                 initial_scan_status: "failed",
+                initial_scan_turn_status: "failed",
                 initial_scan_progress: null,
               },
             ],
@@ -242,6 +247,7 @@ describe("ProjectInitPage", () => {
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
               initial_scan_status: "completed",
+              initial_scan_turn_status: "completed",
               initial_scan_progress: null,
             },
           ],

--- a/turbo/apps/web/app/projects/[id]/init/page.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/page.tsx
@@ -48,11 +48,8 @@ export default function ProjectInitPage() {
         setProject(foundProject);
         setLoading(false);
 
-        // If scan is already completed or failed, redirect immediately
-        if (
-          foundProject.initial_scan_status === "completed" ||
-          foundProject.initial_scan_status === "failed"
-        ) {
+        // If first turn is completed, redirect immediately
+        if (foundProject.initial_scan_turn_status === "completed") {
           navigateToProject(foundProject.id);
         }
       } catch {
@@ -70,11 +67,8 @@ export default function ProjectInitPage() {
       return;
     }
 
-    // Don't poll if scan is already completed or failed
-    if (
-      project.initial_scan_status === "completed" ||
-      project.initial_scan_status === "failed"
-    ) {
+    // Don't poll if first turn is already completed
+    if (project.initial_scan_turn_status === "completed") {
       return;
     }
 
@@ -88,11 +82,8 @@ export default function ProjectInitPage() {
           );
           if (updatedProject) {
             setProject(updatedProject);
-            // Auto-redirect when scan completes (both success and failure)
-            if (
-              updatedProject.initial_scan_status === "completed" ||
-              updatedProject.initial_scan_status === "failed"
-            ) {
+            // Auto-redirect when first turn completes
+            if (updatedProject.initial_scan_turn_status === "completed") {
               clearInterval(interval);
               navigateToProject(updatedProject.id);
             }

--- a/turbo/apps/web/app/projects/[id]/init/page.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/page.tsx
@@ -48,8 +48,11 @@ export default function ProjectInitPage() {
         setProject(foundProject);
         setLoading(false);
 
-        // If first turn is completed, redirect immediately
-        if (foundProject.initial_scan_turn_status === "completed") {
+        // If first turn is completed or failed, redirect immediately
+        if (
+          foundProject.initial_scan_turn_status === "completed" ||
+          foundProject.initial_scan_turn_status === "failed"
+        ) {
           navigateToProject(foundProject.id);
         }
       } catch {
@@ -67,8 +70,11 @@ export default function ProjectInitPage() {
       return;
     }
 
-    // Don't poll if first turn is already completed
-    if (project.initial_scan_turn_status === "completed") {
+    // Don't poll if first turn is already completed or failed
+    if (
+      project.initial_scan_turn_status === "completed" ||
+      project.initial_scan_turn_status === "failed"
+    ) {
       return;
     }
 
@@ -82,8 +88,11 @@ export default function ProjectInitPage() {
           );
           if (updatedProject) {
             setProject(updatedProject);
-            // Auto-redirect when first turn completes
-            if (updatedProject.initial_scan_turn_status === "completed") {
+            // Auto-redirect when first turn completes or fails
+            if (
+              updatedProject.initial_scan_turn_status === "completed" ||
+              updatedProject.initial_scan_turn_status === "failed"
+            ) {
               clearInterval(interval);
               navigateToProject(updatedProject.id);
             }

--- a/turbo/apps/web/app/projects/page.tsx
+++ b/turbo/apps/web/app/projects/page.tsx
@@ -40,11 +40,22 @@ export default function ProjectsListPage() {
   const [deleting, setDeleting] = useState(false);
   const [checkingGitHub, setCheckingGitHub] = useState(true);
 
-  // Navigate to project in app subdomain (workspace)
-  const navigateToProject = (projectId: string) => {
+  // Navigate to project - check if init is completed
+  const navigateToProject = (project: Project) => {
     const currentUrl = new URL(window.location.href);
+
+    // If project has an init session and first turn is not completed, go to init page
+    if (
+      project.initial_scan_session_id &&
+      project.initial_scan_turn_status !== "completed"
+    ) {
+      window.location.href = `/projects/${project.id}/init`;
+      return;
+    }
+
+    // Otherwise go to the workspace project page
     const newUrl =
-      currentUrl.origin.replace("www.", "app.") + `/projects/${projectId}`;
+      currentUrl.origin.replace("www.", "app.") + `/projects/${project.id}`;
     window.location.href = newUrl;
   };
 
@@ -219,7 +230,7 @@ export default function ProjectsListPage() {
             <Card
               key={project.id}
               className="group cursor-pointer transition-all hover:shadow-lg"
-              onClick={() => navigateToProject(project.id)}
+              onClick={() => navigateToProject(project)}
             >
               <CardHeader>
                 <div className="flex items-start justify-between">

--- a/turbo/packages/core/src/contracts/projects.contract.ts
+++ b/turbo/packages/core/src/contracts/projects.contract.ts
@@ -51,6 +51,11 @@ export const ProjectSchema = z.object({
   initial_scan_progress: InitialScanProgressSchema.nullable()
     .optional()
     .describe("Progress of initial scan (todos or last block)"),
+  initial_scan_turn_status: z
+    .enum(["pending", "running", "completed", "failed"])
+    .nullable()
+    .optional()
+    .describe("Status of the first turn in the initial scan session"),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/projects.contract.ts
+++ b/turbo/packages/core/src/contracts/projects.contract.ts
@@ -52,8 +52,9 @@ export const ProjectSchema = z.object({
     .optional()
     .describe("Progress of initial scan (todos or last block)"),
   initial_scan_turn_status: z
-    .enum(["pending", "running", "completed", "failed"])
-    .nullable()
+    .nullable(
+      z.enum(["pending", "in_progress", "completed", "failed", "interrupted"]),
+    )
     .optional()
     .describe("Status of the first turn in the initial scan session"),
 });


### PR DESCRIPTION
## Summary

This PR improves the project initialization page user experience by addressing several UX issues:

- Removes duplicate spinner in title when todos are displayed - now shows a clean title with progress indicator
- Adds [completed/total] progress indicator (e.g., [2/6]) to give users a better sense of progress
- Auto-redirects to project page when init session's first turn completes (instead of checking scan status)
- Implements conditional navigation in project list based on init turn status - directs users to init page if initialization is incomplete, or to the workspace project page if complete
- Includes initial_scan_turn_status in project API response for accurate status tracking

## Changes

### Modified Files:
- `turbo/apps/web/app/components/initial-scan-progress.tsx` - Removed title spinner when todos exist, added progress indicator
- `turbo/apps/web/app/projects/[id]/init/page.tsx` - Updated auto-redirect logic to check turn status instead of scan status
- `turbo/apps/web/app/projects/page.tsx` - Added conditional navigation based on init turn status
- `turbo/apps/web/app/api/projects/route.ts` - Added turn status query to API response
- `turbo/packages/core/src/contracts/projects.contract.ts` - Added initial_scan_turn_status field to Project schema

## Test Plan

- [x] All CI checks pass locally
- [ ] Verify spinner is removed from title when todos are present
- [ ] Verify progress indicator shows [completed/total] format
- [ ] Verify auto-redirect works when first turn completes
- [ ] Verify project list navigation goes to init page when turn is not completed
- [ ] Verify project list navigation goes to workspace page when turn is completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)