### PR TITLE
fix(workspace): update test for hidden tool result content

### DIFF
--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -598,17 +598,24 @@ describe('projectPage - turn and blocks rendering', () => {
 
     // Verify all block types are rendered
     // This tests that turns$ correctly calls turnDetail and includes blocks
+
+    // Thinking block
     await expect(
       screen.findByText('Let me check the files...'),
     ).resolves.toBeInTheDocument()
+
+    // Content block
     await expect(
       screen.findByText('Here are the files in your project'),
     ).resolves.toBeInTheDocument()
+
+    // Tool use block shows tool name
     await expect(
-      screen.findByText((content) => {
-        return content.includes('README.md') && content.includes('package.json')
-      }),
+      screen.findByText('Tool: list_files'),
     ).resolves.toBeInTheDocument()
+
+    // Tool result block shows status label (content is now hidden)
+    await expect(screen.findByText('Tool Result')).resolves.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary
- Fix failing test after PR #604 hid tool result content
- Update test to check for 'Tool Result' label instead of actual content
- All 175 workspace tests now passing

## Changes
- Modified `projectPage - turn and blocks rendering` test in project-page.test.tsx
- Now verifies 'Tool Result' status label is displayed instead of checking for file content
- Added comments explaining each block type being tested

## Context
PR #604 changed block-display to hide detailed content from tool_result blocks, showing only a status indicator. This test was still expecting to find the actual tool result content (README.md and package.json), causing it to fail.

## Test Results
✅ All 175 workspace tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)