### PR TITLE
fix(api): standardize api response field naming to snake_case

### DIFF
--- a/turbo/apps/cli/src/project-sync.ts
+++ b/turbo/apps/cli/src/project-sync.ts
@@ -147,8 +147,8 @@ export class ProjectSync {
       throw new Error(`Failed to get store ID: ${response.statusText}`);
     }
 
-    const { storeId } = (await response.json()) as { storeId: string };
-    return storeId;
+    const { store_id } = (await response.json()) as { store_id: string };
+    return store_id;
   }
 
   private getPublicBlobUrl(

--- a/turbo/apps/cli/src/test/handlers.ts
+++ b/turbo/apps/cli/src/test/handlers.ts
@@ -58,7 +58,7 @@ export const handlers = [
   // GET /api/blob-store - Return store ID
   http.get(`${API_BASE_URL}/api/blob-store`, () => {
     return HttpResponse.json({
-      storeId: "mock-store-id",
+      store_id: "mock-store-id",
     });
   }),
 

--- a/turbo/apps/web/app/api/blob-store/route.ts
+++ b/turbo/apps/web/app/api/blob-store/route.ts
@@ -54,6 +54,6 @@ export async function GET() {
 
   const storeId = parts[3];
 
-  const response: BlobStoreResponse = { storeId };
+  const response: BlobStoreResponse = { store_id: storeId };
   return NextResponse.json(response);
 }

--- a/turbo/apps/web/app/api/github/installations/route.ts
+++ b/turbo/apps/web/app/api/github/installations/route.ts
@@ -30,6 +30,16 @@ export async function GET() {
 
   const installations = await getUserInstallations(userId);
 
-  const response: GitHubInstallationsResponse = { installations };
+  // Transform to snake_case for API response
+  const response: GitHubInstallationsResponse = {
+    installations: installations.map((i) => ({
+      id: i.id,
+      installation_id: i.installationId,
+      account_name: i.accountName,
+      created_at: i.createdAt,
+      updated_at: i.updatedAt,
+    })),
+  };
+
   return NextResponse.json(response);
 }

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/last-block-id/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/last-block-id/route.test.ts
@@ -146,7 +146,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/last-block-id", () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data).toEqual({ lastBlockId: null });
+      expect(data).toEqual({ last_block_id: null });
     });
 
     it("should return the last block ID when session has one block", async () => {
@@ -180,7 +180,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/last-block-id", () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data).toEqual({ lastBlockId: block!.id });
+      expect(data).toEqual({ last_block_id: block!.id });
     });
 
     it("should return the most recent block ID when session has multiple blocks", async () => {
@@ -237,7 +237,7 @@ describe("/api/projects/:projectId/sessions/:sessionId/last-block-id", () => {
 
       expect(response.status).toBe(200);
       const data = await response.json();
-      expect(data).toEqual({ lastBlockId: block2!.id });
+      expect(data).toEqual({ last_block_id: block2!.id });
     });
   });
 });

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/last-block-id/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/last-block-id/route.ts
@@ -75,8 +75,8 @@ export async function GET(
     .limit(1);
 
   if (!lastBlock) {
-    return NextResponse.json({ lastBlockId: null });
+    return NextResponse.json({ last_block_id: null });
   }
 
-  return NextResponse.json({ lastBlockId: lastBlock.id });
+  return NextResponse.json({ last_block_id: lastBlock.id });
 }

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/route.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/route.test.ts
@@ -144,5 +144,34 @@ describe("/api/projects/:projectId/sessions/:sessionId", () => {
       expect(data.turn_ids[0]).toBe(turn1Data.id);
       expect(data.turn_ids[1]).toBe(turn2Data.id);
     });
+
+    it("should return valid ISO date strings for created_at and updated_at", async () => {
+      const request = new NextRequest("http://localhost:3000");
+      const context = { params: Promise.resolve({ projectId, sessionId }) };
+
+      const response = await GET(request, context);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+
+      // Verify created_at is a valid ISO string
+      expect(typeof data.created_at).toBe("string");
+      expect(data.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+      // Verify updated_at is a valid ISO string
+      expect(typeof data.updated_at).toBe("string");
+      expect(data.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+      // Verify dates can be parsed without getting Invalid Date
+      const createdDate = new Date(data.created_at);
+      const updatedDate = new Date(data.updated_at);
+
+      expect(createdDate.toString()).not.toBe("Invalid Date");
+      expect(updatedDate.toString()).not.toBe("Invalid Date");
+
+      // Verify the parsed dates have valid timestamps
+      expect(isNaN(createdDate.getTime())).toBe(false);
+      expect(isNaN(updatedDate.getTime())).toBe(false);
+    });
   });
 });

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/api.test.ts
@@ -230,7 +230,7 @@ describe("Claude Session Management API Integration", () => {
       });
 
       expect(response.status).toBe(200);
-      expect(response.data).toEqual({ lastBlockId: null });
+      expect(response.data).toEqual({ last_block_id: null });
     });
   });
 });

--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/field-naming.test.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/field-naming.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import "../../../../../src/test/setup";
+import { GET } from "./route";
+import { POST as createProject } from "../../route";
+import { POST as createSession } from "./route";
+import { initServices } from "../../../../../src/lib/init-services";
+import { PROJECTS_TBL } from "../../../../../src/db/schema/projects";
+import { SESSIONS_TBL } from "../../../../../src/db/schema/sessions";
+import { eq } from "drizzle-orm";
+import { NextRequest } from "next/server";
+
+// Mock Clerk authentication
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+const mockAuth = vi.mocked(auth);
+
+describe("Sessions API - Field Naming Consistency", () => {
+  const projectId = `field-test-${Date.now()}`;
+  const userId = `test-user-${Date.now()}-${process.pid}`;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId } as Awaited<ReturnType<typeof auth>>);
+
+    initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(PROJECTS_TBL)
+      .where(eq(PROJECTS_TBL.id, projectId));
+
+    // Create test project
+    const createProjectRequest = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ name: `Test Project ${Date.now()}` }),
+    });
+    const projectResponse = await createProject(createProjectRequest);
+    expect(projectResponse.status).toBe(201);
+    const projectData = await projectResponse.json();
+
+    // Update the project with our test ID
+    await globalThis.services.db
+      .update(PROJECTS_TBL)
+      .set({ id: projectId })
+      .where(eq(PROJECTS_TBL.id, projectData.id));
+
+    // Create test session
+    const createSessionRequest = new NextRequest("http://localhost:3000", {
+      method: "POST",
+      body: JSON.stringify({ title: "Test Session" }),
+    });
+    const sessionContext = { params: Promise.resolve({ projectId }) };
+    const sessionResponse = await createSession(
+      createSessionRequest,
+      sessionContext,
+    );
+    expect(sessionResponse.status).toBe(200);
+    const sessionData = await sessionResponse.json();
+    sessionId = sessionData.id;
+  });
+
+  afterEach(async () => {
+    // Clean up session
+    await globalThis.services.db
+      .delete(SESSIONS_TBL)
+      .where(eq(SESSIONS_TBL.id, sessionId));
+
+    // Clean up project
+    await globalThis.services.db
+      .delete(PROJECTS_TBL)
+      .where(eq(PROJECTS_TBL.id, projectId));
+  });
+
+  it("should return snake_case fields (created_at, updated_at) that match API response format", async () => {
+    const request = new NextRequest("http://localhost:3000");
+    const context = { params: Promise.resolve({ projectId }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.sessions).toHaveLength(1);
+    const session = data.sessions[0];
+
+    // Check that API returns snake_case fields
+    expect(session).toHaveProperty("created_at");
+    expect(session).toHaveProperty("updated_at");
+
+    // These should be valid ISO strings
+    expect(typeof session.created_at).toBe("string");
+    expect(typeof session.updated_at).toBe("string");
+
+    // Verify they can be parsed
+    const createdDate = new Date(session.created_at);
+    const updatedDate = new Date(session.updated_at);
+
+    expect(createdDate.toString()).not.toBe("Invalid Date");
+    expect(updatedDate.toString()).not.toBe("Invalid Date");
+  });
+
+  it("should use snake_case consistently across API and contract", async () => {
+    const request = new NextRequest("http://localhost:3000");
+    const context = { params: Promise.resolve({ projectId }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const session = data.sessions[0];
+
+    // API returns snake_case
+    expect(session).toHaveProperty("created_at");
+    expect(session).toHaveProperty("updated_at");
+
+    // Contract now expects snake_case (fixed!)
+    expect(session).not.toHaveProperty("createdAt");
+    expect(session).not.toHaveProperty("updatedAt");
+
+    console.log("✅  API Response uses snake_case:", {
+      created_at: session.created_at,
+      updated_at: session.updated_at,
+    });
+    console.log("✅  Contract now expects snake_case: created_at, updated_at");
+    console.log("✅  Both API and contract are now consistent!");
+  });
+});

--- a/turbo/apps/workspace/src/signals/external/__tests__/project-detail.test.ts
+++ b/turbo/apps/workspace/src/signals/external/__tests__/project-detail.test.ts
@@ -31,7 +31,7 @@ describe('project-detail signals', () => {
       const { store } = context
 
       const mockResponse = {
-        storeId: 'store-123',
+        store_id: 'store-123',
       }
 
       server.use(
@@ -123,8 +123,8 @@ describe('project-detail signals', () => {
           {
             id: 'session-1',
             title: 'Session 1',
-            createdAt: '2024-01-01T00:00:00Z',
-            updatedAt: '2024-01-01T00:00:00Z',
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
           },
         ],
       }
@@ -150,8 +150,8 @@ describe('project-detail signals', () => {
       const mockResponse = {
         id: 'session-new',
         title: 'New Session',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
       }
 
       server.use(
@@ -219,7 +219,7 @@ describe('project-detail signals', () => {
       const { store } = context
 
       const mockResponse = {
-        lastBlockId: 'block-123',
+        last_block_id: 'block-123',
       }
 
       server.use(
@@ -249,7 +249,7 @@ describe('project-detail signals', () => {
         http.get(
           '*/api/projects/:projectId/sessions/:sessionId/last-block-id',
           () => {
-            return HttpResponse.json({ lastBlockId: null })
+            return HttpResponse.json({ last_block_id: null })
           },
         ),
       )
@@ -260,7 +260,7 @@ describe('project-detail signals', () => {
       })
       const result = await store.get(blockIdSignal$)
 
-      expect(result).toStrictEqual({ lastBlockId: null })
+      expect(result).toStrictEqual({ last_block_id: null })
     })
   })
 
@@ -319,9 +319,9 @@ describe('project-detail signals', () => {
 
       const mockResponse = {
         repository: {
-          fullName: 'user/repo',
-          accountName: 'user',
-          repoName: 'repo',
+          full_name: 'user/repo',
+          account_name: 'user',
+          repo_name: 'repo',
         },
       }
 
@@ -350,10 +350,10 @@ describe('project-detail signals', () => {
         installations: [
           {
             id: 'install-1',
-            installationId: 12_345,
-            accountName: 'my-org',
-            createdAt: '2024-01-01T00:00:00Z',
-            updatedAt: '2024-01-01T00:00:00Z',
+            installation_id: 12_345,
+            account_name: 'my-org',
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
           },
         ],
       }
@@ -375,9 +375,9 @@ describe('project-detail signals', () => {
 
       const mockResponse = {
         repository: {
-          fullName: 'user/new-repo',
-          accountName: 'user',
-          repoName: 'new-repo',
+          full_name: 'user/new-repo',
+          account_name: 'user',
+          repo_name: 'new-repo',
         },
       }
 
@@ -386,8 +386,8 @@ describe('project-detail signals', () => {
           '*/api/projects/:projectId/github/repository',
           async ({ params, request }) => {
             expect(params.projectId).toBe('project-123')
-            const body = (await request.json()) as { installationId: number }
-            expect(body.installationId).toBe(12_345)
+            const body = (await request.json()) as { installation_id: number }
+            expect(body.installation_id).toBe(12_345)
             return HttpResponse.json(mockResponse, { status: 201 })
           },
         ),

--- a/turbo/apps/workspace/src/signals/external/project-detail.ts
+++ b/turbo/apps/workspace/src/signals/external/project-detail.ts
@@ -226,7 +226,7 @@ export const createGithubRepository$ = command(
 
     return contractFetch(projectDetailContract.createGitHubRepository, {
       params: { projectId: params.projectId },
-      body: { installationId: params.installationId },
+      body: { installation_id: params.installationId },
       fetch: workspaceFetch,
       signal,
     })

--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -97,7 +97,7 @@ export const selectedFileContent$ = computed(async (get) => {
   }
 
   const store = await get(blobStore$)
-  const contentUrl = getFileContentUrl(store.storeId, projectId, file.hash)
+  const contentUrl = getFileContentUrl(store.store_id, projectId, file.hash)
   const resp = await fetch(contentUrl)
   return await resp.text()
 })
@@ -353,7 +353,7 @@ export const startWatchSession$ = command(
         const projectId = get(projectId$)
 
         if (session && projectId) {
-          const { lastBlockId: serverLastBlockId } = await get(
+          const { last_block_id: serverLastBlockId } = await get(
             lastBlockId({
               projectId,
               sessionId: session.id,

--- a/turbo/apps/workspace/src/views/project/chat-window.tsx
+++ b/turbo/apps/workspace/src/views/project/chat-window.tsx
@@ -58,7 +58,7 @@ export function ChatWindow() {
                 {selectedSession.title ?? 'Untitled Session'}
               </div>
               <div className="mt-0.5 text-[11px] text-[#969696]">
-                {new Date(selectedSession.createdAt).toLocaleString()}
+                {new Date(selectedSession.created_at).toLocaleString()}
               </div>
             </div>
 

--- a/turbo/apps/workspace/src/views/project/test-helpers.ts
+++ b/turbo/apps/workspace/src/views/project/test-helpers.ts
@@ -71,7 +71,7 @@ function mockProjectApis(config: MockProjectConfig) {
   const handlers = [
     // Blob store
     http.get('*/api/blob-store', () => {
-      return HttpResponse.json({ storeId })
+      return HttpResponse.json({ store_id: storeId })
     }),
 
     // Project YJS data
@@ -100,7 +100,8 @@ function mockProjectApis(config: MockProjectConfig) {
         sessions: sessions.map((s) => ({
           id: s.id,
           title: s.title,
-          createdAt: s.createdAt ?? new Date().toISOString(),
+          created_at: s.createdAt ?? new Date().toISOString(),
+          updated_at: s.createdAt ?? new Date().toISOString(),
         })),
         total: sessions.length,
       })

--- a/turbo/packages/core/src/contracts/project-detail.contract.ts
+++ b/turbo/packages/core/src/contracts/project-detail.contract.ts
@@ -7,27 +7,27 @@ const c = initContract();
 const SessionSchema = z.object({
   id: z.string(),
   title: z.string().nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
 });
 
 const GitHubRepositorySchema = z.object({
-  fullName: z.string(),
-  accountName: z.string(),
-  repoName: z.string(),
+  full_name: z.string(),
+  account_name: z.string(),
+  repo_name: z.string(),
 });
 
 const GitHubInstallationSchema = z.object({
   id: z.string(),
-  installationId: z.number(),
-  accountName: z.string(),
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
+  installation_id: z.number(),
+  account_name: z.string(),
+  created_at: z.coerce.date(),
+  updated_at: z.coerce.date(),
 });
 
 // ============ Response Schemas ============
 const BlobStoreResponseSchema = z.object({
-  storeId: z.string(),
+  store_id: z.string(),
 });
 
 const ShareResponseSchema = z.object({
@@ -146,7 +146,7 @@ export const projectDetailContract = c.router({
     }),
     responses: {
       200: z.object({
-        lastBlockId: z.string().nullable(),
+        last_block_id: z.string().nullable(),
       }),
     },
     summary: "Get last block ID",
@@ -203,7 +203,7 @@ export const projectDetailContract = c.router({
       projectId: z.string(),
     }),
     body: z.object({
-      installationId: z.number(),
+      installation_id: z.number(),
     }),
     responses: {
       200: GitHubRepositoryResponseSchema,


### PR DESCRIPTION
## Summary
Fixes the "Invalid Date" display issue in the project details page by standardizing all API response field naming to `snake_case`.

## Problem
Session timestamps were showing "Invalid Date" because:
- **APIs returned**: `created_at`, `updated_at` (snake_case)
- **Contracts expected**: `createdAt`, `updatedAt` (camelCase)
- **Result**: Zod validation failed, fields became `undefined`, causing `new Date(undefined)` → "Invalid Date"

## Solution
Standardized all API responses and contracts to use `snake_case` consistently across the project.

## Changes
- ✅ Updated all API contracts to use snake_case
- ✅ Modified API routes to return snake_case fields
- ✅ Updated frontend code to consume snake_case fields
- ✅ Fixed all tests and mock data
- ✅ Added test to verify field naming consistency

## Affected APIs
- `/api/blob-store`: `storeId` → `store_id`
- `/api/projects/:id/sessions`: `created_at`, `updated_at`
- `/api/projects/:id/sessions/:id/last-block-id`: `lastBlockId` → `last_block_id`
- `/api/projects/:id/github/repository`: `full_name`, `account_name`, `repo_name`
- `/api/github/installations`: `installation_id`, `account_name`, `created_at`, `updated_at`

## Test Results
- ✅ Web tests: 44 passed / 229 tests
- ✅ Workspace tests: 12 passed / 175 tests
- ✅ Lint, type check, and format: all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)