### PR TITLE
fix: add pull.log for initial scan git setup

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -236,7 +236,7 @@ grep -qxF '.uspark' .gitignore 2>/dev/null || echo '.uspark' >> .gitignore
 
 # Pull uspark content to .uspark subdirectory
 echo "Pulling uspark content to ~/workspace/.uspark..."
-uspark pull --all --project-id "${projectId}" --output-dir ~/workspace/.uspark --verbose
+uspark pull --all --project-id "${projectId}" --output-dir ~/workspace/.uspark --verbose 2>&1 | tee /tmp/pull.log
 `;
 
       const result = await sandbox.commands.run(gitSetupScript, {


### PR DESCRIPTION
## Summary

Fixes missing `/tmp/pull.log` file in E2B sandbox during initial scan when project has a GitHub repository.

## Problem

When running initial scan with a GitHub repository:
- Git setup script pulls uspark files to `~/workspace/.uspark`
- BUT the command did not include `2>&1 | tee /tmp/pull.log`
- This caused inconsistency with non-git initialization path (which does create the log file)
- Users could not debug pull failures during initial scan

## Solution

Added `2>&1 | tee /tmp/pull.log` to the `uspark pull` command in the git setup script.

**Before**:
```bash
uspark pull --all --project-id "${projectId}" --output-dir ~/workspace/.uspark --verbose
```

**After**:
```bash
uspark pull --all --project-id "${projectId}" --output-dir ~/workspace/.uspark --verbose 2>&1 | tee /tmp/pull.log
```

## Changes

- Modified `apps/web/src/lib/e2b-executor.ts:239`
- Now both initialization paths (with/without GitHub repo) create `/tmp/pull.log` consistently

## Test Plan

- [x] All tests pass (59 test files)
- [x] Lint checks pass
- [x] Type checks pass
- [ ] Manual test: Run initial scan and verify `/tmp/pull.log` exists in E2B sandbox
- [ ] Verify log file contains uspark pull output

## Impact

- **Minimal risk**: Only adds logging, does not change functionality
- **Improves debuggability**: Users can now check `/tmp/pull.log` for pull errors
- **Consistent behavior**: Both init paths now create the same log files

🤖 Generated with [Claude Code](https://claude.com/claude-code)