### PR TITLE
build(e2b): update uspark cli to v0.12.2

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y git curl
 RUN npm install -g @anthropic-ai/claude-code@2.0.22
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.12.1
+RUN npm install -g @uspark/cli@0.12.2
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary

- Update E2B Dockerfile to use @uspark/cli@0.12.2
- Aligns E2B sandbox environment with latest CLI release from PR #598

## Changes

- Modified `/e2b/e2b.Dockerfile` line 10
- Changed `@uspark/cli@0.12.1` to `@uspark/cli@0.12.2`

## Test Plan

- [ ] Verify PR passes all CI checks
- [ ] Confirm no build errors
- [ ] E2B sandbox will use updated CLI version on next build

## Context

This update ensures the E2B development sandbox uses the latest published version of the uspark CLI, maintaining consistency with the main package release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)