### PR TITLE
refactor: change files label to specs in project page

### DIFF
--- a/turbo/apps/workspace/src/views/project/file-tree-popover.tsx
+++ b/turbo/apps/workspace/src/views/project/file-tree-popover.tsx
@@ -39,7 +39,7 @@ export function FileTreePopover() {
         >
           <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
         </svg>
-        <span>Files</span>
+        <span>specs</span>
       </button>
 
       {isOpen && (


### PR DESCRIPTION
## Summary

- Changed the top-right corner button label from "Files" to "specs" in the project details page
- Updated the FileTreePopover component to use "specs" instead of "Files"

## Changes

- Modified `/turbo/apps/workspace/src/views/project/file-tree-popover.tsx`
  - Line 42: Changed `<span>Files</span>` to `<span>specs</span>`

## Test plan

- [x] All CI checks passed locally (lint, format, type-check, tests, build, knip)
- [x] No breaking changes
- [x] Type-safe changes
- [ ] Verify label appears as "specs" in the UI

Generated with [Claude Code](https://claude.com/claude-code)