### PR TITLE
fix: remove duplicate task number from init page title

### DIFF
--- a/turbo/apps/web/app/components/initial-scan-progress.tsx
+++ b/turbo/apps/web/app/components/initial-scan-progress.tsx
@@ -42,11 +42,7 @@ export function InitialScanProgress({
     const inProgressTodos = progress.todos.filter(
       (todo) => todo.status === "in_progress",
     );
-    const completedTodos = progress.todos.filter(
-      (todo) => todo.status === "completed",
-    );
     const totalTodos = progress.todos.length;
-    const completedCount = completedTodos.length;
 
     // If no in_progress tasks, show a generic scanning message
     if (inProgressTodos.length === 0) {
@@ -65,9 +61,7 @@ export function InitialScanProgress({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>
-            Scanning {projectName} [{completedCount}/{totalTodos}]
-          </CardTitle>
+          <CardTitle>Scanning {projectName}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">


### PR DESCRIPTION
## Problem
The init page was showing two confusing task numbers:

**Before**:
```
Scanning uspark [4/8]           ← Title showing completed count
[5/8] Identifying code quality issues  ← Task showing current number
```

Users reported this was confusing because:
1. Title showed `[4/8]` (completed tasks)
2. Current task showed `[5/8]` (task index)
3. These numbers didn't match and caused confusion

## Solution
Remove the task counter from the title, keep it only on individual tasks.

**After**:
```
Scanning uspark                 ← Clean title without numbers
[5/8] Identifying code quality issues  ← Task showing its position
```

## Changes
- Removed `[completedCount/totalTodos]` from card title
- Removed unused `completedTodos` and `completedCount` variables
- Individual tasks still show their progress numbers `[current/total]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)