### PR TITLE
fix(cli): resolve file sync error when using watch-claude with prefix

### DIFF
--- a/turbo/apps/cli/src/commands/watch-claude.ts
+++ b/turbo/apps/cli/src/commands/watch-claude.ts
@@ -184,7 +184,11 @@ export async function watchClaudeCommand(options: {
             const syncPromise = (async () => {
               try {
                 // File was successfully modified, sync it now
-                await syncFile(context, options.projectId, filePath);
+                // When using prefix, reconstruct the local path for reading
+                const localPath = options.prefix
+                  ? `${options.prefix}/${filePath}`
+                  : filePath;
+                await syncFile(context, options.projectId, filePath, localPath);
               } catch (error) {
                 // Only output errors to stderr
                 console.error(

--- a/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
@@ -104,17 +104,23 @@ describe("NewProjectPage", () => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
 
-    // Select a repository
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "test-user/test-repo" } });
+    // Select a repository by clicking the CommandItem
+    await waitFor(() => {
+      expect(screen.getByText("test-repo")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("test-repo"));
 
     // Click continue
+    await waitFor(() => {
+      const continueButton = screen.getByRole("button", { name: /Continue/i });
+      expect(continueButton).not.toBeDisabled();
+    });
     const continueButton = screen.getByRole("button", { name: /Continue/i });
     fireEvent.click(continueButton);
 
     // Should go directly to ready step (no token step needed)
     await waitFor(() => {
-      expect(screen.getByText("You're All Set!")).toBeInTheDocument();
+      expect(screen.getByText(/You'?re All Set!/i)).toBeInTheDocument();
     });
   });
 
@@ -138,12 +144,21 @@ describe("NewProjectPage", () => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
 
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "test-user/test-repo" } });
+    // Select a repository by clicking the CommandItem
+    await waitFor(() => {
+      expect(screen.getByText("test-repo")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("test-repo"));
+
+    // Click continue
+    await waitFor(() => {
+      const continueButton = screen.getByRole("button", { name: /Continue/i });
+      expect(continueButton).not.toBeDisabled();
+    });
     fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("You're All Set!")).toBeInTheDocument();
+      expect(screen.getByText(/You'?re All Set!/i)).toBeInTheDocument();
     });
 
     // Click Start Scanning
@@ -274,12 +289,21 @@ describe("NewProjectPage", () => {
       expect(screen.getByRole("combobox")).toBeInTheDocument();
     });
 
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "test-user/test-repo" } });
+    // Select a repository by clicking the CommandItem
+    await waitFor(() => {
+      expect(screen.getByText("test-repo")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("test-repo"));
+
+    // Click continue
+    await waitFor(() => {
+      const continueButton = screen.getByRole("button", { name: /Continue/i });
+      expect(continueButton).not.toBeDisabled();
+    });
     fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("You're All Set!")).toBeInTheDocument();
+      expect(screen.getByText(/You'?re All Set!/i)).toBeInTheDocument();
     });
 
     // Start scanning - should redirect to init page

--- a/turbo/apps/web/src/test/setup.ts
+++ b/turbo/apps/web/src/test/setup.ts
@@ -17,15 +17,20 @@ global.URL.revokeObjectURL = () => {};
 
 // Polyfill ResizeObserver for jsdom
 // Required by cmdk component used in Command/ComboBox
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+if (typeof ResizeObserver === "undefined") {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
 
 // Polyfill scrollIntoView for jsdom
 // Required by cmdk component for keyboard navigation
-Element.prototype.scrollIntoView = vi.fn();
+// Only available in jsdom environment, not in node environment
+if (typeof Element !== "undefined") {
+  Element.prototype.scrollIntoView = vi.fn();
+}
 
 // Force override Clerk test environment variables for offline testing
 // These are mock values that ensure tests never use real API credentials


### PR DESCRIPTION
## Summary
This PR fixes three critical issues that were blocking CI:
1. **watch-claude file sync error** when using `--prefix` option  
2. **CI test suite failures** caused by jsdom-only polyfills in node environment (30 test suites)
3. **NewProjectPage test failures** caused by incorrect Command component interaction (3 tests)

All issues are now resolved with comprehensive test coverage.

---

## Issue 1: watch-claude File Sync Error

### Problem
Files under `.uspark/` couldn't be synced in e2b containers when using `--prefix .uspark` option.

**Error message:**
```
[uspark] Failed to sync tech-debt.md: ENOENT: no such file or directory
```

### Root Cause
`extractFilePath` strips prefix for remote storage, but `syncFile` needs full local path to read the file.

### Solution
Modified `watch-claude.ts` to reconstruct local file path when prefix is used:
```typescript
const localPath = options.prefix
  ? `${options.prefix}/${filePath}`
  : filePath;
await syncFile(context, options.projectId, filePath, localPath);
```

### Impact
✅ Files in e2b containers now sync properly

---

## Issue 2: CI Test Environment Errors (30 Failed Suites)

### Problem
30 test suite failures with "ReferenceError: Element is not defined" in CI.

**Error pattern:**
```
ReferenceError: Element is not defined
❯ src/test/setup.ts:28:1
```

### Root Cause
`setup.ts` unconditionally accessed `Element.prototype` and `ResizeObserver` in node environment:
- setup.ts runs in ALL test environments (node + jsdom)
- Element and ResizeObserver only exist in jsdom
- Node environment tests failed when accessing these globals

### Solution
Added environment checks before setting polyfills:
```typescript
// Only set in jsdom environment
if (typeof Element !== "undefined") {
  Element.prototype.scrollIntoView = vi.fn();
}

if (typeof ResizeObserver === "undefined") {
  global.ResizeObserver = class ResizeObserver { ... };
}
```

### Impact
✅ Eliminated 30 failed test suites  
✅ Node environment tests now run successfully  
✅ Test files: 60/61 passing

---

## Issue 3: NewProjectPage Test Failures (3 Tests)

### Problem
3 tests failing because they couldn't interact with GitHubRepoSelector properly.

**Failed tests:**
1. "should navigate to repository selection and continue to ready step"
2. "should display error when project creation fails"  
3. "should redirect to init page after GitHub project creation"

### Root Cause
Tests used `fireEvent.change` to select repository, but GitHubRepoSelector uses cmdk's Command component which requires clicking CommandItem elements.

### Solution
Updated tests to properly interact with Command component:
```typescript
// Before (incorrect)
const select = screen.getByRole("combobox");
fireEvent.change(select, { target: { value: "test-user/test-repo" } });

// After (correct)
await waitFor(() => {
  expect(screen.getByText("test-repo")).toBeInTheDocument();
});
fireEvent.click(screen.getByText("test-repo"));

await waitFor(() => {
  const continueButton = screen.getByRole("button", { name: /Continue/i });
  expect(continueButton).not.toBeDisabled();
});
```

Also used regex matching for text to handle HTML entities:
```typescript
expect(screen.getByText(/You'?re All Set!/i)).toBeInTheDocument();
```

### Impact
✅ All 8 NewProjectPage tests now passing  
✅ Proper Command component interaction  
✅ Robust text matching with regex

---

## Test Results

### Before All Fixes (CI)
```
❌ 30 Failed Suites (Element is not defined)
❌ 3 Failed Tests (NewProjectPage)
❌ Total: 33+ test failures
```

### After All Fixes (CI)
```
✅ 60 Test Files Passed / 61
✅ 357 Tests Passed / 358
✅ 0 Element Errors
✅ 0 NewProjectPage Failures
```

The remaining 1 test failure is `app/api/github/installation-status/route.test.ts` with a database unique constraint issue, which is a pre-existing problem unrelated to this PR.

---

## Changes Summary

### CLI - watch-claude fix
- `apps/cli/src/commands/watch-claude.ts`: Reconstruct local path when prefix is used
- `apps/cli/src/commands/watch-claude.test.ts`: Updated tests + added prefix test coverage

### Test Environment fix  
- `apps/web/src/test/setup.ts`: Added environment checks for jsdom-only polyfills

### NewProjectPage tests fix
- `apps/web/app/projects/new/__tests__/page.test.tsx`: Correct Command component interaction

---

## Test Plan
- [x] CLI tests pass (6/6 watch-claude tests)
- [x] Web tests pass (357/358 tests, 1 pre-existing failure)
- [x] Lint and type checks pass
- [x] Pre-commit hooks pass  
- [x] CI validates all three fixes
- [x] E2E tests pending

---

## Commits
1. `fix(cli): resolve file sync error when using watch-claude with prefix`
2. `fix(test): add environment checks for jsdom-only polyfills`  
3. `fix(test): correct github repo selector interaction in new project page tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)