### PR TITLE
fix(ci): use pull_request_target for cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,7 @@
 name: Cleanup Resources
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## Summary

- Changed cleanup workflow trigger from `pull_request` to `pull_request_target` to ensure reliable execution when PRs are closed
- Manually cleaned up orphaned deployments and branches from PRs #552 and #556

## Problem

The `pull_request` event requires GitHub to create a merge commit to trigger workflows. When a PR is closed (especially without merging), GitHub doesn't consistently queue this merge commit job, causing cleanup workflows to not trigger reliably.

This is a [known GitHub Actions limitation](https://github.com/orgs/community/discussions/26657) that affects workflows using `on: { pull_request: { types: ["closed"] } }`.

## Solution

The `pull_request_target` event:
- Runs in the context of the base branch (main)
- Doesn't require a merge commit
- Triggers reliably for all PR close events
- Is safe for cleanup workflows since it runs trusted code from main and only reads PR metadata

## Evidence

Two PRs were closed but their cleanup workflows never triggered:
- PR #556 (feat/monaco-editor-integration) - closed 2025-10-17, no cleanup run
- PR #552 (docs/monaco-editor-research) - closed 2025-10-16, no cleanup run

This left 6 orphaned preview deployments and 2 remote branches that were manually cleaned up.

## Test plan

- [ ] Merge this PR
- [ ] Create a test PR and close it without merging
- [ ] Verify cleanup workflow triggers and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)