### PR TITLE
refactor: extract initial scan status to separate api endpoint

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "../../../../../src/test/setup";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { POST as createProject } from "../../route";
+import { POST as createSession } from "../sessions/route";
+import { POST as createTurn } from "../sessions/[sessionId]/turns/route";
+import { POST as onClaudeStdout } from "../sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route";
+import { apiCall } from "../../../../../src/test/api-helpers";
+import { initServices } from "../../../../../src/lib/init-services";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { SESSIONS_TBL } from "../../../../../src/db/schema/sessions";
+import { eq } from "drizzle-orm";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+
+const mockAuth = vi.mocked(auth);
+
+describe("/api/projects/[projectId]/initial-scan", () => {
+  const userId = `test-user-initial-scan-${Date.now()}-${process.pid}`;
+  const createdProjectIds: string[] = [];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Mock successful authentication by default
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+    createdProjectIds.length = 0;
+  });
+
+  describe("GET /api/projects/[projectId]/initial-scan", () => {
+    it("should return 401 when user is not authenticated", async () => {
+      mockAuth.mockResolvedValue({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
+
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId: "test-project-id" }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+
+    it("should return 404 when project does not exist", async () => {
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId: "non-existent-project" }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("project_not_found");
+    });
+
+    it("should return 401 when project belongs to another user", async () => {
+      // Create project as different user
+      const otherUserId = `other-user-${Date.now()}`;
+      mockAuth.mockResolvedValue({
+        userId: otherUserId,
+      } as Awaited<ReturnType<typeof auth>>);
+
+      const createResponse = await apiCall(
+        createProject,
+        "POST",
+        {},
+        { name: `Test Project ${Date.now()}` },
+      );
+      const projectId = createResponse.data.id;
+
+      // Try to access as original user
+      mockAuth.mockResolvedValue({ userId } as Awaited<
+        ReturnType<typeof auth>
+      >);
+
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+
+    it("should return null values for project without initial scan", async () => {
+      // Create project without scan
+      const createResponse = await apiCall(
+        createProject,
+        "POST",
+        {},
+        { name: `Test Project ${Date.now()}` },
+      );
+      const projectId = createResponse.data.id;
+      createdProjectIds.push(projectId);
+
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.initial_scan_status).toBeNull();
+      expect(data.initial_scan_progress).toBeNull();
+      expect(data.initial_scan_turn_status).toBeNull();
+    });
+
+    it("should return initial scan progress with todos from TodoWrite blocks", async () => {
+      initServices();
+      const db = globalThis.services.db;
+
+      // Create project
+      const createProjectResponse = await apiCall(
+        createProject,
+        "POST",
+        {},
+        { name: `Test Project ${Date.now()}` },
+      );
+      const projectId = createProjectResponse.data.id;
+      createdProjectIds.push(projectId);
+
+      // Create session
+      const sessionResponse = await createSession(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ title: "Initial Repository Scan" }),
+        }),
+        { params: Promise.resolve({ projectId }) },
+      );
+      const sessionData = await sessionResponse.json();
+      const sessionId = sessionData.id;
+
+      // Mark session as initial-scan
+      await db
+        .update(SESSIONS_TBL)
+        .set({ type: "initial-scan" })
+        .where(eq(SESSIONS_TBL.id, sessionId));
+
+      // Update project to reference this scan session
+      await db
+        .update(PROJECTS_TBL)
+        .set({
+          sourceRepoUrl: "owner/repo",
+          sourceRepoInstallationId: 12345,
+          initialScanStatus: "running",
+          initialScanSessionId: sessionId,
+        })
+        .where(eq(PROJECTS_TBL.id, projectId));
+
+      // Create turn
+      const turnResponse = await createTurn(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ user_message: "Scan repository" }),
+        }),
+        { params: Promise.resolve({ projectId, sessionId }) },
+      );
+      const turnData = await turnResponse.json();
+      const turnId = turnData.id;
+
+      // Create TodoWrite block
+      const todoWriteLine = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_todowrite_123",
+              name: "TodoWrite",
+              input: {
+                todos: [
+                  {
+                    content: "Clone repository",
+                    status: "completed",
+                    activeForm: "Cloning repository",
+                  },
+                  {
+                    content: "Analyze codebase",
+                    status: "in_progress",
+                    activeForm: "Analyzing codebase",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+
+      await onClaudeStdout(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ line: todoWriteLine }),
+        }),
+        { params: Promise.resolve({ projectId, sessionId, turnId }) },
+      );
+
+      // Get initial scan data
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.initial_scan_status).toBe("running");
+      expect(data.initial_scan_progress).toBeDefined();
+      expect(data.initial_scan_progress.todos).toHaveLength(2);
+      expect(data.initial_scan_progress.todos[0]).toMatchObject({
+        content: "Clone repository",
+        status: "completed",
+      });
+      expect(data.initial_scan_turn_status).toBe("in_progress");
+    });
+
+    it("should return lastBlock when no TodoWrite blocks exist", async () => {
+      initServices();
+      const db = globalThis.services.db;
+
+      // Create project
+      const createProjectResponse = await apiCall(
+        createProject,
+        "POST",
+        {},
+        { name: `Test Project ${Date.now()}` },
+      );
+      const projectId = createProjectResponse.data.id;
+      createdProjectIds.push(projectId);
+
+      // Create session
+      const sessionResponse = await createSession(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ title: "Initial Repository Scan" }),
+        }),
+        { params: Promise.resolve({ projectId }) },
+      );
+      const sessionData = await sessionResponse.json();
+      const sessionId = sessionData.id;
+
+      // Mark session as initial-scan
+      await db
+        .update(SESSIONS_TBL)
+        .set({ type: "initial-scan" })
+        .where(eq(SESSIONS_TBL.id, sessionId));
+
+      // Update project scan status
+      await db
+        .update(PROJECTS_TBL)
+        .set({
+          initialScanStatus: "running",
+          initialScanSessionId: sessionId,
+        })
+        .where(eq(PROJECTS_TBL.id, projectId));
+
+      // Create turn
+      const turnResponse = await createTurn(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ user_message: "Scan repository" }),
+        }),
+        { params: Promise.resolve({ projectId, sessionId }) },
+      );
+      const turnData = await turnResponse.json();
+      const turnId = turnData.id;
+
+      // Create content block (not TodoWrite)
+      const contentLine = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "Analyzing repository structure...",
+            },
+          ],
+        },
+      });
+
+      await onClaudeStdout(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ line: contentLine }),
+        }),
+        { params: Promise.resolve({ projectId, sessionId, turnId }) },
+      );
+
+      // Get initial scan data
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.initial_scan_progress).toBeDefined();
+      expect(data.initial_scan_progress.lastBlock).toBeDefined();
+      expect(data.initial_scan_progress.lastBlock.type).toBe("content");
+      expect(data.initial_scan_progress.lastBlock.content).toMatchObject({
+        text: "Analyzing repository structure...",
+      });
+    });
+
+    it("should not fetch progress for completed scans", async () => {
+      initServices();
+      const db = globalThis.services.db;
+
+      // Create project
+      const createProjectResponse = await apiCall(
+        createProject,
+        "POST",
+        {},
+        { name: `Test Project ${Date.now()}` },
+      );
+      const projectId = createProjectResponse.data.id;
+      createdProjectIds.push(projectId);
+
+      // Create session
+      const sessionResponse = await createSession(
+        new NextRequest("http://localhost:3000", {
+          method: "POST",
+          body: JSON.stringify({ title: "Initial Repository Scan" }),
+        }),
+        { params: Promise.resolve({ projectId }) },
+      );
+      const sessionData = await sessionResponse.json();
+      const sessionId = sessionData.id;
+
+      // Update project to mark scan as completed
+      await db
+        .update(PROJECTS_TBL)
+        .set({
+          initialScanStatus: "completed",
+          initialScanSessionId: sessionId,
+        })
+        .where(eq(PROJECTS_TBL.id, projectId));
+
+      // Get initial scan data
+      const response = await GET(new NextRequest("http://localhost:3000"), {
+        params: Promise.resolve({ projectId }),
+      });
+
+      const data = await response.json();
+      expect(response.status).toBe(200);
+      expect(data.initial_scan_status).toBe("completed");
+      expect(data.initial_scan_progress).toBeNull();
+    });
+  });
+});

--- a/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from "next/server";
+import { getUserId } from "../../../../../src/lib/auth/get-user-id";
+import { initServices } from "../../../../../src/lib/init-services";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { TURNS_TBL, BLOCKS_TBL } from "../../../../../src/db/schema/sessions";
+import { eq, desc } from "drizzle-orm";
+
+/**
+ * GET /api/projects/[projectId]/initial-scan
+ * Returns initial scan progress and turn status for a specific project
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+) {
+  const userId = await getUserId();
+
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  initServices();
+
+  // Verify project exists and belongs to user
+  const projects = await globalThis.services.db
+    .select({
+      id: PROJECTS_TBL.id,
+      initial_scan_status: PROJECTS_TBL.initialScanStatus,
+      initial_scan_session_id: PROJECTS_TBL.initialScanSessionId,
+    })
+    .from(PROJECTS_TBL)
+    .where(eq(PROJECTS_TBL.id, projectId));
+
+  if (projects.length === 0) {
+    return NextResponse.json(
+      {
+        error: "project_not_found",
+        error_description: "Project not found",
+      },
+      { status: 404 },
+    );
+  }
+
+  const project = projects[0]!;
+
+  // Check if project belongs to user
+  const userProjects = await globalThis.services.db
+    .select({ id: PROJECTS_TBL.id })
+    .from(PROJECTS_TBL)
+    .where(eq(PROJECTS_TBL.userId, userId));
+
+  const userProjectIds = userProjects.map((p) => p.id);
+  if (!userProjectIds.includes(projectId)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let initial_scan_progress = null;
+  let initial_scan_turn_status = null;
+
+  if (project.initial_scan_session_id) {
+    // Get first turn status for this session
+    const turns = await globalThis.services.db
+      .select({ status: TURNS_TBL.status })
+      .from(TURNS_TBL)
+      .where(eq(TURNS_TBL.sessionId, project.initial_scan_session_id))
+      .limit(1);
+
+    if (turns.length > 0) {
+      initial_scan_turn_status = turns[0]!.status;
+    }
+
+    // Only fetch progress for active scans
+    if (
+      project.initial_scan_status === "pending" ||
+      project.initial_scan_status === "running"
+    ) {
+      initial_scan_progress = await getInitialScanProgress(
+        project.initial_scan_session_id,
+      );
+    }
+  }
+
+  return NextResponse.json({
+    initial_scan_status: project.initial_scan_status,
+    initial_scan_progress,
+    initial_scan_turn_status,
+  });
+}
+
+/**
+ * Get initial scan progress from session blocks
+ */
+async function getInitialScanProgress(
+  sessionId: string,
+): Promise<{ todos?: unknown[]; lastBlock?: unknown } | null> {
+  // Get all turns for this session
+  const turns = await globalThis.services.db
+    .select({ id: TURNS_TBL.id })
+    .from(TURNS_TBL)
+    .where(eq(TURNS_TBL.sessionId, sessionId));
+
+  if (turns.length === 0) {
+    return null;
+  }
+
+  // Get all blocks for the first turn (usually only one turn in initial scan)
+  // Ordered by created_at descending to get most recent first
+  const blocks = await globalThis.services.db
+    .select()
+    .from(BLOCKS_TBL)
+    .where(eq(BLOCKS_TBL.turnId, turns[0]!.id))
+    .orderBy(desc(BLOCKS_TBL.createdAt));
+
+  // Find the most recent TodoWrite block
+  const todoWriteBlock = blocks.find(
+    (block) =>
+      block.type === "tool_use" &&
+      (block.content as { tool_name?: string }).tool_name === "TodoWrite",
+  );
+
+  if (todoWriteBlock) {
+    const content = todoWriteBlock.content as {
+      parameters?: { todos?: unknown[] };
+    };
+    return {
+      todos: content.parameters?.todos,
+    };
+  }
+
+  // If no todos, find the last content block
+  const lastContentBlock = blocks.find((block) => block.type === "content");
+
+  if (lastContentBlock) {
+    return {
+      lastBlock: {
+        type: lastContentBlock.type,
+        content: lastContentBlock.content,
+      },
+    };
+  }
+
+  return null;
+}

--- a/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/[id]/init/__tests__/page.test.tsx
@@ -22,18 +22,25 @@ describe("ProjectInitPage", () => {
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
               initial_scan_status: "running",
-              initial_scan_turn_status: "in_progress",
-              initial_scan_progress: {
-                todos: [
-                  {
-                    content: "Clone repository",
-                    status: "in_progress",
-                    activeForm: "Cloning repository",
-                  },
-                ],
-              },
+              initial_scan_session_id: "session-123",
             },
           ],
+        });
+      }),
+      // Initial scan endpoint - GET
+      http.get("*/api/projects/*/initial-scan", () => {
+        return HttpResponse.json({
+          initial_scan_status: "running",
+          initial_scan_turn_status: "in_progress",
+          initial_scan_progress: {
+            todos: [
+              {
+                content: "Clone repository",
+                status: "in_progress",
+                activeForm: "Cloning repository",
+              },
+            ],
+          },
         });
       }),
     );
@@ -97,44 +104,42 @@ describe("ProjectInitPage", () => {
 
     server.use(
       http.get("*/api/projects", () => {
+        return HttpResponse.json({
+          projects: [
+            {
+              id: "project-123",
+              name: "test-repo",
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              initial_scan_status: "running",
+              initial_scan_session_id: "session-123",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/projects/*/initial-scan", () => {
         pollCount++;
         if (pollCount === 1) {
-          // First fetch: get project with running scan
+          // First fetch: get scan with running status
           return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "running",
-                initial_scan_turn_status: "in_progress",
-                initial_scan_progress: {
-                  todos: [
-                    {
-                      content: "Clone repository",
-                      status: "in_progress",
-                      activeForm: "Cloning repository",
-                    },
-                  ],
+            initial_scan_status: "running",
+            initial_scan_turn_status: "in_progress",
+            initial_scan_progress: {
+              todos: [
+                {
+                  content: "Clone repository",
+                  status: "in_progress",
+                  activeForm: "Cloning repository",
                 },
-              },
-            ],
+              ],
+            },
           });
         } else {
           // Subsequent polls: scan completed
           return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "completed",
-                initial_scan_turn_status: "completed",
-                initial_scan_progress: null,
-              },
-            ],
+            initial_scan_status: "completed",
+            initial_scan_turn_status: "completed",
+            initial_scan_progress: null,
           });
         }
       }),
@@ -169,44 +174,42 @@ describe("ProjectInitPage", () => {
 
     server.use(
       http.get("*/api/projects", () => {
+        return HttpResponse.json({
+          projects: [
+            {
+              id: "project-123",
+              name: "test-repo",
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              initial_scan_status: "running",
+              initial_scan_session_id: "session-123",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/projects/*/initial-scan", () => {
         pollCount++;
         if (pollCount === 1) {
-          // First fetch: get project with running scan
+          // First fetch: get scan with running status
           return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "running",
-                initial_scan_turn_status: "in_progress",
-                initial_scan_progress: {
-                  todos: [
-                    {
-                      content: "Analyze code",
-                      status: "in_progress",
-                      activeForm: "Analyzing code",
-                    },
-                  ],
+            initial_scan_status: "running",
+            initial_scan_turn_status: "in_progress",
+            initial_scan_progress: {
+              todos: [
+                {
+                  content: "Analyze code",
+                  status: "in_progress",
+                  activeForm: "Analyzing code",
                 },
-              },
-            ],
+              ],
+            },
           });
         } else {
           // Subsequent polls: scan failed
           return HttpResponse.json({
-            projects: [
-              {
-                id: "project-123",
-                name: "test-repo",
-                created_at: new Date().toISOString(),
-                updated_at: new Date().toISOString(),
-                initial_scan_status: "failed",
-                initial_scan_turn_status: "failed",
-                initial_scan_progress: null,
-              },
-            ],
+            initial_scan_status: "failed",
+            initial_scan_turn_status: "failed",
+            initial_scan_progress: null,
           });
         }
       }),
@@ -247,10 +250,16 @@ describe("ProjectInitPage", () => {
               created_at: new Date().toISOString(),
               updated_at: new Date().toISOString(),
               initial_scan_status: "completed",
-              initial_scan_turn_status: "completed",
-              initial_scan_progress: null,
+              initial_scan_session_id: "session-123",
             },
           ],
+        });
+      }),
+      http.get("*/api/projects/*/initial-scan", () => {
+        return HttpResponse.json({
+          initial_scan_status: "completed",
+          initial_scan_turn_status: "completed",
+          initial_scan_progress: null,
         });
       }),
     );

--- a/turbo/apps/web/app/projects/page.tsx
+++ b/turbo/apps/web/app/projects/page.tsx
@@ -41,16 +41,26 @@ export default function ProjectsListPage() {
   const [checkingGitHub, setCheckingGitHub] = useState(true);
 
   // Navigate to project - check if init is completed
-  const navigateToProject = (project: Project) => {
+  const navigateToProject = async (project: Project) => {
     const currentUrl = new URL(window.location.href);
 
-    // If project has an init session and first turn is not completed, go to init page
-    if (
-      project.initial_scan_session_id &&
-      project.initial_scan_turn_status !== "completed"
-    ) {
-      window.location.href = `/projects/${project.id}/init`;
-      return;
+    // If project has an init session, check its status
+    if (project.initial_scan_session_id) {
+      try {
+        const scanResponse = await fetch(
+          `/api/projects/${project.id}/initial-scan`,
+        );
+        if (scanResponse.ok) {
+          const scanData = await scanResponse.json();
+          // If first turn is not completed, go to init page
+          if (scanData.initial_scan_turn_status !== "completed") {
+            window.location.href = `/projects/${project.id}/init`;
+            return;
+          }
+        }
+      } catch {
+        // If fetch fails, proceed to workspace
+      }
     }
 
     // Otherwise go to the workspace project page


### PR DESCRIPTION
## Summary

This PR refactors the initial scan status API to use a dedicated endpoint instead of embedding progress data in the projects list response.

### Changes Made

**Backend:**
- Created new endpoint: `GET /api/projects/[projectId]/initial-scan`
- Moved `initial_scan_progress` and `initial_scan_turn_status` to the new endpoint
- Kept `initial_scan_status` and `initial_scan_session_id` in `GET /api/projects` for basic status checking
- Updated contracts with new `InitialScanResponse` schema

**Frontend:**
- Updated `ProjectInitPage` to fetch from both endpoints
- Updated `ProjectsListPage` navigation logic to fetch scan status when needed
- Modified all component tests to mock the new endpoint

**Tests:**
- Created comprehensive test suite for new initial-scan endpoint
- Updated projects route tests to verify scan fields are not included
- Updated all frontend component tests to use new API structure

### Benefits

1. **Reduced Payload Size**: Project list responses no longer include heavy progress data
2. **Targeted Fetching**: Progress data only fetched when actually viewing init page
3. **Better API Design**: Follows RESTful principles with resource-specific endpoints
4. **Improved Performance**: Faster project list loading for users with many projects

### Testing

All tests pass including:
- Unit tests for new endpoint
- Integration tests for project routes
- Component tests for init page and project list
- Type safety verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)