### PR TITLE
fix(workspace): align three-column header heights and improve editor padding

### DIFF
--- a/turbo/apps/workspace/src/views/css/index.css
+++ b/turbo/apps/workspace/src/views/css/index.css
@@ -10,4 +10,13 @@
   img {
     -webkit-user-drag: none;
   }
+
+  /* CodeMirror 编辑器样式优化 */
+  .cm-editor {
+    height: 100%;
+  }
+
+  .cm-content {
+    padding: 1rem !important;
+  }
 }

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -18,7 +18,7 @@ export function ChatWindow() {
 
   return (
     <div className="flex h-full flex-col bg-[#1e1e1e]">
-      <div className="flex items-center justify-between border-b border-[#3e3e42] px-3 py-1.5">
+      <div className="flex h-8 items-center justify-between border-b border-[#3e3e42] px-3">
         <div className="text-[11px] font-semibold tracking-wide text-[#cccccc] uppercase">
           Assistant
         </div>

--- a/turbo/apps/workspace/src/views/project/file-tree.tsx
+++ b/turbo/apps/workspace/src/views/project/file-tree.tsx
@@ -81,7 +81,7 @@ export function FileTree() {
 
   return (
     <div className="h-full overflow-y-auto bg-[#252526]">
-      <div className="border-b border-[#3e3e42] px-3 py-1.5 text-[11px] font-semibold tracking-wide text-[#cccccc] uppercase">
+      <div className="flex h-8 items-center border-b border-[#3e3e42] px-3 text-[11px] font-semibold tracking-wide text-[#cccccc] uppercase">
         Explorer
       </div>
       <div className="py-0.5">

--- a/turbo/apps/workspace/src/views/project/markdown-editor.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-editor.tsx
@@ -25,7 +25,7 @@ export function MarkdownEditor() {
   return (
     <div className="flex h-full flex-col bg-[#1e1e1e]">
       {/* 文件名标题栏 */}
-      <div className="flex items-center border-b border-[#3e3e42] px-3 py-1.5">
+      <div className="flex h-8 items-center border-b border-[#3e3e42] px-3">
         <span className="text-[13px] text-[#cccccc]">
           {selectedFile?.path.split('/').pop()}
         </span>

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^6.31.6
-        version: 6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.1
@@ -195,7 +195,7 @@ importers:
         version: 5.1.5
       next:
         specifier: ^15.5.2
-        version: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -6722,13 +6722,13 @@ snapshots:
     dependencies:
       '@clerk/types': 4.85.0
 
-  '@clerk/nextjs@6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@clerk/nextjs@6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@clerk/backend': 2.10.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/clerk-react': 5.45.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
-      next: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       server-only: 0.0.1
@@ -9060,7 +9060,7 @@ snapshots:
       flatted: 3.3.3
       pathe: 2.0.3
       sirv: 3.0.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
 
@@ -11434,6 +11434,29 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@next/env': 15.5.2
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001737
+      postcss: 8.4.31
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      styled-jsx: 5.1.6(react@19.1.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.2
+      '@next/swc-darwin-x64': 15.5.2
+      '@next/swc-linux-arm64-gnu': 15.5.2
+      '@next/swc-linux-arm64-musl': 15.5.2
+      '@next/swc-linux-x64-gnu': 15.5.2
+      '@next/swc-linux-x64-musl': 15.5.2
+      '@next/swc-win32-arm64-msvc': 15.5.2
+      '@next/swc-win32-x64-msvc': 15.5.2
+      sharp: 0.34.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -12389,6 +12412,11 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@babel/core': 7.28.3
+
+  styled-jsx@5.1.6(react@19.1.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.1
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
## Summary

Fixed UI alignment issues in the workspace project detail page:
- Unified header bar heights across all three columns to ensure horizontal borders align properly
- Improved CodeMirror editor padding for better readability and breathing space

## Changes

### Header Alignment
- Set fixed height (`h-8` = 32px) for all three column headers:
  - Explorer panel (file-tree.tsx:84)
  - File content panel (markdown-editor.tsx:28)
  - Assistant panel (chat-window.tsx:21)
- Removed variable `py-1.5` padding in favor of fixed height with flexbox centering
- Ensured horizontal borders are perfectly aligned across the layout

### CodeMirror Padding
- Added `1rem` padding to `.cm-content` for better text spacing (index.css:19-21)
- Ensures `.cm-editor` fills container height (index.css:15-17)
- Improves readability by providing comfortable margins around editor content

## Visual Impact

**Before:**
- Header bars had inconsistent heights due to different padding values
- Horizontal borders appeared disconnected/misaligned
- CodeMirror content felt cramped with minimal padding

**After:**
- All three header bars maintain consistent 32px height
- Horizontal borders form continuous lines across the layout
- Editor content has comfortable 16px padding on all sides

## Test Plan

- [x] Verified all CI checks pass (lint, format, type check, tests, knip)
- [x] Confirmed header heights are visually aligned
- [x] Tested CodeMirror editor displays with proper padding
- [x] Checked layout responsiveness and overflow behavior

## Files Modified

- `turbo/apps/workspace/src/views/css/index.css` - CodeMirror styling
- `turbo/apps/workspace/src/views/project/chat-window.tsx` - Assistant header
- `turbo/apps/workspace/src/views/project/file-tree.tsx` - Explorer header
- `turbo/apps/workspace/src/views/project/markdown-editor.tsx` - File content header
- `turbo/pnpm-lock.yaml` - Dependency updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)