### PR TITLE
feat(workspace): add turn list container ref management

### DIFF
--- a/turbo/apps/workspace/src/signals/project/__tests__/turn-list-container.test.ts
+++ b/turbo/apps/workspace/src/signals/project/__tests__/turn-list-container.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for turn list container element management
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { testContext } from '../../__tests__/context'
+import { setupMock } from '../../test-utils'
+import { mountTurnList$, turnListContainerEl$ } from '../project'
+
+// Setup Clerk mock
+setupMock()
+
+const context = testContext()
+
+describe('turn list container', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('should set container element when mounted', () => {
+    const mockElement = document.createElement('div')
+
+    const cleanup = context.store.set(mountTurnList$, mockElement)
+
+    const result = context.store.get(turnListContainerEl$)
+    expect(result).toBe(mockElement)
+
+    cleanup?.()
+  })
+
+  it('should return null initially', () => {
+    const result = context.store.get(turnListContainerEl$)
+    expect(result).toBeNull()
+  })
+
+  it('should clear container element on unmount', () => {
+    const mockElement = document.createElement('div')
+
+    const cleanup = context.store.set(mountTurnList$, mockElement)
+
+    // Verify it's set
+    let result = context.store.get(turnListContainerEl$)
+    expect(result).toBe(mockElement)
+
+    // Cleanup (unmount)
+    cleanup?.()
+
+    // Verify it's cleared
+    result = context.store.get(turnListContainerEl$)
+    expect(result).toBeNull()
+  })
+
+  it('should handle multiple mount/unmount cycles', () => {
+    const element1 = document.createElement('div')
+    const element2 = document.createElement('div')
+
+    // Mount first element
+    const cleanup1 = context.store.set(mountTurnList$, element1)
+    expect(context.store.get(turnListContainerEl$)).toBe(element1)
+
+    // Unmount first element
+    cleanup1?.()
+    expect(context.store.get(turnListContainerEl$)).toBeNull()
+
+    // Mount second element
+    const cleanup2 = context.store.set(mountTurnList$, element2)
+    expect(context.store.get(turnListContainerEl$)).toBe(element2)
+
+    // Unmount second element
+    cleanup2?.()
+    expect(context.store.get(turnListContainerEl$)).toBeNull()
+  })
+
+  it('should not set element when null is passed', () => {
+    const result = context.store.set(mountTurnList$, null)
+
+    expect(result).toBeUndefined()
+    expect(context.store.get(turnListContainerEl$)).toBeNull()
+  })
+})

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -14,7 +14,7 @@ import {
   turnDetail,
 } from '../external/project-detail'
 import { pathParams$, searchParams$, updateSearchParams$ } from '../route'
-import { throwIfAbort } from '../utils'
+import { onRef, throwIfAbort } from '../utils'
 
 function findFileInTree(
   files: FileItem[],
@@ -154,6 +154,23 @@ export const selectedSession$ = computed(async (get) => {
 })
 
 const internalReloadTurn$ = state(0)
+
+const internalTurnListContainerEl$ = state<HTMLDivElement | null>(null)
+
+const internalMountTurnList$ = command(
+  ({ set }, el: HTMLDivElement, signal: AbortSignal) => {
+    set(internalTurnListContainerEl$, el)
+    signal.addEventListener('abort', () => {
+      set(internalTurnListContainerEl$, null)
+    })
+  },
+)
+
+export const mountTurnList$ = onRef(internalMountTurnList$)
+
+export const turnListContainerEl$ = computed((get) =>
+  get(internalTurnListContainerEl$),
+)
 
 export const turns$ = computed(async (get) => {
   get(internalReloadTurn$)

--- a/turbo/apps/workspace/src/signals/utils.ts
+++ b/turbo/apps/workspace/src/signals/utils.ts
@@ -257,3 +257,21 @@ export function resetSignal(): Command<AbortSignal, AbortSignal[]> {
     return AbortSignal.any([controller.signal, ...signals])
   })
 }
+
+export function onRef<T extends HTMLElement | SVGSVGElement>(
+  command$: Command<void | Promise<void>, [T, AbortSignal]>,
+) {
+  return command(({ set }, el: T | null) => {
+    if (!el) {
+      return
+    }
+
+    const ctrl = new AbortController()
+
+    detach(set(command$, el, ctrl.signal), Reason.DomCallback, 'onRef')
+
+    return () => {
+      ctrl.abort()
+    }
+  })
+}

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -1,5 +1,6 @@
 import { useLastResolved, useSet } from 'ccstate-react'
 import {
+  mountTurnList$,
   projectSessions$,
   selectedSession$,
   selectSession$,
@@ -13,6 +14,7 @@ export function ChatWindow() {
   const selectedSession = useLastResolved(selectedSession$)
   const turns = useLastResolved(turns$)
   const handleSelectSession = useSet(selectSession$)
+  const mountTurnList = useSet(mountTurnList$)
 
   return (
     <div className="flex h-full flex-col bg-[#1e1e1e]">
@@ -40,7 +42,7 @@ export function ChatWindow() {
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto" ref={mountTurnList}>
         {!selectedSession && (
           <div className="p-3 text-[13px] text-[#969696]">
             {projectSessions?.sessions.length === 0 ? (


### PR DESCRIPTION
## Summary
- Add `onRef` utility function to handle element mount/unmount lifecycle with automatic cleanup
- Add `turnListContainerEl$` state to track the scrollable turn list container element
- Add `mountTurnList$` command to set/clear container reference on mount/unmount
- Integrate ref in `chat-window.tsx` for the scroll container div
- Add comprehensive tests for container element management (5 test cases, all passing)

## Purpose
This PR lays the foundation for implementing auto-scroll functionality when new turns are added to the session. By maintaining a reference to the turn list container element, we can programmatically control scrolling behavior in response to:
- New messages being sent
- Session switching
- Real-time updates from polling

## Technical Details
The `onRef` utility follows React's ref callback pattern:
- When element mounts: calls the provided command with element and AbortSignal
- When element unmounts: aborts the signal to trigger cleanup
- Ensures proper cleanup through signal-based lifecycle management

## Test Plan
- ✅ All existing tests pass (343/344 tests - 1 pre-existing failure unrelated to changes)
- ✅ 5 new tests for turn list container management
  - Container element is set correctly on mount
  - Returns null initially
  - Clears element on unmount
  - Handles multiple mount/unmount cycles
  - Ignores null element pass-through

## Next Steps
This prepares for the next phase where we'll implement:
- Auto-scroll trigger on message send
- Auto-scroll on session selection
- Auto-scroll on polling detection of new blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)