### PR TITLE
feat(sessions): optimize turn state management and add interrupt functionality

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/interrupt/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/interrupt/route.test.ts
@@ -90,7 +90,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId,
           userPrompt: "Running question 1",
           status: "running",
-          startedAt: new Date(),
         })
         .returning();
 
@@ -101,7 +100,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId,
           userPrompt: "Running question 2",
           status: "running",
-          startedAt: new Date(),
         })
         .returning();
 
@@ -112,7 +110,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId,
           userPrompt: "Completed question",
           status: "completed",
-          startedAt: new Date(),
           completedAt: new Date(),
         })
         .returning();
@@ -194,7 +191,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId,
           userPrompt: "Completed question",
           status: "completed",
-          startedAt: new Date(),
           completedAt: new Date(),
         })
         .returning();
@@ -250,7 +246,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId,
           userPrompt: "Running in test session",
           status: "running",
-          startedAt: new Date(),
         })
         .returning();
 
@@ -280,7 +275,6 @@ describe("/api/projects/:projectId/sessions/:sessionId/interrupt", () => {
           sessionId: otherSessionId,
           userPrompt: "Running in other session",
           status: "running",
-          startedAt: new Date(),
         })
         .returning();
 

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/on-claude-stdout/route.ts
@@ -96,6 +96,15 @@ export async function POST(
     return NextResponse.json(error, { status: 404 });
   }
 
+  // Reject stdout if turn is not running (already completed/cancelled/etc)
+  if (turn.status !== "running") {
+    const error: TurnErrorResponse = {
+      error: "turn_not_running",
+      error_description: `Cannot accept stdout for turn with status: ${turn.status}`,
+    };
+    return NextResponse.json(error, { status: 409 });
+  }
+
   // Parse and validate request body
   const body = await request.json();
   const parseResult = turnsContract.onClaudeStdout.body.safeParse(body);

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/[turnId]/route.ts
@@ -84,8 +84,8 @@ export async function GET(
     session_id: turn.sessionId,
     user_prompt: turn.userPrompt,
     status: turn.status,
-    started_at: turn.startedAt,
     completed_at: turn.completedAt,
+    created_at: turn.createdAt,
     blocks: parsedBlocks,
   });
 }

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/turns/route.test.ts
@@ -114,7 +114,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns", () => {
   });
 
   describe("POST /api/projects/:projectId/sessions/:sessionId/turns", () => {
-    it("should create a new turn with pending status", async () => {
+    it("should create a new turn with running status", async () => {
       const userMessage = "What is the weather today?";
       const request = new NextRequest("http://localhost:3000", {
         method: "POST",
@@ -130,7 +130,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns", () => {
       expect(data.id).toMatch(/^turn_/);
       expect(data).toHaveProperty("session_id", sessionId);
       expect(data).toHaveProperty("user_message", userMessage);
-      expect(data).toHaveProperty("status", "pending");
+      expect(data).toHaveProperty("status", "running");
       expect(data).toHaveProperty("created_at");
 
       createdTurnIds.push(data.id);
@@ -144,8 +144,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns", () => {
       expect(turn).toBeDefined();
       expect(turn!.sessionId).toBe(sessionId);
       expect(turn!.userPrompt).toBe(userMessage);
-      expect(turn!.status).toBe("pending");
-      expect(turn!.startedAt).toBeNull();
+      expect(turn!.status).toBe("running");
       expect(turn!.completedAt).toBeNull();
     });
   });
@@ -192,14 +191,13 @@ describe("/api/projects/:projectId/sessions/:sessionId/turns", () => {
         .update(TURNS_TBL)
         .set({
           status: "completed",
-          startedAt: new Date(),
           completedAt: new Date(),
         })
         .where(eq(TURNS_TBL.id, turn1Data.id));
 
       await globalThis.services.db
         .update(TURNS_TBL)
-        .set({ status: "running", startedAt: new Date() })
+        .set({ status: "running" })
         .where(eq(TURNS_TBL.id, turn2Data.id));
 
       // Add blocks to turn1 (direct DB - no API for blocks yet)

--- a/turbo/apps/web/src/db/migrations/0015_update_turn_status.sql
+++ b/turbo/apps/web/src/db/migrations/0015_update_turn_status.sql
@@ -1,0 +1,5 @@
+-- Migrate existing pending and in_progress statuses to running
+UPDATE "turns" SET "status" = 'running' WHERE "status" IN ('pending', 'in_progress');
+--> statement-breakpoint
+-- Drop the started_at column as it's no longer needed (use created_at instead)
+ALTER TABLE "turns" DROP COLUMN IF EXISTS "started_at";

--- a/turbo/apps/web/src/db/schema/sessions.ts
+++ b/turbo/apps/web/src/db/schema/sessions.ts
@@ -24,8 +24,7 @@ export const TURNS_TBL = pgTable("turns", {
     .notNull()
     .references(() => SESSIONS_TBL.id, { onDelete: "cascade" }),
   userPrompt: text("user_prompt").notNull(), // User's input message
-  status: text("status").notNull().default("pending"), // pending, running, completed, failed
-  startedAt: timestamp("started_at"),
+  status: text("status").notNull().default("running"), // running, completed, failed, interrupted, cancelled
   completedAt: timestamp("completed_at"),
   errorMessage: text("error_message"), // Error details if status is failed
   createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/turbo/apps/workspace/src/signals/external/project-detail.ts
+++ b/turbo/apps/workspace/src/signals/external/project-detail.ts
@@ -148,6 +148,26 @@ export const sendMessage$ = command(
   },
 )
 
+export const interruptSession$ = command(
+  (
+    { get },
+    params: { projectId: string; sessionId: string },
+    signal: AbortSignal,
+  ) => {
+    const workspaceFetch = get(fetch$)
+
+    return contractFetch(projectDetailContract.interruptSession, {
+      params: {
+        projectId: params.projectId,
+        sessionId: params.sessionId,
+      },
+      body: {},
+      fetch: workspaceFetch,
+      signal,
+    })
+  },
+)
+
 export const lastBlockId = function (params: {
   projectId: string
   sessionId: string

--- a/turbo/apps/workspace/src/views/project/chat-input.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-input.tsx
@@ -1,8 +1,10 @@
-import { useGet, useSet } from 'ccstate-react'
+import { useGet, useLastResolved, useSet } from 'ccstate-react'
 import type { FormEvent, KeyboardEvent } from 'react'
 import { pageSignal$ } from '../../signals/page-signal'
 import {
   chatInput$,
+  interruptCurrentTurn$,
+  lastTurnStatus$,
   sendChatMessage$,
   updateChatInput$,
 } from '../../signals/project/project'
@@ -12,19 +14,29 @@ export function ChatInput() {
   const input = useGet(chatInput$)
   const setInput = useSet(updateChatInput$)
   const sendMessage = useSet(sendChatMessage$)
+  const interruptTurn = useSet(interruptCurrentTurn$)
   const signal = useGet(pageSignal$)
+  const lastTurnStatus = useLastResolved(lastTurnStatus$)
+
+  const isRunning = lastTurnStatus === 'running'
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
-    if (!input.trim()) {
-      return
-    }
 
-    detach(sendMessage(signal), Reason.DomCallback)
+    if (isRunning) {
+      // Interrupt the current turn
+      detach(interruptTurn(signal), Reason.DomCallback)
+    } else {
+      // Send a new message
+      if (!input.trim()) {
+        return
+      }
+      detach(sendMessage(signal), Reason.DomCallback)
+    }
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !isRunning) {
       e.preventDefault()
       handleSubmit(e)
     }
@@ -42,16 +54,25 @@ export function ChatInput() {
             setInput(e.target.value)
           }}
           onKeyDown={handleKeyDown}
-          placeholder="Type a message... (Enter to send, Shift+Enter for new line)"
-          className="flex-1 resize-none rounded border border-[#3e3e42] bg-[#3c3c3c] px-2 py-1.5 text-[13px] text-[#cccccc] placeholder-[#6a6a6a] focus:border-[#007acc] focus:outline-none"
+          placeholder={
+            isRunning
+              ? 'Processing... Click Interrupt to stop'
+              : 'Type a message... (Enter to send, Shift+Enter for new line)'
+          }
+          disabled={isRunning}
+          className="flex-1 resize-none rounded border border-[#3e3e42] bg-[#3c3c3c] px-2 py-1.5 text-[13px] text-[#cccccc] placeholder-[#6a6a6a] focus:border-[#007acc] focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           rows={2}
         />
         <button
           type="submit"
-          disabled={!input.trim()}
-          className="self-end rounded bg-[#0e639c] px-3 py-1.5 text-[13px] font-medium text-[#ffffff] transition-colors hover:bg-[#1177bb] disabled:cursor-not-allowed disabled:bg-[#3e3e42] disabled:text-[#6a6a6a]"
+          disabled={!isRunning && !input.trim()}
+          className={`self-end rounded px-3 py-1.5 text-[13px] font-medium text-[#ffffff] transition-colors ${
+            isRunning
+              ? 'bg-[#a1260d] hover:bg-[#c72e0d]'
+              : 'bg-[#0e639c] hover:bg-[#1177bb] disabled:cursor-not-allowed disabled:bg-[#3e3e42] disabled:text-[#6a6a6a]'
+          }`}
         >
-          Send
+          {isRunning ? 'Interrupt' : 'Send'}
         </button>
       </div>
     </form>

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -74,7 +74,13 @@ export function ChatWindow() {
 
             <div className="space-y-3">
               {turns && turns.length > 0 ? (
-                turns.map((turn) => <TurnDisplay key={turn.id} turn={turn} />)
+                turns.map((turn, index) => (
+                  <TurnDisplay
+                    key={turn.id}
+                    turn={turn}
+                    isLastTurn={index === turns.length - 1}
+                  />
+                ))
               ) : (
                 <div className="py-12 text-center text-[13px] text-[#969696]">
                   <div className="mb-2 text-3xl">✨</div>

--- a/turbo/apps/workspace/src/views/project/turn-display.tsx
+++ b/turbo/apps/workspace/src/views/project/turn-display.tsx
@@ -3,12 +3,12 @@ import { BlockDisplay } from './block-display'
 
 interface TurnDisplayProps {
   turn: GetTurnResponse
+  isLastTurn?: boolean
 }
 
-export function TurnDisplay({ turn }: TurnDisplayProps) {
+export function TurnDisplay({ turn, isLastTurn = false }: TurnDisplayProps) {
   const hasBlocks = (turn.blocks as unknown[] | undefined)?.length > 0
-  const isInProgress =
-    turn.status === 'pending' || turn.status === 'in_progress'
+  const isRunning = turn.status === 'running'
 
   return (
     <div className="space-y-2">
@@ -20,7 +20,7 @@ export function TurnDisplay({ turn }: TurnDisplayProps) {
         <div className="text-[13px] leading-[1.5] whitespace-pre-wrap text-[#e3e3e3]">
           {turn.user_prompt}
         </div>
-        {isInProgress && (
+        {isLastTurn && isRunning && (
           <div className="mt-2 text-[#9cdcfe]">
             <span className="inline-flex gap-0.5">
               <span className="animate-pulse">.</span>
@@ -38,15 +38,11 @@ export function TurnDisplay({ turn }: TurnDisplayProps) {
             <BlockDisplay key={block.id} block={block} />
           ))}
         </div>
-      ) : turn.status === 'pending' || turn.status === 'in_progress' ? (
+      ) : turn.status === 'running' ? (
         <div className="rounded border border-[#3e3e42] bg-[#2d2d30] p-2 pl-5">
           <div className="flex items-center gap-2 text-[13px] text-[#969696]">
             <div className="h-3 w-3 animate-spin rounded-full border-2 border-[#3e3e42] border-t-[#007acc]" />
-            <span>
-              {turn.status === 'pending'
-                ? 'Waiting to start...'
-                : 'Processing...'}
-            </span>
+            <span>Processing...</span>
           </div>
         </div>
       ) : turn.status === 'failed' ? (
@@ -58,18 +54,11 @@ export function TurnDisplay({ turn }: TurnDisplayProps) {
       ) : null}
 
       {/* Timing info */}
-      {(turn.started_at ?? turn.completed_at) && (
+      {turn.completed_at && (
         <div className="pl-3 text-[10px] text-[#6a6a6a]">
-          {turn.started_at && (
-            <span>
-              Started: {new Date(turn.started_at).toLocaleTimeString()}
-            </span>
-          )}
-          {turn.completed_at && (
-            <span className="ml-2">
-              Completed: {new Date(turn.completed_at).toLocaleTimeString()}
-            </span>
-          )}
+          <span>
+            Completed: {new Date(turn.completed_at).toLocaleTimeString()}
+          </span>
         </div>
       )}
     </div>

--- a/turbo/packages/core/src/contracts/project-detail.contract.ts
+++ b/turbo/packages/core/src/contracts/project-detail.contract.ts
@@ -154,6 +154,24 @@ export const projectDetailContract = c.router({
       "Returns the ID of the most recent block in the session, or null if no blocks exist.",
   },
 
+  interruptSession: {
+    method: "POST",
+    path: "/api/projects/:projectId/sessions/:sessionId/interrupt",
+    pathParams: z.object({
+      projectId: z.string(),
+      sessionId: z.string(),
+    }),
+    body: z.object({}), // Empty body
+    responses: {
+      200: z.object({
+        success: z.boolean(),
+      }),
+    },
+    summary: "Interrupt running session",
+    description:
+      "Cancels any running turns in the session and stops E2B processes",
+  },
+
   // GitHub Integration
   getGitHubRepository: {
     method: "GET",


### PR DESCRIPTION
## Summary

Optimizes turn state management and adds interrupt functionality for better user experience:

- **Simplified state machine**: Merged `pending` and `in_progress` into single `running` state
- **Auto-cancellation**: Previous running turns are automatically cancelled when creating a new turn
- **Process interruption**: Added E2B process interrupt capability to stop Claude execution
- **UI improvements**: Loading indicator only shows on last turn, dynamic send/interrupt button
- **Conflict prevention**: API rejects stdout for non-running turns with 409 status

## Changes

### Backend
- Merged turn statuses: `pending` + `in_progress` → `running`
- Added `cancelled` status for interrupted turns
- Removed `startedAt` field (use `createdAt` instead)
- Added 409 conflict response in on-claude-stdout API
- Auto-cancel previous running turns in create turn API
- Added `E2BExecutor.interruptSession()` method with pkill commands
- Added interrupt session API endpoint

### Frontend  
- Show loading dots only on the last turn (not all running turns)
- Dynamic button: "Send" (blue) / "Interrupt" (red) based on turn status
- Disable input textarea when turn is running
- Added interrupt session signal and command

### Database
- Migration 0015: Update existing turn statuses and drop startedAt column

## Test Plan

- [x] Type check passes
- [x] Linting passes  
- [x] All tests updated for new status names
- [ ] Manual testing:
  - Create turn and verify status is "running"
  - Create another turn while first is running - verify first is cancelled
  - Loading dots appear only on last turn
  - Send button changes to Interrupt when turn is running
  - Interrupt button cancels the running turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)