### PR TITLE
test(workspace): fix failing tests and add to CI pipeline

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: ./.github/actions/toolchain-init
 
       - name: Test
-        run: cd turbo && pnpm test
+        run: cd turbo && pnpm test && pnpm -F workspace test
         env:
           DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/postgres"
           CLERK_SECRET_KEY: "test_clerk_secret_key"

--- a/turbo/apps/workspace/src/signals/project/__tests__/watch-session.test.ts
+++ b/turbo/apps/workspace/src/signals/project/__tests__/watch-session.test.ts
@@ -88,7 +88,7 @@ describe('session watching', () => {
       expect(result).toBeFalsy()
     })
 
-    it('should return true when there are pending turns', async () => {
+    it('should return true when there are running turns', async () => {
       await setupProjectPage(
         `/projects/${mockProjectId}?sessionId=${mockSessionId}`,
         context,
@@ -101,7 +101,7 @@ describe('session watching', () => {
               {
                 id: 'turn_1',
                 userMessage: 'test',
-                status: 'pending',
+                status: 'running',
               },
             ],
           },
@@ -112,7 +112,7 @@ describe('session watching', () => {
       expect(result).toBeTruthy()
     })
 
-    it('should return true when there are in_progress turns', async () => {
+    it('should return true when there are multiple running turns', async () => {
       await setupProjectPage(
         `/projects/${mockProjectId}?sessionId=${mockSessionId}`,
         context,
@@ -126,7 +126,7 @@ describe('session watching', () => {
                 id: 'turn_1',
                 userMessage: 'test',
                 assistantMessage: 'processing...',
-                status: 'in_progress',
+                status: 'running',
               },
             ],
           },
@@ -178,7 +178,7 @@ describe('session watching', () => {
                 id: 'turn_1',
                 userMessage: 'test',
                 assistantMessage: 'response',
-                status: 'in_progress',
+                status: 'running',
               },
             ],
           },

--- a/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
@@ -18,20 +18,16 @@ describe('markdown editor - codemirror integration', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
 
-    await setupProjectPage(
-      `/projects/${projectId}`,
-      context,
-      {
-        projectId,
-        files: [
-          {
-            path: 'README.md',
-            hash: 'md-hash-123',
-            content: markdownContent,
-          },
-        ],
-      },
-    )
+    await setupProjectPage(`/projects/${projectId}`, context, {
+      projectId,
+      files: [
+        {
+          path: 'README.md',
+          hash: 'md-hash-123',
+          content: markdownContent,
+        },
+      ],
+    })
   })
 
   afterEach(() => {

--- a/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/markdown-editor.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
+import user from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { server } from '../../../mocks/node'
 import { testContext } from '../../../signals/__tests__/context'
@@ -17,44 +18,54 @@ describe('markdown editor - codemirror integration', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
 
-    await setupProjectPage(`/projects/${projectId}`, context, {
-      projectId,
-      files: [
-        {
-          path: 'README.md',
-          hash: 'md-hash-123',
-          content: markdownContent,
-        },
-      ],
-    })
+    await setupProjectPage(
+      `/projects/${projectId}`,
+      context,
+      {
+        projectId,
+        files: [
+          {
+            path: 'README.md',
+            hash: 'md-hash-123',
+            content: markdownContent,
+          },
+        ],
+      },
+    )
   })
 
   afterEach(() => {
     server.resetHandlers()
   })
 
-  it('renders CodeMirror editor for markdown files', async () => {
-    // Wait for file tree to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+  it('renders and displays markdown content in CodeMirror editor after clicking file', async () => {
+    const userEvent = user.setup()
+
+    // Wait for page to load by checking for the file tree button
+    const explorerButton = await screen.findByLabelText('Open file explorer')
+    expect(explorerButton).toBeInTheDocument()
+
+    // Open file tree popover
+    await userEvent.click(explorerButton)
+
+    // Wait for file tree to appear and click on the markdown file
+    const markdownFile = await screen.findByText('README.md')
+    await userEvent.click(markdownFile)
+
+    // File opens in Preview mode by default, switch to Edit mode
+    const editButton = await screen.findByText('Edit')
+    await userEvent.click(editButton)
 
     // Verify CodeMirror editor is rendered by checking for its root element
     await waitFor(() => {
       const editorElement = document.querySelector('.cm-editor')
       expect(editorElement).toBeInTheDocument()
     })
-  })
-
-  it('displays markdown content in CodeMirror editor', async () => {
-    // Wait for file to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
-
-    // CodeMirror renders content in .cm-content
-    const editorElement = document.querySelector('.cm-editor')
-    expect(editorElement).toBeInTheDocument()
 
     // Verify the content is in the editor
     const contentElement = document.querySelector('.cm-content')
     expect(contentElement).toBeInTheDocument()
     expect(contentElement?.textContent).toContain('Test Markdown')
+    expect(contentElement?.textContent).toContain('Section')
   })
 })

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -12,42 +12,8 @@ setupMock()
 
 const context = testContext()
 
-describe('projectPage - file content display', () => {
-  const projectId = 'test-project-123'
-  const fileContent = '# Test README\n\nThis is a test document'
-
-  beforeEach(async () => {
-    await setupProjectPage(`/projects/${projectId}`, context, {
-      projectId,
-      files: [
-        {
-          path: 'README.md',
-          hash: 'readme-hash-123',
-          content: fileContent,
-        },
-      ],
-    })
-  })
-
-  afterEach(() => {
-    server.resetHandlers()
-  })
-
-  it('displays file content when file is loaded', async () => {
-    // Wait for file tree to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
-
-    // Verify file content is displayed in CodeMirror
-    await waitFor(() => {
-      const contentElement = document.querySelector('.cm-content')
-      expect(contentElement).toBeInTheDocument()
-    })
-
-    const contentElement = document.querySelector('.cm-content')
-    expect(contentElement?.textContent).toContain('Test README')
-    expect(contentElement?.textContent).toContain('This is a test document')
-  })
-})
+// Removed 'projectPage - file content display' test because files no longer auto-display.
+// File selection functionality is tested in 'projectPage - file selection' below.
 
 describe('projectPage - file selection', () => {
   const projectId = 'test-project-456'
@@ -80,28 +46,32 @@ describe('projectPage - file selection', () => {
   it('selects file on click and displays its content', async () => {
     const userEvent = user.setup()
 
-    // Wait for files to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    // Open file tree popover
+    const explorerButton = await screen.findByLabelText('Open file explorer')
+    await userEvent.click(explorerButton)
 
     // Click on README.md
-    const readmeFile = screen.getByText('README.md')
+    const readmeFile = await screen.findByText('README.md')
     await userEvent.click(readmeFile)
 
-    // Verify README content is displayed in CodeMirror
+    // Verify README content is displayed in preview mode (using <pre> tag)
     await waitFor(() => {
-      const contentElement = document.querySelector('.cm-content')
-      expect(contentElement?.textContent).toContain('Main documentation')
+      const previewContent = screen.getByText(/Main documentation/i)
+      expect(previewContent).toBeInTheDocument()
     })
+
+    // Open file tree again to select another file
+    await userEvent.click(explorerButton)
 
     // Click on guide.md (get all matches and take the last one which is the file, not directory)
     const guideFiles = screen.getAllByText('guide.md')
     const guideFile = guideFiles[guideFiles.length - 1]
     await userEvent.click(guideFile)
 
-    // Verify guide content is displayed in CodeMirror
+    // Verify guide content is displayed in preview mode
     await waitFor(() => {
-      const contentElement = document.querySelector('.cm-content')
-      expect(contentElement?.textContent).toContain('User guide content')
+      const previewContent = screen.getByText(/User guide content/i)
+      expect(previewContent).toBeInTheDocument()
     })
   })
 })
@@ -154,7 +124,9 @@ describe('projectPage - chat input', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Find textarea and send button
     const textarea = screen.getByPlaceholderText(/Type a message/)
@@ -174,7 +146,9 @@ describe('projectPage - chat input', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Find textarea and send button
     const textarea = screen.getByPlaceholderText(/Type a message/)
@@ -194,7 +168,9 @@ describe('projectPage - chat input', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Find textarea
     const textarea = screen.getByPlaceholderText(/Type a message/)
@@ -212,7 +188,9 @@ describe('projectPage - chat input', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Find textarea
     const textarea = screen.getByPlaceholderText(/Type a message/)
@@ -281,7 +259,9 @@ describe('projectPage - session selector', () => {
 
   it('displays session selector with multiple sessions', async () => {
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Find session selector
     const sessionSelector = screen.getByRole('combobox')
@@ -297,7 +277,9 @@ describe('projectPage - session selector', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Wait for first session content to load
     await expect(
@@ -344,7 +326,9 @@ describe('projectPage - no sessions', () => {
 
   it('does not show selector when no sessions exist', async () => {
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Session selector should not exist
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
@@ -428,7 +412,9 @@ describe('projectPage - auto-create session', () => {
     const userEvent = user.setup()
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Should show "no sessions" message initially
     expect(screen.getByText(/No sessions yet/)).toBeInTheDocument()
@@ -479,7 +465,9 @@ describe('projectPage - auto-create session', () => {
     )
 
     // Wait for page to load
-    await expect(screen.findByText('Explorer')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByLabelText('Open file explorer'),
+    ).resolves.toBeInTheDocument()
 
     // Send message
     const textarea = screen.getByPlaceholderText(/Type a message/)
@@ -632,7 +620,7 @@ describe('projectPage - turn status display', () => {
     server.resetHandlers()
   })
 
-  it('handles turn with pending status', async () => {
+  it('handles turn with running status', async () => {
     await setupProjectPage(
       `/projects/${projectId}?sessionId=${sessionId}`,
       context,
@@ -644,14 +632,14 @@ describe('projectPage - turn status display', () => {
       },
       [
         http.get(
-          `*/api/projects/${projectId}/sessions/${sessionId}/turns/turn-status`,
+          `*/api/projects/${projectId}/sessions/${sessionId}/turns/turn-running`,
           () => {
             return HttpResponse.json({
-              id: 'turn-status',
+              id: 'turn-running',
               session_id: sessionId,
-              user_prompt: 'Test status',
-              status: 'pending',
-              started_at: null,
+              user_prompt: 'Test running status',
+              status: 'running',
+              started_at: new Date().toISOString(),
               completed_at: null,
               created_at: new Date().toISOString(),
               blocks: [],
@@ -664,10 +652,10 @@ describe('projectPage - turn status display', () => {
             return HttpResponse.json({
               turns: [
                 {
-                  id: 'turn-status',
-                  user_prompt: 'Test status',
-                  status: 'pending',
-                  started_at: null,
+                  id: 'turn-running',
+                  user_prompt: 'Test running status',
+                  status: 'running',
+                  started_at: new Date().toISOString(),
                   completed_at: null,
                   created_at: new Date().toISOString(),
                   block_count: 0,
@@ -681,10 +669,9 @@ describe('projectPage - turn status display', () => {
       ],
     )
 
-    // Verify pending status is rendered through turns$ signal
-    await expect(screen.findByText('Test status')).resolves.toBeInTheDocument()
-    const statusBadge = screen.getByTestId('turn-status')
-    expect(statusBadge).toHaveTextContent('Pending')
+    // Verify running status shows processing indicator
+    await expect(screen.findByText('Test running status')).resolves.toBeInTheDocument()
+    await expect(screen.findByText('Processing...')).resolves.toBeInTheDocument()
   })
 
   it('handles turn with failed status', async () => {
@@ -736,11 +723,12 @@ describe('projectPage - turn status display', () => {
       ],
     )
 
-    // Verify failed status is handled through turns$ signal
+    // Verify failed status shows error message
     await expect(
       screen.findByText('Failed message'),
     ).resolves.toBeInTheDocument()
-    const statusBadge = screen.getByTestId('turn-status')
-    expect(statusBadge).toHaveTextContent('Failed')
+    await expect(
+      screen.findByText('Turn execution failed. Please try again.'),
+    ).resolves.toBeInTheDocument()
   })
 })

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -670,8 +670,12 @@ describe('projectPage - turn status display', () => {
     )
 
     // Verify running status shows processing indicator
-    await expect(screen.findByText('Test running status')).resolves.toBeInTheDocument()
-    await expect(screen.findByText('Processing...')).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByText('Test running status'),
+    ).resolves.toBeInTheDocument()
+    await expect(
+      screen.findByText('Processing...'),
+    ).resolves.toBeInTheDocument()
   })
 
   it('handles turn with failed status', async () => {


### PR DESCRIPTION
## Summary
- Fixed 17 failing workspace tests by updating to current API and UI patterns
- Added workspace tests to CI pipeline to prevent future regressions
- All 175 workspace tests now passing

## Changes
- **Turn status updates**: Changed deprecated `'pending'` and `'in_progress'` statuses to `'running'` (unified in turns.contract.ts)
- **Markdown editor tests**: Updated to work with new popover-based file tree UI
- **Project page tests**: Fixed to match current UI behavior (files open in preview mode by default)
- **CI integration**: Added `pnpm -F workspace test` to CI test command

## Test Results
✅ 12 test files, 175 tests passing
- watch-session.test.ts: 9 tests
- markdown-editor.test.tsx: 1 test  
- project-page.test.tsx: 13 tests
- Plus 9 other test files

## Test Plan
- [x] Run `pnpm -F workspace test` locally - all tests pass
- [x] Verify CI configuration change
- [ ] CI will run workspace tests on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)