### PR TITLE
feat: add logging to on-claude-stdout endpoint

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
@@ -110,6 +110,9 @@ export async function POST(
 
   const { line } = parseResult.data;
 
+  // Log received content
+  console.log(`[on-claude-stdout] Received: ${line}`);
+
   // Parse Claude output line
   let block: Record<string, unknown>;
   try {


### PR DESCRIPTION
## Summary
- Add console logging to the `on-claude-stdout` API endpoint to output received content for better debugging and observability

## Test plan
- [x] Verify the logging statement is added correctly
- [ ] Test that logs appear when Claude stdout is received via watch-claude
- [ ] Confirm logs don't interfere with normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)