### PR TITLE
feat(workspace): add markdown preview/edit mode toggle and fix turn status tests

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.test.ts
@@ -211,7 +211,7 @@ describe("/api/projects/[projectId]/initial-scan", () => {
         content: "Clone repository",
         status: "completed",
       });
-      expect(data.initial_scan_turn_status).toBe("in_progress");
+      expect(data.initial_scan_turn_status).toBe("running");
     });
 
     it("should return lastBlock when no TodoWrite blocks exist", async () => {

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
@@ -121,7 +121,7 @@ describe("Claude Session Management API Integration", () => {
       expect(turnResponse.status).toBe(200);
       expect(turnResponse.data).toHaveProperty("id");
       expect(turnResponse.data.user_message).toBe("Test prompt");
-      expect(turnResponse.data.status).toBe("pending");
+      expect(turnResponse.data.status).toBe("running");
       turnId = turnResponse.data.id;
 
       // 2. List turns

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -389,3 +389,12 @@ export const startWatchSession$ = command(
     } while (!IN_VITEST && !signal.aborted)
   },
 )
+
+// View mode state ('preview' | 'edit')
+const internalViewMode$ = state<'preview' | 'edit'>('preview')
+
+export const viewMode$ = computed((get) => get(internalViewMode$))
+
+export const setViewMode$ = command(({ set }, mode: 'preview' | 'edit') => {
+  set(internalViewMode$, mode)
+})

--- a/turbo/apps/workspace/src/views/project/file-content.tsx
+++ b/turbo/apps/workspace/src/views/project/file-content.tsx
@@ -3,13 +3,18 @@ import {
   closeFileContent$,
   selectedFileContent$,
   selectedFileItem$,
+  setViewMode$,
+  viewMode$,
 } from '../../signals/project/project'
 import { MarkdownEditor } from './markdown-editor'
+import { MarkdownPreview } from './markdown-preview'
 
 export function FileContent() {
   const fileContent = useLastResolved(selectedFileContent$)
   const selectedFile = useLastResolved(selectedFileItem$)
   const closeFileContent = useSet(closeFileContent$)
+  const mode = useLastResolved(viewMode$) ?? 'preview'
+  const setViewMode = useSet(setViewMode$)
 
   if (!fileContent) {
     return (
@@ -27,36 +32,68 @@ export function FileContent() {
   if (isMarkdown) {
     return (
       <div className="flex h-full flex-col bg-[#1e1e1e]">
-        {/* Header with file name and close button */}
+        {/* Header with file name, mode toggle, and close button */}
         <div className="flex items-center justify-between border-b border-[#3e3e42] bg-[#252526] px-4 py-2">
           <div className="text-[13px] text-[#cccccc]">
             {selectedFile?.path.split('/').pop()}
           </div>
-          <button
-            onClick={closeFileContent}
-            className="flex h-6 w-6 items-center justify-center rounded text-[#cccccc] transition-colors hover:bg-[#2a2d2e] hover:text-[#ffffff]"
-            aria-label="Close file"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+
+          <div className="flex items-center gap-2">
+            {/* Preview/Edit toggle buttons */}
+            <div className="flex overflow-hidden rounded border border-[#3e3e42]">
+              <button
+                onClick={() => {
+                  setViewMode('preview')
+                }}
+                className={`px-3 py-1 text-[12px] transition-colors ${
+                  mode === 'preview'
+                    ? 'bg-[#094771] text-[#ffffff]'
+                    : 'bg-[#2a2d2e] text-[#cccccc] hover:bg-[#3e3e42]'
+                }`}
+              >
+                Preview
+              </button>
+              <button
+                onClick={() => {
+                  setViewMode('edit')
+                }}
+                className={`px-3 py-1 text-[12px] transition-colors ${
+                  mode === 'edit'
+                    ? 'bg-[#094771] text-[#ffffff]'
+                    : 'bg-[#2a2d2e] text-[#cccccc] hover:bg-[#3e3e42]'
+                }`}
+              >
+                Edit
+              </button>
+            </div>
+
+            {/* Close button */}
+            <button
+              onClick={closeFileContent}
+              className="flex h-6 w-6 items-center justify-center rounded text-[#cccccc] transition-colors hover:bg-[#2a2d2e] hover:text-[#ffffff]"
+              aria-label="Close file"
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
         </div>
 
-        {/* File content */}
+        {/* File content - show preview or editor based on mode */}
         <div className="flex-1 overflow-hidden">
-          <MarkdownEditor />
+          {mode === 'preview' ? <MarkdownPreview /> : <MarkdownEditor />}
         </div>
       </div>
     )

--- a/turbo/apps/workspace/src/views/project/markdown-editor.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-editor.tsx
@@ -23,19 +23,12 @@ export function MarkdownEditor() {
   }
 
   return (
-    <div className="flex h-full flex-col bg-[#1e1e1e]">
-      {/* 文件名标题栏 */}
-      <div className="flex h-8 items-center border-b border-[#3e3e42] px-3">
-        <span className="text-[13px] text-[#cccccc]">
-          {selectedFile?.path.split('/').pop()}
-        </span>
-      </div>
-
+    <div className="h-full bg-[#1e1e1e]">
       {/* 编辑器容器 - 使用 key 确保文件切换时重建 DOM */}
       <div
         key={selectedFile?.path}
         ref={handleEditorRef}
-        className="flex-1 overflow-auto"
+        className="h-full overflow-auto"
       />
     </div>
   )

--- a/turbo/apps/workspace/src/views/project/markdown-preview.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-preview.tsx
@@ -1,0 +1,18 @@
+import { useLastResolved } from 'ccstate-react'
+import { selectedFileContent$ } from '../../signals/project/project'
+
+export function MarkdownPreview() {
+  const fileContent = useLastResolved(selectedFileContent$)
+
+  if (!fileContent) {
+    return null
+  }
+
+  return (
+    <div className="h-full overflow-auto bg-[#1e1e1e] p-4">
+      <pre className="font-mono text-[13px] whitespace-pre-wrap text-[#cccccc]">
+        {fileContent}
+      </pre>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

This PR implements the markdown preview/edit mode toggle feature for the workspace app and fixes two failing tests related to the turn status migration.

### Features

**Markdown Preview/Edit Mode Toggle**
- Add view mode state management (preview/edit) to project signals
- Create `MarkdownPreview` component with simple `<pre>` tag rendering
- Update `FileContent` with Preview/Edit toggle buttons
- Simplify `MarkdownEditor` by removing duplicate title bar

**UI Design**
- Preview mode as default (符合 MVP 规格要求)
- Toggle buttons with VS Code-style colors
  - Selected state: blue highlight (#094771)
  - Unselected state: dark gray (#2a2d2e)
- Smooth transitions between modes

### Test Fixes

Fixed 2 failing tests to align with database migration `0015_update_turn_status.sql`:
- `initial-scan/route.test.ts`: Changed expected status from `'in_progress'` to `'running'`
- `sessions/api.test.ts`: Changed expected status from `'pending'` to `'running'`

## Testing

- ✅ **All 357 tests passing** (was 355/357 before this PR)
- ✅ **All CI checks passing**: lint, format, type-check, build, knip
- ✅ **Type safety**: Full TypeScript compliance
- ✅ **Code quality**: ESLint passing with only pre-existing warnings

## Changes

### New Files
- `turbo/apps/workspace/src/views/project/markdown-preview.tsx` - Preview component

### Modified Files
- `turbo/apps/workspace/src/signals/project/project.ts` - View mode state
- `turbo/apps/workspace/src/views/project/file-content.tsx` - Toggle UI
- `turbo/apps/workspace/src/views/project/markdown-editor.tsx` - Simplified
- `turbo/apps/web/app/api/projects/[projectId]/initial-scan/route.test.ts` - Fix test
- `turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts` - Fix test

## User Experience

**Default Behavior:**
1. Open markdown file → Auto-display **preview mode** (readable format)
2. Click "Edit" button → Switch to **edit mode** (CodeMirror editor)
3. Click "Preview" button → Return to **preview mode**

**UI Location:**
```
[filename.md] [Preview|Edit] [✕]
```

## Future Enhancements

This is the first version using `<pre>` tag for preview. Future versions can add:

1. **v2**: react-markdown + remark-gfm for GFM rendering
2. **v3**: Mermaid diagram support
3. **v4**: Split view (editor + live preview side-by-side)
4. **v5**: Save functionality with version history

## Screenshots

_(Will show preview/edit toggle in action once deployed)_

## Related

- Implements requirements from `spec/mvp.md` (Preview/Edit mode section)
- Complements the existing CodeMirror integration
- Foundation for future document editing workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)