### PR TITLE
build: update e2b dockerfile to cli v0.12.0

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y git curl
 RUN npm install -g @anthropic-ai/claude-code@2.0.15
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.11.9
+RUN npm install -g @uspark/cli@0.12.0
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary
Update E2B Dockerfile to use CLI v0.12.0 (latest version published to npm)

## Why
- CLI v0.12.0 was just published to npm (2025-10-18 03:47:50)
- Previous PR #567 updated from 0.11.5 → 0.11.9, but 0.12.0 is now available
- Ensures E2B sandboxes use the absolute latest version with all fixes

## Changes
- Update `@uspark/cli` version in e2b.Dockerfile: 0.11.9 → 0.12.0

## Testing
After this merges and E2B template is rebuilt:
- All new sandboxes will use CLI v0.12.0
- Initial scan status bug will be completely resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)