### PR TITLE
fix(api): correct interrupt route to use running status

### DIFF
--- a/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/interrupt/route.ts
+++ b/turbo/apps/web/app/api/projects/[projectId]/sessions/[sessionId]/interrupt/route.ts
@@ -62,19 +62,16 @@ export async function POST(
     return NextResponse.json(error, { status: 404 });
   }
 
-  // Update all running turns to failed status
+  // Update all running turns to interrupted status
   await globalThis.services.db
     .update(TURNS_TBL)
     .set({
-      status: "failed",
+      status: "interrupted",
       errorMessage: "Session interrupted by user",
       completedAt: new Date(),
     })
     .where(
-      and(
-        eq(TURNS_TBL.sessionId, sessionId),
-        eq(TURNS_TBL.status, "in_progress"),
-      ),
+      and(eq(TURNS_TBL.sessionId, sessionId), eq(TURNS_TBL.status, "running")),
     );
 
   // Update session's updatedAt timestamp


### PR DESCRIPTION
## Summary
Fixes the bug where interrupt requests don't change turn status from "running" to "interrupted".

## Problem
The interrupt route was searching for turns with `"in_progress"` status, but migration 0015 changed all turn statuses to `"running"`. This caused interrupt requests to match zero rows, leaving turns in running state even after interrupt.

## Changes
- ✅ Update WHERE clause from `"in_progress"` to `"running"`
- ✅ Change target status from `"failed"` to `"interrupted"` for semantic accuracy  
- ✅ Refactor tests to use API instead of direct DB inserts to reflect real user behavior
- ✅ Tests now properly validate the actual user flow

## Test Plan
- All existing tests pass
- Updated tests now use API to create turns (reflecting real behavior)
- Verified interrupt changes turn status correctly

## Related
Fixes issue where user interrupt requests didn't update turn state from "running".

🤖 Generated with [Claude Code](https://claude.com/claude-code)