### PR TITLE
fix(cli): ensure directory creation on empty pull and complete callback delivery

### DIFF
--- a/turbo/apps/cli/src/__tests__/pull.test.ts
+++ b/turbo/apps/cli/src/__tests__/pull.test.ts
@@ -129,19 +129,25 @@ describe("pull --all command", () => {
     }
   });
 
-  it("should handle empty project gracefully", async () => {
+  it("should handle empty project gracefully and create output directory", async () => {
     const projectId = "empty-project";
+    const outputDir = join(tempDir, "empty-output");
 
     // Don't add any files to the project
 
     // Execute pull --all command - should not throw
     await pullAllCommand({
       projectId,
-      outputDir: tempDir,
+      outputDir,
     });
 
-    // Verify no files were created
-    const files = readdirSync(tempDir);
+    // Verify directory was created even though no files were pulled
+    const { statSync } = await import("fs");
+    const stat = statSync(outputDir);
+    expect(stat.isDirectory()).toBe(true);
+
+    // Verify no files were created inside the directory
+    const files = readdirSync(outputDir);
     expect(files).toHaveLength(0);
   });
 });

--- a/turbo/apps/cli/src/project-sync.ts
+++ b/turbo/apps/cli/src/project-sync.ts
@@ -451,6 +451,10 @@ export class ProjectSync {
 
     if (allFiles.size === 0) {
       console.log("ℹ️  No files found in project");
+      // Create output directory even when there are no files
+      if (outputDir) {
+        await mkdir(outputDir, { recursive: true });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes two issues in the CLI:

1. **`uspark pull --output-dir` with empty projects**: Now creates the output directory even when there are no files to sync
2. **`uspark watch-claude` log data loss**: Now waits for all HTTP callbacks to complete before exiting

## Problem

### Issue 1: Empty Pull Directory Creation
When using `uspark pull --all --output-dir <dir>` on an empty project, the output directory was not created because the function returned early when no files were found.

### Issue 2: Watch-Claude Log Loss
The final result block and other logs from Claude Code were not reaching the server because:
- `sendStdoutCallback()` HTTP requests were fire-and-forget (non-blocking)
- When stdin closed, the process exited immediately
- Pending HTTP requests were interrupted before completion

## Solution

### Fix 1: pullAll Directory Creation
- Modified `pullAll()` in `project-sync.ts` to create the output directory even when `allFiles.size === 0`
- Added test case to verify directory creation for empty projects

### Fix 2: Watch-Claude Callback Tracking
- Added `pendingCallbacks` array to track all HTTP callback promises
- Each `sendStdoutCallback()` promise is now tracked and removed upon completion
- Process waits for all pending callbacks (`[...pendingSyncs, ...pendingCallbacks]`) before exiting

## Changes

- `apps/cli/src/project-sync.ts`: Create output directory for empty projects
- `apps/cli/src/commands/watch-claude.ts`: Track and wait for all HTTP callbacks
- `apps/cli/src/__tests__/pull.test.ts`: Add test for empty project directory creation

## Testing

✅ All tests pass (29/29)
- New test: "should handle empty project gracefully and create output directory"
- Existing tests continue to pass

✅ Lint checks pass (0 errors, 0 warnings)

## Impact

- Users can now rely on output directories being created even for empty projects
- All Claude Code logs, including final result blocks, will reliably reach the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)