### PR TITLE
feat(workspace): integrate codemirror 6 for markdown file viewing

### DIFF
--- a/turbo/apps/workspace/package.json
+++ b/turbo/apps/workspace/package.json
@@ -15,6 +15,10 @@
   },
   "dependencies": {
     "@clerk/clerk-js": "^5.92.1",
+    "@codemirror/lang-markdown": "^6.4.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.38.6",
     "@uspark/core": "workspace:*",
     "ccstate": "^5.0.0",
     "ccstate-react": "^5.0.0",

--- a/turbo/apps/workspace/src/signals/project/editor.ts
+++ b/turbo/apps/workspace/src/signals/project/editor.ts
@@ -1,0 +1,62 @@
+import { markdown } from '@codemirror/lang-markdown'
+import { EditorState } from '@codemirror/state'
+import { oneDark } from '@codemirror/theme-one-dark'
+import { EditorView } from '@codemirror/view'
+import { command, computed } from 'ccstate'
+import { selectedFileContent$, selectedFileItem$ } from './project'
+
+// 编辑器初始化配置
+export const editorStateConfig$ = computed(async (get) => {
+  const file = await get(selectedFileItem$)
+
+  if (!file || file.type === 'directory' || !file.path.endsWith('.md')) {
+    return null
+  }
+
+  const content = await get(selectedFileContent$)
+  if (!content) {
+    return null
+  }
+
+  // 编辑器扩展配置
+  const editorExtensions = [
+    markdown(),
+    oneDark,
+    EditorView.lineWrapping,
+    EditorView.editable.of(false), // 只读模式
+  ]
+
+  return {
+    doc: content,
+    extensions: editorExtensions,
+  }
+})
+
+// 挂载编辑器
+export const mountEditor$ = command(
+  async ({ get }, container: HTMLElement, signal: AbortSignal) => {
+    // 获取配置
+    const config = await get(editorStateConfig$)
+    signal.throwIfAborted()
+
+    if (!config) {
+      return
+    }
+
+    // 创建 EditorView
+    const state = EditorState.create({
+      doc: config.doc,
+      extensions: config.extensions,
+    })
+
+    const view = new EditorView({
+      state,
+      parent: container,
+    })
+
+    // 监听 signal abort 事件，清理编辑器
+    signal.addEventListener('abort', () => {
+      view.destroy()
+    })
+  },
+)

--- a/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
@@ -1,0 +1,60 @@
+import { screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { server } from '../../../mocks/node'
+import { testContext } from '../../../signals/__tests__/context'
+import { setupMock } from '../../../signals/test-utils'
+import { setupProjectPage } from '../test-helpers'
+
+// Setup Clerk mock
+setupMock()
+
+const context = testContext()
+
+describe('markdown editor - codemirror integration', () => {
+  const projectId = 'test-project-md'
+  const markdownContent = '# Test Markdown\n\n## Section\n\nContent here'
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    await setupProjectPage(`/projects/${projectId}`, context, {
+      projectId,
+      files: [
+        {
+          path: 'README.md',
+          hash: 'md-hash-123',
+          content: markdownContent,
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('renders CodeMirror editor for markdown files', async () => {
+    // Wait for file tree to load
+    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+
+    // Verify CodeMirror editor is rendered by checking for its root element
+    await waitFor(() => {
+      const editorElement = document.querySelector('.cm-editor')
+      expect(editorElement).toBeInTheDocument()
+    })
+  })
+
+  it('displays markdown content in CodeMirror editor', async () => {
+    // Wait for file to load
+    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+
+    // CodeMirror renders content in .cm-content
+    const editorElement = document.querySelector('.cm-editor')
+    expect(editorElement).toBeInTheDocument()
+
+    // Verify the content is in the editor
+    const contentElement = document.querySelector('.cm-content')
+    expect(contentElement).toBeInTheDocument()
+    expect(contentElement?.textContent).toContain('Test Markdown')
+  })
+})

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -37,10 +37,15 @@ describe('projectPage - file content display', () => {
     // Wait for file tree to load
     await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
 
-    // Verify file content is displayed
-    const content = await screen.findByText(/Test README/)
-    expect(content).toBeInTheDocument()
-    expect(screen.getByText(/This is a test document/)).toBeInTheDocument()
+    // Verify file content is displayed in CodeMirror
+    await waitFor(() => {
+      const contentElement = document.querySelector('.cm-content')
+      expect(contentElement).toBeInTheDocument()
+    })
+
+    const contentElement = document.querySelector('.cm-content')
+    expect(contentElement?.textContent).toContain('Test README')
+    expect(contentElement?.textContent).toContain('This is a test document')
   })
 })
 
@@ -82,20 +87,22 @@ describe('projectPage - file selection', () => {
     const readmeFile = screen.getByText('README.md')
     await userEvent.click(readmeFile)
 
-    // Verify README content is displayed
-    await expect(
-      screen.findByText(/Main documentation/),
-    ).resolves.toBeInTheDocument()
+    // Verify README content is displayed in CodeMirror
+    await waitFor(() => {
+      const contentElement = document.querySelector('.cm-content')
+      expect(contentElement?.textContent).toContain('Main documentation')
+    })
 
     // Click on guide.md (get all matches and take the last one which is the file, not directory)
     const guideFiles = screen.getAllByText('guide.md')
     const guideFile = guideFiles[guideFiles.length - 1]
     await userEvent.click(guideFile)
 
-    // Verify guide content is displayed
-    await expect(
-      screen.findByText(/User guide content/),
-    ).resolves.toBeInTheDocument()
+    // Verify guide content is displayed in CodeMirror
+    await waitFor(() => {
+      const contentElement = document.querySelector('.cm-content')
+      expect(contentElement?.textContent).toContain('User guide content')
+    })
   })
 })
 

--- a/turbo/apps/workspace/src/views/project/file-content.tsx
+++ b/turbo/apps/workspace/src/views/project/file-content.tsx
@@ -3,6 +3,7 @@ import {
   selectedFileContent$,
   selectedFileItem$,
 } from '../../signals/project/project'
+import { MarkdownEditor } from './markdown-editor'
 
 export function FileContent() {
   const fileContent = useLastResolved(selectedFileContent$)
@@ -18,16 +19,13 @@ export function FileContent() {
     )
   }
 
-  return (
-    <div className="h-full overflow-y-auto bg-[#1e1e1e]">
-      <div className="flex items-center gap-1.5 border-b border-[#3e3e42] px-3 py-1.5 text-[13px] text-[#cccccc]">
-        <span>{selectedFile?.path.split('/').pop() ?? 'File'}</span>
-      </div>
-      <div className="p-3">
-        <pre className="font-mono text-[13px] leading-[1.6] whitespace-pre-wrap text-[#d4d4d4]">
-          {fileContent}
-        </pre>
-      </div>
-    </div>
-  )
+  // 只渲染 markdown 文件
+  const isMarkdown = selectedFile?.path.endsWith('.md') ?? false
+
+  if (isMarkdown) {
+    return <MarkdownEditor />
+  }
+
+  // 非 markdown 文件不显示内容
+  return null
 }

--- a/turbo/apps/workspace/src/views/project/markdown-editor.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-editor.tsx
@@ -1,0 +1,42 @@
+import { useGet, useLastResolved, useSet } from 'ccstate-react'
+import { pageSignal$ } from '../../signals/page-signal'
+import { editorStateConfig$, mountEditor$ } from '../../signals/project/editor'
+import { selectedFileItem$ } from '../../signals/project/project'
+import { detach, Reason } from '../../signals/utils'
+
+export function MarkdownEditor() {
+  const stateConfig = useLastResolved(editorStateConfig$)
+  const selectedFile = useLastResolved(selectedFileItem$)
+  const signal = useGet(pageSignal$)
+  const mountEditor = useSet(mountEditor$)
+
+  // ref callback: 挂载时调用 mountEditor$ command
+  const handleEditorRef = (element: HTMLDivElement | null) => {
+    if (element) {
+      detach(mountEditor(element, signal), Reason.DomCallback)
+    }
+    // 卸载时不需要处理，signal abort 会自动清理
+  }
+
+  if (!stateConfig) {
+    return null
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-[#1e1e1e]">
+      {/* 文件名标题栏 */}
+      <div className="flex items-center border-b border-[#3e3e42] px-3 py-1.5">
+        <span className="text-[13px] text-[#cccccc]">
+          {selectedFile?.path.split('/').pop()}
+        </span>
+      </div>
+
+      {/* 编辑器容器 - 使用 key 确保文件切换时重建 DOM */}
+      <div
+        key={selectedFile?.path}
+        ref={handleEditorRef}
+        className="flex-1 overflow-auto"
+      />
+    </div>
+  )
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -281,6 +281,18 @@ importers:
       '@clerk/clerk-js':
         specifier: ^5.92.1
         version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+      '@codemirror/lang-markdown':
+        specifier: ^6.4.0
+        version: 6.4.0
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.2
+      '@codemirror/theme-one-dark':
+        specifier: ^6.1.3
+        version: 6.1.3
+      '@codemirror/view':
+        specifier: ^6.38.6
+        version: 6.38.6
       '@uspark/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -717,6 +729,36 @@ packages:
   '@clerk/types@4.85.0':
     resolution: {integrity: sha512-0s7KZbWpX4e9/CHl29sYGGBUBbZa7qlXp74OaaXfm1WTzYGiOOTyyE54j2WTz91+TZxIZZu5UA5rfn9qc79hYA==}
     engines: {node: '>=18.17.0'}
+
+  '@codemirror/autocomplete@6.19.0':
+    resolution: {integrity: sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.4':
+    resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+
+  '@codemirror/lang-markdown@6.4.0':
+    resolution: {integrity: sha512-ZeArR54seh4laFbUTVy0ZmQgO+C/cxxlW4jEoQMhL3HALScBpZBeZcLzrQmJsTEx4is9GzOe0bFAke2B1KZqeA==}
+
+  '@codemirror/language@6.11.3':
+    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
+
+  '@codemirror/lint@6.9.0':
+    resolution: {integrity: sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==}
+
+  '@codemirror/state@6.5.2':
+    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.38.6':
+    resolution: {integrity: sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==}
 
   '@coinbase/wallet-sdk@4.3.0':
     resolution: {integrity: sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw==}
@@ -1407,6 +1449,30 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@lezer/common@1.3.0':
+    resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
+
+  '@lezer/css@1.3.0':
+    resolution: {integrity: sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==}
+
+  '@lezer/highlight@1.2.2':
+    resolution: {integrity: sha512-z8TQwaBXXQIvG6i2g3e9cgMwUUXu9Ib7jo2qRRggdhwKpM56Dw3PM3wmexn+EGaaOZ7az0K7sjc3/gcGW7sz7A==}
+
+  '@lezer/html@1.3.12':
+    resolution: {integrity: sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.2':
+    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
+  '@lezer/markdown@1.4.3':
+    resolution: {integrity: sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
@@ -3402,6 +3468,9 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -5726,6 +5795,9 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
 
@@ -6234,6 +6306,9 @@ packages:
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6656,6 +6731,86 @@ snapshots:
   '@clerk/types@4.85.0':
     dependencies:
       csstype: 3.1.3
+
+  '@codemirror/autocomplete@6.19.0':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.3.0
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@lezer/common': 1.3.0
+      '@lezer/css': 1.3.0
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.3.0
+      '@lezer/css': 1.3.0
+      '@lezer/html': 1.3.12
+
+  '@codemirror/lang-javascript@6.2.4':
+    dependencies:
+      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.9.0
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.3.0
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-markdown@6.4.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.19.0
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.3.0
+      '@lezer/markdown': 1.4.3
+
+  '@codemirror/language@6.11.3':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+      '@lezer/lr': 1.4.2
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.0':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      crelt: 1.0.6
+
+  '@codemirror/state@6.5.2':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.6
+      '@lezer/highlight': 1.2.2
+
+  '@codemirror/view@6.38.6':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@coinbase/wallet-sdk@4.3.0':
     dependencies:
@@ -7212,6 +7367,41 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.3.0': {}
+
+  '@lezer/css@1.3.0':
+    dependencies:
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+      '@lezer/lr': 1.4.2
+
+  '@lezer/highlight@1.2.2':
+    dependencies:
+      '@lezer/common': 1.3.0
+
+  '@lezer/html@1.3.12':
+    dependencies:
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+      '@lezer/lr': 1.4.2
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+      '@lezer/lr': 1.4.2
+
+  '@lezer/lr@1.4.2':
+    dependencies:
+      '@lezer/common': 1.3.0
+
+  '@lezer/markdown@1.4.3':
+    dependencies:
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.0(acorn@8.15.0)':
     dependencies:
@@ -8864,7 +9054,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9229,6 +9419,8 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+
+  crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -12161,6 +12353,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -12893,6 +13087,8 @@ snapshots:
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.17.5: {}
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

This PR integrates CodeMirror 6 to replace the simple `<pre>` tag for markdown file viewing in the workspace application.

### Key Changes

- **Add CodeMirror 6 dependencies**: @codemirror/state, @codemirror/view, @codemirror/lang-markdown, @codemirror/theme-one-dark
- **Create signal-based editor state management** in `signals/project/editor.ts`
  - `editorStateConfig$` computed signal for editor initialization
  - `mountEditor$` command for DOM lifecycle management
- **Implement MarkdownEditor component** using ref callback and AbortSignal for lifecycle
- **Update FileContent** to render MarkdownEditor for .md files, null for others
- **Add comprehensive tests** for CodeMirror integration
- **Fix existing tests** to work with CodeMirror DOM structure

### Technical Implementation

- Pure signal-based architecture with no useState/useEffect/useRef
- EditorView lifecycle managed via pageSignal$ and AbortSignal cleanup
- Read-only mode with syntax highlighting and line wrapping
- Single editor instance with automatic rebuild on file switch (using key prop)
- Uses document.querySelector in tests since CM6 renders outside React

### Files Changed

- `apps/workspace/package.json` - Added CM6 dependencies
- `apps/workspace/src/signals/project/editor.ts` - New signal layer (62 lines)
- `apps/workspace/src/views/project/markdown-editor.tsx` - New component (42 lines)
- `apps/workspace/src/views/project/file-content.tsx` - Updated to use MarkdownEditor
- `apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx` - New tests (60 lines)
- `apps/workspace/src/views/project/__tests__/project-page.test.tsx` - Updated tests
- `pnpm-lock.yaml` - Dependency lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)