### PR TITLE
fix: display task counter before task description and show correct index

### DIFF
--- a/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/initial-scan-progress.test.tsx
@@ -39,8 +39,10 @@ describe("InitialScanProgress", () => {
       <InitialScanProgress progress={progress} projectName="Test Project" />,
     );
 
-    // Should only show the in_progress task
-    expect(screen.getByText("Analyzing code structure")).toBeInTheDocument();
+    // Should only show the in_progress task with correct counter
+    expect(
+      screen.getByText("[2/3] Analyzing code structure"),
+    ).toBeInTheDocument();
 
     // Should NOT show completed tasks
     expect(screen.queryByText("Clone repository")).not.toBeInTheDocument();
@@ -117,8 +119,10 @@ describe("InitialScanProgress", () => {
       <InitialScanProgress progress={progress} projectName="Test Project" />,
     );
 
-    // Should show both in_progress tasks
-    expect(screen.getByText("Analyzing code structure")).toBeInTheDocument();
-    expect(screen.getByText("Scanning dependencies")).toBeInTheDocument();
+    // Should show both in_progress tasks with correct counters
+    expect(
+      screen.getByText("[1/2] Analyzing code structure"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("[2/2] Scanning dependencies")).toBeInTheDocument();
   });
 });

--- a/turbo/apps/web/app/components/initial-scan-progress.tsx
+++ b/turbo/apps/web/app/components/initial-scan-progress.tsx
@@ -71,17 +71,28 @@ export function InitialScanProgress({
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {inProgressTodos.map((todo, index) => (
-              <div
-                key={index}
-                className="flex items-start gap-3 rounded-lg border p-3"
-              >
-                <Loader2 className="h-5 w-5 animate-spin text-primary mt-0.5 flex-shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium">{todo.activeForm}</p>
+            {inProgressTodos.map((todo, index) => {
+              // Find the actual index of this task in the full todos array
+              // We know progress.todos exists here because we're inside the if block
+              const actualIndex = progress.todos!.findIndex(
+                (t) => t.content === todo.content && t.status === todo.status,
+              );
+              const currentTaskNumber = actualIndex + 1;
+
+              return (
+                <div
+                  key={index}
+                  className="flex items-start gap-3 rounded-lg border p-3"
+                >
+                  <Loader2 className="h-5 w-5 animate-spin text-primary mt-0.5 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium">
+                      [{currentTaskNumber}/{totalTodos}] {todo.activeForm}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </CardContent>
       </Card>

--- a/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
@@ -52,7 +52,7 @@ describe("ProjectInitPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Scanning test-repo/)).toBeInTheDocument();
-      expect(screen.getByText("Cloning repository")).toBeInTheDocument();
+      expect(screen.getByText("[1/1] Cloning repository")).toBeInTheDocument();
     });
   });
 
@@ -144,7 +144,7 @@ describe("ProjectInitPage", () => {
 
     // Wait for initial scan progress
     await waitFor(() => {
-      expect(screen.getByText("Cloning repository")).toBeInTheDocument();
+      expect(screen.getByText("[1/1] Cloning repository")).toBeInTheDocument();
     });
 
     // Should auto-redirect when scan completes
@@ -216,7 +216,7 @@ describe("ProjectInitPage", () => {
 
     // Wait for initial scan progress
     await waitFor(() => {
-      expect(screen.getByText("Analyzing code")).toBeInTheDocument();
+      expect(screen.getByText("[1/1] Analyzing code")).toBeInTheDocument();
     });
 
     // Should auto-redirect even when scan fails


### PR DESCRIPTION
## Summary

This PR fixes two issues with the task counter on the init page:

- **Counter Positioning**: Task counter `[n/total]` now appears before the task description instead of missing
- **Counter Value**: Shows the correct current task index from the full todos array, not always "1"

## Changes Made

1. **Initial Scan Progress Component** (`initial-scan-progress.tsx`):
   - Added task counter display in format `[currentTaskNumber/totalTodos]` before each task description
   - Fixed counter calculation to use the actual index from the full `todos` array instead of the filtered `inProgressTodos` array
   - Used non-null assertion for `progress.todos` since we're inside a guard block that verifies it exists

2. **Test Updates**:
   - Updated `initial-scan-progress.test.tsx` to expect task counter in task descriptions
   - Updated `page.test.tsx` for init page to match new format with counter

## Test Plan

- ✅ All existing tests pass with updated assertions
- ✅ Lint, type-check, format, and knip checks pass
- ✅ Counter displays before each task description
- ✅ Counter shows correct index (e.g., `[2/3]` for second task out of three)

## Before vs After

**Before:**
```
Scanning project-name [0/3]

[Spinner] Analyzing code structure
```

**After:**
```
Scanning project-name [1/3]

[Spinner] [2/3] Analyzing code structure
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)