### PR TITLE
feat(workspace): redesign layout with popover file tree and dynamic split view

### DIFF
--- a/turbo/apps/workspace/src/signals/project/file-tree-popover.ts
+++ b/turbo/apps/workspace/src/signals/project/file-tree-popover.ts
@@ -1,0 +1,61 @@
+import { command, computed, state } from 'ccstate'
+import { onRef } from '../utils'
+
+const internalPopoverOpen$ = state(false)
+const internalPopoverEl$ = state<HTMLDivElement | null>(null)
+const internalButtonEl$ = state<HTMLButtonElement | null>(null)
+
+export const fileTreePopoverOpen$ = computed((get) => get(internalPopoverOpen$))
+
+export const toggleFileTreePopover$ = command(({ get, set }) => {
+  const isOpen = get(internalPopoverOpen$)
+  set(internalPopoverOpen$, !isOpen)
+})
+
+export const closeFileTreePopover$ = command(({ set }) => {
+  set(internalPopoverOpen$, false)
+})
+
+// Handle click outside to close popover
+const internalSetupClickOutside$ = command(
+  ({ get, set }, _el: HTMLDivElement, signal: AbortSignal) => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const popoverEl = get(internalPopoverEl$)
+      const buttonEl = get(internalButtonEl$)
+
+      if (
+        popoverEl &&
+        !popoverEl.contains(event.target as Node) &&
+        buttonEl &&
+        !buttonEl.contains(event.target as Node) &&
+        get(internalPopoverOpen$)
+      ) {
+        set(internalPopoverOpen$, false)
+      }
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && get(internalPopoverOpen$)) {
+        set(internalPopoverOpen$, false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+
+    signal.addEventListener('abort', () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    })
+  },
+)
+
+export const setupPopoverClickOutside$ = onRef(internalSetupClickOutside$)
+
+export const setPopoverEl$ = command(({ set }, el: HTMLDivElement | null) => {
+  set(internalPopoverEl$, el)
+})
+
+export const setButtonEl$ = command(({ set }, el: HTMLButtonElement | null) => {
+  set(internalButtonEl$, el)
+})

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -108,6 +108,9 @@ export const selectFile$ = command(({ get, set }, filePath: string) => {
   newSearchParams.set('file', filePath)
 
   set(updateSearchParams$, newSearchParams)
+
+  // Show file content when a file is selected
+  set(internalFileContentVisible$, true)
 })
 
 export const selectSession$ = command(({ get, set }, sessionId: string) => {
@@ -202,6 +205,23 @@ export const turns$ = computed(async (get) => {
       )
     }),
   )
+})
+
+// File content visibility state
+const internalFileContentVisible$ = state(false)
+
+export const fileContentVisible$ = computed((get) =>
+  get(internalFileContentVisible$),
+)
+
+export const closeFileContent$ = command(({ get, set }) => {
+  set(internalFileContentVisible$, false)
+
+  // Also clear the file selection from URL
+  const currentSearchParams = get(searchParams$)
+  const newSearchParams = new URLSearchParams(currentSearchParams)
+  newSearchParams.delete('file')
+  set(updateSearchParams$, newSearchParams)
 })
 
 const internalChatInput$ = state('')

--- a/turbo/apps/workspace/src/views/project/file-content.tsx
+++ b/turbo/apps/workspace/src/views/project/file-content.tsx
@@ -1,5 +1,6 @@
-import { useLastResolved } from 'ccstate-react'
+import { useLastResolved, useSet } from 'ccstate-react'
 import {
+  closeFileContent$,
   selectedFileContent$,
   selectedFileItem$,
 } from '../../signals/project/project'
@@ -8,6 +9,7 @@ import { MarkdownEditor } from './markdown-editor'
 export function FileContent() {
   const fileContent = useLastResolved(selectedFileContent$)
   const selectedFile = useLastResolved(selectedFileItem$)
+  const closeFileContent = useSet(closeFileContent$)
 
   if (!fileContent) {
     return (
@@ -23,7 +25,41 @@ export function FileContent() {
   const isMarkdown = selectedFile?.path.endsWith('.md') ?? false
 
   if (isMarkdown) {
-    return <MarkdownEditor />
+    return (
+      <div className="flex h-full flex-col bg-[#1e1e1e]">
+        {/* Header with file name and close button */}
+        <div className="flex items-center justify-between border-b border-[#3e3e42] bg-[#252526] px-4 py-2">
+          <div className="text-[13px] text-[#cccccc]">
+            {selectedFile?.path.split('/').pop()}
+          </div>
+          <button
+            onClick={closeFileContent}
+            className="flex h-6 w-6 items-center justify-center rounded text-[#cccccc] transition-colors hover:bg-[#2a2d2e] hover:text-[#ffffff]"
+            aria-label="Close file"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* File content */}
+        <div className="flex-1 overflow-hidden">
+          <MarkdownEditor />
+        </div>
+      </div>
+    )
   }
 
   // 非 markdown 文件不显示内容

--- a/turbo/apps/workspace/src/views/project/file-tree-popover.tsx
+++ b/turbo/apps/workspace/src/views/project/file-tree-popover.tsx
@@ -1,0 +1,56 @@
+import { useLastResolved, useSet } from 'ccstate-react'
+import {
+  closeFileTreePopover$,
+  fileTreePopoverOpen$,
+  setButtonEl$,
+  setPopoverEl$,
+  setupPopoverClickOutside$,
+  toggleFileTreePopover$,
+} from '../../signals/project/file-tree-popover'
+import { onDomEventFn } from '../../signals/utils'
+import { FileTree } from './file-tree'
+
+export function FileTreePopover() {
+  const isOpen = useLastResolved(fileTreePopoverOpen$)
+  const togglePopover = useSet(toggleFileTreePopover$)
+  const closePopover = useSet(closeFileTreePopover$)
+  const setButtonEl = useSet(setButtonEl$)
+  const setPopoverEl = useSet(setPopoverEl$)
+  const setupClickOutside = useSet(setupPopoverClickOutside$)
+
+  return (
+    <div className="relative" ref={setupClickOutside}>
+      <button
+        ref={setButtonEl}
+        onClick={onDomEventFn(togglePopover)}
+        className="flex items-center gap-2 rounded px-3 py-1.5 text-[13px] text-[#cccccc] transition-colors hover:bg-[#2a2d2e]"
+        aria-label="Open file explorer"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+        </svg>
+        <span>Files</span>
+      </button>
+
+      {isOpen && (
+        <div
+          ref={setPopoverEl}
+          className="absolute top-full right-0 z-50 mt-1 h-[500px] w-[300px] overflow-hidden rounded border border-[#3e3e42] bg-[#252526] shadow-lg"
+          onClick={onDomEventFn(closePopover)}
+        >
+          <FileTree />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -1,33 +1,47 @@
+import { useLastResolved } from 'ccstate-react'
+import { fileContentVisible$ } from '../../signals/project/project'
 import { ChatWindow } from './chat-window'
 import { FileContent } from './file-content'
-import { FileTree } from './file-tree'
-import { Statusbar } from './statusbar'
+import { FileTreePopover } from './file-tree-popover'
 
 /**
  * ProjectPage component that provides the main workspace layout.
- * Features a three-column layout with file tree, content viewer, and chat panel,
- * plus a bottom status bar for project information.
+ * Features a dynamic layout that adapts based on file selection:
+ * - Default: Full-screen chat window
+ * - File selected: 50/50 split between chat and file viewer
+ * - File tree accessible via popover in top-right corner
  *
  * @returns The complete project workspace interface
  */
 export function ProjectPage() {
+  const isFileContentVisible = useLastResolved(fileContentVisible$)
+
   return (
     <div className="flex h-screen flex-col bg-[#1e1e1e] text-[#cccccc]">
-      <div className="flex min-h-0 flex-1">
-        <div className="w-64 flex-shrink-0 border-r border-[#3e3e42]">
-          <FileTree />
-        </div>
-
-        <div className="flex-1 border-r border-[#3e3e42]">
-          <FileContent />
-        </div>
-
-        <div className="w-96 flex-shrink-0">
-          <ChatWindow />
-        </div>
+      {/* Top bar with file tree button */}
+      <div className="flex items-center justify-end border-b border-[#3e3e42] bg-[#252526] px-4 py-2">
+        <FileTreePopover />
       </div>
 
-      <Statusbar />
+      {/* Main content area */}
+      <div className="flex min-h-0 flex-1">
+        {isFileContentVisible ? (
+          <>
+            {/* 50/50 split: Chat window on left, file content on right */}
+            <div className="flex-1 border-r border-[#3e3e42]">
+              <ChatWindow />
+            </div>
+            <div className="flex-1">
+              <FileContent />
+            </div>
+          </>
+        ) : (
+          /* Full-screen chat window */
+          <div className="flex-1">
+            <ChatWindow />
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Redesigned workspace page layout to maximize chat window space and provide a more flexible viewing experience.

### Changes

**Default Layout**
- Chat window now occupies full screen by default
- File tree moved to a popover accessible via button in top-right corner
- Removed bottom status bar for cleaner interface

**File Viewing**
- Clicking a file opens a 50/50 split view (chat | file content)
- File content panel includes header with filename and close button
- Close button returns to full-screen chat view

**Technical Implementation**
- Added `fileContentVisible$` signal to control file content visibility
- Created `FileTreePopover` component with:
  - Click-outside detection to close popover
  - ESC key support
  - Follows ccstate architecture patterns
- Enhanced `FileContent` component with header and close button
- Refactored `ProjectPage` to support dynamic layout switching

## Test plan

- [ ] Verify default view shows full-screen chat window
- [ ] Click "Files" button in top-right to open file tree popover
- [ ] Select a file from the popover
  - [ ] Popover closes automatically
  - [ ] Layout switches to 50/50 split view
  - [ ] File content displays with header and close button
- [ ] Click close button (X) on file content
  - [ ] Returns to full-screen chat view
  - [ ] File selection cleared from URL
- [ ] Press ESC key when popover is open
  - [ ] Popover closes
- [ ] Click outside popover
  - [ ] Popover closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)