### PR TITLE
feat(workspace): enable editing mode in project markdown editor

### DIFF
--- a/turbo/apps/workspace/src/signals/project/editor.ts
+++ b/turbo/apps/workspace/src/signals/project/editor.ts
@@ -23,7 +23,7 @@ export const editorStateConfig$ = computed(async (get) => {
     markdown(),
     oneDark,
     EditorView.lineWrapping,
-    EditorView.editable.of(false), // 只读模式
+    EditorView.editable.of(true), // 编辑模式
   ]
 
   return {


### PR DESCRIPTION
## Summary
- Enable CodeMirror editing mode in workspace project detail pages
- Change from read-only to editable mode for markdown files

## Changes
- Modified `apps/workspace/src/signals/project/editor.ts:26`
- Changed `EditorView.editable.of(false)` to `EditorView.editable.of(true)`

## Test plan
- [x] Workspace app passes all type checks
- [x] All workspace tests pass (177 tests)
- [x] Lint and format checks pass
- [x] Pre-commit hooks pass (lint, prettier, knip, commitlint)

## Notes
- All workspace app checks pass successfully
- Pre-existing type errors in @uspark/core package are unrelated to this change
- Save functionality may need to be implemented separately to persist edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)