### PR TITLE
fix: improve repository selector UX and test quality

### DIFF
--- a/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
+++ b/turbo/apps/web/app/projects/new/__tests__/page.test.tsx
@@ -112,14 +112,18 @@ describe("NewProjectPage", () => {
 
     // Wait for repository option to appear
     await waitFor(() => {
-      expect(screen.getByRole("option", { name: /test-repo/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /test-repo/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("option", { name: /test-repo/i }));
 
     // Verify repository is selected (shown in combobox button)
     await waitFor(() => {
-      expect(screen.getByRole("combobox")).toHaveTextContent("test-user/test-repo");
+      expect(screen.getByRole("combobox")).toHaveTextContent(
+        "test-user/test-repo",
+      );
     });
 
     // Click continue
@@ -157,7 +161,9 @@ describe("NewProjectPage", () => {
     await user.click(screen.getByRole("combobox"));
 
     await waitFor(() => {
-      expect(screen.getByRole("option", { name: /test-repo/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /test-repo/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("option", { name: /test-repo/i }));
@@ -303,7 +309,9 @@ describe("NewProjectPage", () => {
     await user.click(screen.getByRole("combobox"));
 
     await waitFor(() => {
-      expect(screen.getByRole("option", { name: /test-repo/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /test-repo/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("option", { name: /test-repo/i }));

--- a/turbo/apps/web/app/projects/new/page.tsx
+++ b/turbo/apps/web/app/projects/new/page.tsx
@@ -326,14 +326,6 @@ export default function NewProjectPage() {
             <CardContent>
               <div className="space-y-4">
                 <GitHubRepoSelector onSelect={handleRepoSelect} />
-                {selectedRepo && (
-                  <div className="rounded-lg border bg-muted/50 p-4">
-                    <p className="text-sm font-medium">Selected repository:</p>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {selectedRepo.repo.fullName}
-                    </p>
-                  </div>
-                )}
                 <Button
                   onClick={handleContinueFromRepo}
                   disabled={!selectedRepo}

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "../../lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -6,6 +6,7 @@ export * from "./components/ui/card";
 export * from "./components/ui/command";
 export * from "./components/ui/dialog";
 export * from "./components/ui/input";
+export * from "./components/ui/popover";
 export * from "./components/ui/skeleton";
 
 // Utils

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -283,7 +283,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^5.92.1
-        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@codemirror/lang-markdown':
         specifier: ^6.4.0
         version: 6.4.0
@@ -501,6 +501,9 @@ importers:
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slot':
@@ -6626,15 +6629,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.2)(zod@4.1.5)
       preact: 10.24.2
-      viem: 2.37.5(typescript@5.9.2)(zod@3.25.76)
+      viem: 2.37.5(typescript@5.9.2)(zod@4.1.5)
       zustand: 5.0.3(@types/react@19.1.12)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -6669,9 +6672,9 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
-      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@clerk/localizations': 3.25.0
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
@@ -8934,16 +8937,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))
+      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.18
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.0
@@ -8954,16 +8957,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))
+      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.18
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.0
@@ -8989,9 +8992,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -9030,16 +9033,6 @@ snapshots:
       msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
       vite: 6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)
 
-  '@vitest/mocker@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.18
-    optionalDependencies:
-      msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
-      vite: 7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5)
-    optional: true
-
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -9069,7 +9062,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9083,10 +9076,10 @@ snapshots:
 
   '@zxcvbn-ts/language-common@3.0.4': {}
 
-  abitype@1.1.0(typescript@5.9.2)(zod@3.25.76):
+  abitype@1.1.0(typescript@5.9.2)(zod@4.1.5):
     optionalDependencies:
       typescript: 5.9.2
-      zod: 3.25.76
+      zod: 4.1.5
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -11520,21 +11513,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.9.2)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@5.9.2)(zod@3.25.76):
+  ox@0.9.3(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -11542,7 +11535,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
@@ -12816,15 +12809,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.37.5(typescript@5.9.2)(zod@3.25.76):
+  viem@2.37.5(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.9.3(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.9.3(typescript@5.9.2)(zod@4.1.5)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.2
@@ -12941,22 +12934,6 @@ snapshots:
       lightningcss: 1.30.1
       tsx: 4.20.5
 
-  vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5):
-    dependencies:
-      esbuild: 0.25.9
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.50.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.3.0
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.30.1
-      tsx: 4.20.5
-    optional: true
-
   vite@7.1.9(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5):
     dependencies:
       esbuild: 0.25.9
@@ -13047,7 +13024,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 20.0.0
       jsdom: 26.1.0


### PR DESCRIPTION
## Summary
- Redesigned GitHubRepoSelector as a combobox with popover for cleaner UX
- Removed duplicate repository display from new project page
- Migrated tests from `global.fetch` mocking to MSW
- Reduced test count from 9 to 5 by removing over-tested cases
- Added Popover component to UI package
- Documented MSW unhandled requests issue in tech-debt.md

## Changes

### UI Improvements
- **Before**: Repository selector showed selected repo twice (in component + on page)
- **After**: Combobox-style selector with popover, single display of selected repo
- Automatically closes after selection for better UX

### Test Quality
Following `bad-smell.md` principles:
- ✅ Use MSW instead of `global.fetch` mocking (#1)
- ✅ Focus tests on user behavior, not implementation details (#15)
- ✅ Remove tests for loading/error states without logic (#15)
- ✅ Use semantic roles instead of exact text matching (#15)

**Removed over-tested cases (4)**:
- displays loading state initially
- displays error message on fetch failure
- displays 401 error message when unauthorized
- displays empty state when no repositories found

**Improved tests (5)**:
- should allow user to select a repository from the list
- should display selected repository information after selection
- should show privacy badge for selected repository
- should group repositories by owner
- should close popover after selecting a repository

### Technical Debt
- Added new section in `spec/tech-debt.md` documenting MSW unhandled requests issue
- Marked as 🔴 ACTIVE for future fixing
- Updated metrics and code review checklist

## Test Results
All tests passing (5/5) ✅

## Screenshots
_Combobox-style repository selector with improved UX_

🤖 Generated with [Claude Code](https://claude.com/claude-code)