### PR TITLE
refactor: simplify turn block ui by removing emoji and collapsible states

### DIFF
--- a/turbo/apps/web/app/components/claude-chat/__tests__/block-display.test.tsx
+++ b/turbo/apps/web/app/components/claude-chat/__tests__/block-display.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { BlockDisplay } from "../block-display";
 
 describe("BlockDisplay", () => {
@@ -25,7 +25,7 @@ describe("BlockDisplay", () => {
     expect(screen.getByText("Here is my response")).toBeInTheDocument();
   });
 
-  it("renders tool_use block with collapsible parameters", () => {
+  it("renders tool_use block with parameters always visible", () => {
     const block = {
       id: "block-3",
       type: "tool_use",
@@ -36,22 +36,11 @@ describe("BlockDisplay", () => {
       },
     };
 
-    const { container } = render(<BlockDisplay block={block} />);
+    render(<BlockDisplay block={block} />);
     expect(screen.getByText(/Tool: read_file/)).toBeInTheDocument();
 
-    // Should show parameters by default
+    // Parameters should always be visible
     expect(screen.getByText(/\/test\.txt/)).toBeInTheDocument();
-
-    // Click to collapse - find the clickable header div
-    const clickableHeader = container.querySelector(
-      '[style*="cursor: pointer"]',
-    );
-    if (clickableHeader) {
-      fireEvent.click(clickableHeader);
-    }
-
-    // Parameters should be hidden
-    expect(screen.queryByText(/\/test\.txt/)).not.toBeInTheDocument();
   });
 
   it("renders tool_result block with error state", () => {
@@ -84,7 +73,7 @@ describe("BlockDisplay", () => {
     expect(screen.getByText("File content here")).toBeInTheDocument();
   });
 
-  it("collapses tool_result content when more than 3 lines", () => {
+  it("displays all tool_result content without collapsing", () => {
     const multiLineContent = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
     const block = {
       id: "block-6",
@@ -98,67 +87,14 @@ describe("BlockDisplay", () => {
 
     render(<BlockDisplay block={block} />);
 
-    // Should show only first 3 lines with ellipsis by default
-    expect(screen.getByText(/Line 1/)).toBeInTheDocument();
-    expect(screen.getByText(/Line 2/)).toBeInTheDocument();
-    expect(screen.getByText(/Line 3\.\.\./)).toBeInTheDocument();
-    expect(screen.queryByText("Line 4")).not.toBeInTheDocument();
-    expect(screen.queryByText("Line 5")).not.toBeInTheDocument();
-
-    // Should show expand arrow
-    expect(screen.getByText("▶")).toBeInTheDocument();
-  });
-
-  it("expands tool_result content when clicked", () => {
-    const multiLineContent = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5";
-    const block = {
-      id: "block-7",
-      type: "tool_result",
-      content: {
-        tool_use_id: "tool-123",
-        result: multiLineContent,
-        error: null,
-      },
-    };
-
-    const { container } = render(<BlockDisplay block={block} />);
-
-    // Click to expand - find the clickable header div
-    const clickableHeader = container.querySelector(
-      '[style*="cursor: pointer"]',
-    );
-    if (clickableHeader) {
-      fireEvent.click(clickableHeader);
-    }
-
-    // Should show all lines
-    expect(screen.getByText(/Line 4/)).toBeInTheDocument();
-    expect(screen.getByText(/Line 5/)).toBeInTheDocument();
-
-    // Should show collapse arrow
-    expect(screen.getByText("▼")).toBeInTheDocument();
-  });
-
-  it("does not show expand arrow for tool_result with 3 or fewer lines", () => {
-    const shortContent = "Line 1\nLine 2\nLine 3";
-    const block = {
-      id: "block-8",
-      type: "tool_result",
-      content: {
-        tool_use_id: "tool-123",
-        result: shortContent,
-        error: null,
-      },
-    };
-
-    render(<BlockDisplay block={block} />);
-
-    // Should show all content
+    // Should show all lines (no collapsing)
     expect(screen.getByText(/Line 1/)).toBeInTheDocument();
     expect(screen.getByText(/Line 2/)).toBeInTheDocument();
     expect(screen.getByText(/Line 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Line 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Line 5/)).toBeInTheDocument();
 
-    // Should not show expand arrow
+    // Should not show expand/collapse arrows
     expect(screen.queryByText("▶")).not.toBeInTheDocument();
     expect(screen.queryByText("▼")).not.toBeInTheDocument();
   });

--- a/turbo/apps/web/app/components/claude-chat/block-display.tsx
+++ b/turbo/apps/web/app/components/claude-chat/block-display.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState } from "react";
-
 interface BlockProps {
   block: {
     id: string;
@@ -17,23 +15,7 @@ function getToolResultText(content: Record<string, unknown>): string {
     : (content?.result as string) || "No result";
 }
 
-// Helper function to check if text should be collapsed
-function shouldCollapseText(text: string): boolean {
-  return text.split("\n").length > 3;
-}
-
 export function BlockDisplay({ block }: BlockProps) {
-  // For tool_result, default to collapsed if content is long
-  const getInitialExpandedState = () => {
-    if (block.type === "tool_result") {
-      const resultText = getToolResultText(block.content);
-      return !shouldCollapseText(resultText); // Expand if 3 or fewer lines
-    }
-    return true; // Expand by default for other block types
-  };
-
-  const [isExpanded, setIsExpanded] = useState(getInitialExpandedState());
-
   const renderContent = () => {
     switch (block.type) {
       case "thinking":
@@ -49,7 +31,7 @@ export function BlockDisplay({ block }: BlockProps) {
               color: "rgba(156, 163, 175, 0.8)",
             }}
           >
-            💭 {(block.content?.text as string) || "Thinking..."}
+            {(block.content?.text as string) || "Thinking..."}
           </div>
         );
 
@@ -82,32 +64,17 @@ export function BlockDisplay({ block }: BlockProps) {
           >
             <div
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
+                fontWeight: "500",
+                color: "#3b82f6",
                 marginBottom: "8px",
-                cursor: "pointer",
               }}
-              onClick={() => setIsExpanded(!isExpanded)}
             >
-              <span style={{ fontSize: "16px" }}>🔧</span>
-              <span style={{ fontWeight: "500", color: "#3b82f6" }}>
-                Tool: {(block.content?.tool_name as string) || "Unknown"}
-              </span>
-              <span
-                style={{
-                  marginLeft: "auto",
-                  fontSize: "11px",
-                  color: "rgba(156, 163, 175, 0.6)",
-                }}
-              >
-                {isExpanded ? "▼" : "▶"}
-              </span>
+              Tool: {(block.content?.tool_name as string) || "Unknown"}
             </div>
-            {isExpanded && block.content?.parameters != null && (
+            {block.content?.parameters != null && (
               <pre
                 style={{
-                  margin: "8px 0 0 0",
+                  margin: "0",
                   padding: "8px",
                   backgroundColor: "rgba(0, 0, 0, 0.05)",
                   borderRadius: "4px",
@@ -125,10 +92,6 @@ export function BlockDisplay({ block }: BlockProps) {
 
       case "tool_result": {
         const resultText = getToolResultText(block.content);
-        const shouldCollapse = shouldCollapseText(resultText);
-        const previewText = shouldCollapse
-          ? resultText.split("\n").slice(0, 3).join("\n") + "..."
-          : resultText;
 
         return (
           <div
@@ -148,40 +111,15 @@ export function BlockDisplay({ block }: BlockProps) {
           >
             <div
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
+                fontWeight: "500",
+                color: block.content?.error ? "#ef4444" : "#22c55e",
                 marginBottom: "8px",
-                cursor: shouldCollapse ? "pointer" : "default",
               }}
-              onClick={() => shouldCollapse && setIsExpanded(!isExpanded)}
             >
-              <span style={{ fontSize: "16px" }}>
-                {block.content?.error ? "❌" : "✅"}
-              </span>
-              <span
-                style={{
-                  fontWeight: "500",
-                  color: block.content?.error ? "#ef4444" : "#22c55e",
-                }}
-              >
-                Tool Result
-              </span>
-              {shouldCollapse && (
-                <span
-                  style={{
-                    marginLeft: "auto",
-                    fontSize: "11px",
-                    color: "rgba(156, 163, 175, 0.6)",
-                  }}
-                >
-                  {isExpanded ? "▼" : "▶"}
-                </span>
-              )}
+              Tool Result
             </div>
             <div
               style={{
-                marginTop: "8px",
                 padding: "8px",
                 backgroundColor: "rgba(0, 0, 0, 0.03)",
                 borderRadius: "4px",
@@ -189,11 +127,11 @@ export function BlockDisplay({ block }: BlockProps) {
                 fontFamily: "monospace",
                 whiteSpace: "pre-wrap",
                 wordBreak: "break-word",
-                maxHeight: isExpanded ? "300px" : "auto",
-                overflow: isExpanded ? "auto" : "visible",
+                maxHeight: "300px",
+                overflow: "auto",
               }}
             >
-              {isExpanded ? resultText : previewText}
+              {resultText}
             </div>
           </div>
         );

--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -44,7 +44,7 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
       return (
         <div className="rounded border border-[#5c4461] bg-[#3d2d47] p-2">
           <div className="mb-1 text-[11px] font-medium text-[#c586c0]">
-            💭 Thinking
+            Thinking
           </div>
           <div className="text-[13px] leading-[1.5] whitespace-pre-wrap text-[#d4d4d4]">
             {getTextContent(block.content)}
@@ -68,7 +68,7 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
       return (
         <div className="rounded border border-[#2d4f7c] bg-[#1e3a5f] p-2">
           <div className="mb-1 text-[11px] font-medium text-[#569cd6]">
-            🔧 Tool: {toolName}
+            Tool: {toolName}
           </div>
           <details className="text-[13px]">
             <summary className="cursor-pointer text-[#9cdcfe] transition-colors hover:text-[#569cd6]">
@@ -102,7 +102,7 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
           <div
             className={`mb-1 text-[11px] font-medium ${hasError ? 'text-[#f48771]' : 'text-[#89d185]'}`}
           >
-            {hasError ? '❌ Tool Error' : '✅ Tool Result'}
+            {hasError ? 'Tool Error' : 'Tool Result'}
           </div>
           <pre className="overflow-x-auto text-[11px] whitespace-pre-wrap text-[#d4d4d4]">
             {error || result || JSON.stringify(block.content)}
@@ -136,7 +136,7 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
       return (
         <div className="rounded border border-[#6b3a3a] bg-[#4b2b2b] p-2">
           <div className="mb-1 text-[11px] font-medium text-[#f48771]">
-            ⚠️ Error
+            Error
           </div>
           <div className="text-[13px] leading-[1.5] whitespace-pre-wrap text-[#f48771]">
             {errorContent}

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -74,7 +74,28 @@ export function ChatWindow() {
 
             <div className="space-y-3">
               {turns && turns.length > 0 ? (
-                turns.map((turn) => <TurnDisplay key={turn.id} turn={turn} />)
+                <>
+                  {turns.map((turn) => (
+                    <TurnDisplay key={turn.id} turn={turn} />
+                  ))}
+                  {turns.some(
+                    (turn) =>
+                      turn.status === 'pending' ||
+                      turn.status === 'in_progress',
+                  ) && (
+                    <div className="text-[#9cdcfe]">
+                      <span className="inline-flex gap-0.5">
+                        <span className="animate-pulse">.</span>
+                        <span className="animate-pulse [animation-delay:200ms]">
+                          .
+                        </span>
+                        <span className="animate-pulse [animation-delay:400ms]">
+                          .
+                        </span>
+                      </span>
+                    </div>
+                  )}
+                </>
               ) : (
                 <div className="py-12 text-center text-[13px] text-[#969696]">
                   <div className="mb-2 text-3xl">✨</div>

--- a/turbo/apps/workspace/src/views/project/turn-display.tsx
+++ b/turbo/apps/workspace/src/views/project/turn-display.tsx
@@ -7,8 +7,6 @@ interface TurnDisplayProps {
 
 export function TurnDisplay({ turn }: TurnDisplayProps) {
   const hasBlocks = (turn.blocks as unknown[] | undefined)?.length > 0
-  const isInProgress =
-    turn.status === 'pending' || turn.status === 'in_progress'
 
   return (
     <div className="space-y-2">
@@ -20,15 +18,6 @@ export function TurnDisplay({ turn }: TurnDisplayProps) {
         <div className="text-[13px] leading-[1.5] whitespace-pre-wrap text-[#e3e3e3]">
           {turn.user_prompt}
         </div>
-        {isInProgress && (
-          <div className="mt-2 text-[#9cdcfe]">
-            <span className="inline-flex gap-0.5">
-              <span className="animate-pulse">.</span>
-              <span className="animate-pulse [animation-delay:200ms]">.</span>
-              <span className="animate-pulse [animation-delay:400ms]">.</span>
-            </span>
-          </div>
-        )}
       </div>
 
       {/* Assistant blocks */}


### PR DESCRIPTION
## Summary

This PR simplifies the turn block UI across both web and workspace applications by:

- Removing emoji from all turn block titles (thinking, tool use, tool result, error blocks) for a cleaner, more professional appearance
- Simplifying tool result display in the web app by removing collapse/expand logic and replacing it with a consistent max-height and scrollbar approach
- Relocating the three-dot loading animation from inside the user block to be a sibling of the turnlist in the workspace app for better visual hierarchy

## Changes

### Web App (`/turbo/apps/web/app/components/claude-chat/block-display.tsx`)
- Removed emoji from thinking block (thinking emoji)
- Removed emoji and collapse/expand UI from tool_use blocks (wrench emoji)
- Removed emoji and collapse/expand UI from tool_result blocks (checkmark/error emoji)
- Replaced collapsible behavior with fixed max-height (300px) and scrollbars for better consistency

### Workspace App (`/turbo/apps/workspace/src/views/project/`)
- Removed emoji from all block types in `block-display.tsx` (thinking, tool use, tool result, error)
- Moved loading animation from `turn-display.tsx` (inside user block) to `chat-window.tsx` (sibling of turnlist)
- Improved visual hierarchy by separating loading state from user content

## Test Plan

- [x] Pre-commit checks passed (format, lint, type check)
- [ ] Manually test web app: verify turn blocks display correctly without emoji
- [ ] Manually test web app: verify tool results show scrollbars when content exceeds 300px
- [ ] Manually test workspace app: verify turn blocks display correctly without emoji
- [ ] Manually test workspace app: verify loading animation appears below turnlist (not inside user block)
- [ ] Verify both apps maintain consistent styling and readability

Generated with [Claude Code](https://claude.com/claude-code)