### PR TITLE
feat(workspace): upgrade markdown preview with marked.js and DOMPurify

### DIFF
--- a/turbo/apps/workspace/package.json
+++ b/turbo/apps/workspace/package.json
@@ -22,6 +22,8 @@
     "@uspark/core": "workspace:*",
     "ccstate": "^5.0.0",
     "ccstate-react": "^5.0.0",
+    "dompurify": "^3.3.0",
+    "marked": "^16.4.1",
     "path-to-regexp": "^8.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/turbo/apps/workspace/src/signals/project/__tests__/watch-session.test.ts
+++ b/turbo/apps/workspace/src/signals/project/__tests__/watch-session.test.ts
@@ -88,7 +88,7 @@ describe('session watching', () => {
       expect(result).toBeFalsy()
     })
 
-    it('should return true when there are pending turns', async () => {
+    it('should return true when there are running turns', async () => {
       await setupProjectPage(
         `/projects/${mockProjectId}?sessionId=${mockSessionId}`,
         context,
@@ -101,7 +101,7 @@ describe('session watching', () => {
               {
                 id: 'turn_1',
                 userMessage: 'test',
-                status: 'pending',
+                status: 'running',
               },
             ],
           },
@@ -112,7 +112,7 @@ describe('session watching', () => {
       expect(result).toBeTruthy()
     })
 
-    it('should return true when there are in_progress turns', async () => {
+    it('should return true when there are running turns with assistant message', async () => {
       await setupProjectPage(
         `/projects/${mockProjectId}?sessionId=${mockSessionId}`,
         context,
@@ -126,7 +126,7 @@ describe('session watching', () => {
                 id: 'turn_1',
                 userMessage: 'test',
                 assistantMessage: 'processing...',
-                status: 'in_progress',
+                status: 'running',
               },
             ],
           },
@@ -178,7 +178,7 @@ describe('session watching', () => {
                 id: 'turn_1',
                 userMessage: 'test',
                 assistantMessage: 'response',
-                status: 'in_progress',
+                status: 'running',
               },
             ],
           },

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -1,6 +1,8 @@
 import type { FileItem } from '@uspark/core/yjs-filesystem'
 import { command, computed, state } from 'ccstate'
 import { delay } from 'signal-timers'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { IN_VITEST } from '../../env'
 import {
   blobStore$,
@@ -100,6 +102,16 @@ export const selectedFileContent$ = computed(async (get) => {
   const contentUrl = getFileContentUrl(store.storeId, projectId, file.hash)
   const resp = await fetch(contentUrl)
   return await resp.text()
+})
+
+export const selectedFileContentHtml$ = computed(async (get) => {
+  const fileContent = await get(selectedFileContent$)
+  if (!fileContent) {
+    return undefined
+  }
+
+  const rawHtml = marked.parse(fileContent)
+  return DOMPurify.sanitize(rawHtml)
 })
 
 export const selectFile$ = command(({ get, set }, filePath: string) => {

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -1,8 +1,8 @@
 import type { FileItem } from '@uspark/core/yjs-filesystem'
 import { command, computed, state } from 'ccstate'
-import { delay } from 'signal-timers'
-import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import { marked } from 'marked'
+import { delay } from 'signal-timers'
 import { IN_VITEST } from '../../env'
 import {
   blobStore$,

--- a/turbo/apps/workspace/src/views/css/index.css
+++ b/turbo/apps/workspace/src/views/css/index.css
@@ -19,4 +19,144 @@
   .cm-content {
     padding: 1rem !important;
   }
+
+  /* Markdown preview styling - VS Code dark theme */
+  .markdown-preview {
+    color: #cccccc;
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  .markdown-preview h1,
+  .markdown-preview h2,
+  .markdown-preview h3,
+  .markdown-preview h4,
+  .markdown-preview h5,
+  .markdown-preview h6 {
+    color: #ffffff;
+    font-weight: 600;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+    line-height: 1.3;
+  }
+
+  .markdown-preview h1 {
+    font-size: 2em;
+    border-bottom: 1px solid #3e3e42;
+    padding-bottom: 0.3em;
+  }
+
+  .markdown-preview h2 {
+    font-size: 1.5em;
+    border-bottom: 1px solid #3e3e42;
+    padding-bottom: 0.3em;
+  }
+
+  .markdown-preview h3 {
+    font-size: 1.25em;
+  }
+
+  .markdown-preview h4 {
+    font-size: 1.1em;
+  }
+
+  .markdown-preview h5,
+  .markdown-preview h6 {
+    font-size: 1em;
+  }
+
+  .markdown-preview p {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
+
+  .markdown-preview a {
+    color: #3794ff;
+    text-decoration: none;
+  }
+
+  .markdown-preview a:hover {
+    text-decoration: underline;
+  }
+
+  .markdown-preview code {
+    background-color: #2a2d2e;
+    color: #f48771;
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+    font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+      'Courier New', monospace;
+    font-size: 0.9em;
+  }
+
+  .markdown-preview pre {
+    background-color: #252526;
+    border: 1px solid #3e3e42;
+    border-radius: 4px;
+    padding: 1em;
+    overflow-x: auto;
+    margin: 1em 0;
+  }
+
+  .markdown-preview pre code {
+    background-color: transparent;
+    padding: 0;
+    color: #cccccc;
+  }
+
+  .markdown-preview blockquote {
+    border-left: 4px solid #094771;
+    padding-left: 1em;
+    margin-left: 0;
+    color: #969696;
+    font-style: italic;
+  }
+
+  .markdown-preview ul,
+  .markdown-preview ol {
+    padding-left: 2em;
+    margin: 1em 0;
+  }
+
+  .markdown-preview li {
+    margin: 0.25em 0;
+  }
+
+  .markdown-preview table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+  }
+
+  .markdown-preview th,
+  .markdown-preview td {
+    border: 1px solid #3e3e42;
+    padding: 0.5em;
+    text-align: left;
+  }
+
+  .markdown-preview th {
+    background-color: #2a2d2e;
+    font-weight: 600;
+  }
+
+  .markdown-preview hr {
+    border: none;
+    border-top: 1px solid #3e3e42;
+    margin: 2em 0;
+  }
+
+  .markdown-preview img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .markdown-preview strong {
+    color: #ffffff;
+    font-weight: 600;
+  }
+
+  .markdown-preview em {
+    font-style: italic;
+  }
 }

--- a/turbo/apps/workspace/src/views/css/index.css
+++ b/turbo/apps/workspace/src/views/css/index.css
@@ -84,7 +84,8 @@
     color: #f48771;
     padding: 0.2em 0.4em;
     border-radius: 3px;
-    font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
+    font-family:
+      'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas,
       'Courier New', monospace;
     font-size: 0.9em;
   }

--- a/turbo/apps/workspace/src/views/project/markdown-preview.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-preview.tsx
@@ -1,18 +1,19 @@
 import { useLastResolved } from 'ccstate-react'
-import { selectedFileContent$ } from '../../signals/project/project'
+import { selectedFileContentHtml$ } from '../../signals/project/project'
 
 export function MarkdownPreview() {
-  const fileContent = useLastResolved(selectedFileContent$)
+  const sanitizedHtml = useLastResolved(selectedFileContentHtml$)
 
-  if (!fileContent) {
+  if (!sanitizedHtml) {
     return null
   }
 
   return (
     <div className="h-full overflow-auto bg-[#1e1e1e] p-4">
-      <pre className="font-mono text-[13px] whitespace-pre-wrap text-[#cccccc]">
-        {fileContent}
-      </pre>
+      <div
+        className="markdown-preview"
+        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+      />
     </div>
   )
 }

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^6.31.6
-        version: 6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.1
@@ -195,7 +195,7 @@ importers:
         version: 5.1.5
       next:
         specifier: ^15.5.2
-        version: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -283,7 +283,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^5.92.1
-        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
+        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
       '@codemirror/lang-markdown':
         specifier: ^6.4.0
         version: 6.4.0
@@ -305,6 +305,12 @@ importers:
       ccstate-react:
         specifier: ^5.0.0
         version: 5.0.0(@types/react@19.1.12)(react@19.1.1)
+      dompurify:
+        specifier: ^3.3.0
+        version: 3.3.0
+      marked:
+        specifier: ^16.4.1
+        version: 16.4.1
       path-to-regexp:
         specifier: ^8.3.0
         version: 8.3.0
@@ -2792,6 +2798,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -3597,6 +3606,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.0:
+    resolution: {integrity: sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==}
 
   dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -4723,6 +4735,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.1:
+    resolution: {integrity: sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6629,15 +6646,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
+  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.2)(zod@4.1.5)
+      ox: 0.6.9(typescript@5.9.2)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.37.5(typescript@5.9.2)(zod@4.1.5)
+      viem: 2.37.5(typescript@5.9.2)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.1.12)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -6672,9 +6689,9 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
+  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
     dependencies:
-      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
+      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
       '@clerk/localizations': 3.25.0
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
@@ -6722,13 +6739,13 @@ snapshots:
     dependencies:
       '@clerk/types': 4.85.0
 
-  '@clerk/nextjs@6.31.6(next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@clerk/nextjs@6.31.6(next@15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@clerk/backend': 2.10.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/clerk-react': 5.45.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
-      next: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.2(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       server-only: 0.0.1
@@ -8610,6 +8627,9 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -8937,26 +8957,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
-    dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.18
-      sirv: 3.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
-      ws: 8.18.3
-    optionalDependencies:
-      playwright: 1.55.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -8967,6 +8967,26 @@ snapshots:
       sirv: 3.0.1
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.55.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.18
+      sirv: 3.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.0
@@ -8992,9 +9012,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -9033,6 +9053,16 @@ snapshots:
       msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
       vite: 6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)
 
+  '@vitest/mocker@3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.18
+    optionalDependencies:
+      msw: 2.11.1(@types/node@24.3.0)(typescript@5.9.2)
+      vite: 7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5)
+    optional: true
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -9062,7 +9092,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9076,10 +9106,10 @@ snapshots:
 
   '@zxcvbn-ts/language-common@3.0.4': {}
 
-  abitype@1.1.0(typescript@5.9.2)(zod@4.1.5):
+  abitype@1.1.0(typescript@5.9.2)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.2
-      zod: 4.1.5
+      zod: 3.25.76
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -9544,6 +9574,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.0:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.0.3: {}
 
@@ -10867,6 +10901,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@16.4.1: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
@@ -11434,29 +11470,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
-    dependencies:
-      '@next/env': 15.5.2
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001737
-      postcss: 8.4.31
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      styled-jsx: 5.1.6(react@19.1.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.2
-      '@next/swc-darwin-x64': 15.5.2
-      '@next/swc-linux-arm64-gnu': 15.5.2
-      '@next/swc-linux-arm64-musl': 15.5.2
-      '@next/swc-linux-x64-gnu': 15.5.2
-      '@next/swc-linux-x64-musl': 15.5.2
-      '@next/swc-win32-arm64-msvc': 15.5.2
-      '@next/swc-win32-x64-msvc': 15.5.2
-      sharp: 0.34.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
@@ -11536,21 +11549,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.9.2)(zod@4.1.5):
+  ox@0.6.9(typescript@5.9.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
+      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@5.9.2)(zod@4.1.5):
+  ox@0.9.3(typescript@5.9.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -11558,7 +11571,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
+      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
@@ -12413,11 +12426,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.3
 
-  styled-jsx@5.1.6(react@19.1.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.1.1
-
   stylis@4.2.0: {}
 
   sucrase@3.35.0:
@@ -12837,15 +12845,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.37.5(typescript@5.9.2)(zod@4.1.5):
+  viem@2.37.5(typescript@5.9.2)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
+      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.9.3(typescript@5.9.2)(zod@4.1.5)
+      ox: 0.9.3(typescript@5.9.2)(zod@3.25.76)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.2
@@ -12962,6 +12970,22 @@ snapshots:
       lightningcss: 1.30.1
       tsx: 4.20.5
 
+  vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.3.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.30.1
+      tsx: 4.20.5
+    optional: true
+
   vite@7.1.9(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5):
     dependencies:
       esbuild: 0.25.9
@@ -13052,7 +13076,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.3.0
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@7.1.9(@types/node@24.3.0)(jiti@1.21.7)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 20.0.0
       jsdom: 26.1.0


### PR DESCRIPTION
## Summary

Upgrade markdown preview from simple `<pre>` tag to proper HTML rendering using marked.js for parsing and DOMPurify for XSS protection.

## Changes

### Dependencies
- ✅ Install `marked` v16.4.1 - Fast markdown parser and compiler
- ✅ Install `dompurify` v3.3.0 - XSS protection for HTML sanitization

### Signal Layer
- ✅ Add `selectedFileContentHtml$` computed signal for centralized markdown rendering
- ✅ Automatic caching and reactivity through ccstate

### UI Components
- ✅ Update `MarkdownPreview` component to use new computed signal
- ✅ Simplified component logic (rendering moved to signal layer)

### Styling
- ✅ Add comprehensive markdown CSS matching VS Code dark theme:
  - Headings (h1-h6) with underlines for h1/h2
  - Code blocks with syntax highlighting colors
  - Inline code with background and color
  - Links with hover effects
  - Blockquotes with left border accent
  - Lists and tables with proper spacing
  - All using VS Code colors (#1e1e1e, #cccccc, #3794ff, #f48771, etc.)

### Test Fixes
- ✅ Fix `watch-session.test.ts` - update status values from `pending`/`in_progress` to `running`

## Security

All HTML output is sanitized with DOMPurify before rendering to prevent XSS attacks. The implementation follows best practices:
- `marked.parse()` converts markdown to HTML
- `DOMPurify.sanitize()` removes malicious content
- Safe to use with `dangerouslySetInnerHTML`

## Benefits

1. **Better separation of concerns** - Rendering logic in signal layer, UI only displays
2. **Reusable** - Other components can use `selectedFileContentHtml$`
3. **Automatic caching** - ccstate handles memoization
4. **Proper markdown rendering** - Headers, code blocks, links, etc. all styled correctly
5. **Secure** - DOMPurify prevents XSS attacks

## Test Plan

- ✅ Lint passed
- ✅ Type check passed
- ✅ Build successful
- ✅ Knip passed

## Screenshots

Before: Plain text in `<pre>` tag
After: Formatted markdown with headers, code blocks, links, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)