### PR TITLE
fix(turns): remove obsolete pending and in_progress statuses

### DIFF
--- a/turbo/apps/web/src/db/schema/sessions.ts
+++ b/turbo/apps/web/src/db/schema/sessions.ts
@@ -24,8 +24,7 @@ export const TURNS_TBL = pgTable("turns", {
     .notNull()
     .references(() => SESSIONS_TBL.id, { onDelete: "cascade" }),
   userPrompt: text("user_prompt").notNull(), // User's input message
-  status: text("status").notNull().default("pending"), // pending, in_progress, completed, failed, interrupted
-  startedAt: timestamp("started_at"),
+  status: text("status").notNull().default("running"), // running, completed, failed, interrupted
   completedAt: timestamp("completed_at"),
   errorMessage: text("error_message"), // Error details if status is failed
   createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/turbo/apps/web/src/lib/initial-scan-executor.test.ts
+++ b/turbo/apps/web/src/lib/initial-scan-executor.test.ts
@@ -92,7 +92,7 @@ describe("InitialScanExecutor", () => {
       expect(turns).toHaveLength(1);
       expect(turns[0]).toMatchObject({
         sessionId: result.sessionId,
-        status: "pending",
+        status: "running",
       });
       expect(turns[0]?.userPrompt).toContain("owner/repo");
       expect(turns[0]?.userPrompt).toContain("~/workspace");

--- a/turbo/apps/web/src/lib/initial-scan-executor.ts
+++ b/turbo/apps/web/src/lib/initial-scan-executor.ts
@@ -49,7 +49,7 @@ export class InitialScanExecutor {
       id: turnId,
       sessionId,
       userPrompt: scanPrompt,
-      status: "pending",
+      status: "running",
     });
 
     // Update project status

--- a/turbo/apps/web/src/lib/sessions/blocks.test.ts
+++ b/turbo/apps/web/src/lib/sessions/blocks.test.ts
@@ -203,7 +203,7 @@ describe("Blocks Database Functions", () => {
       id: turnId,
       sessionId,
       userPrompt: "Test prompt",
-      status: "in_progress",
+      status: "running",
     });
 
     createdBlockIds = [];

--- a/turbo/apps/web/src/test/msw-handlers.ts
+++ b/turbo/apps/web/src/test/msw-handlers.ts
@@ -257,7 +257,7 @@ const projectsHandlers = [
       return HttpResponse.json({
         id: `turn-${Date.now()}`,
         user_prompt: body.user_message,
-        status: "pending",
+        status: "running",
         blocks: [],
         createdAt: new Date().toISOString(),
       });


### PR DESCRIPTION
## Summary

Remove unused turn statuses (`pending`, `in_progress`) that were migrated away in migration 0015 but still existed in:
- Schema default values  
- Code creating turns
- Tests
- Comments

## Problem

Initial scan executor was creating turns with `status: "pending"`, but the executor checks for `status === "running"`, causing initial scans to never execute.

Log evidence:
```
Turn turn_xxx is not in running state (status: pending), skipping execution
Initial scan started for project xxx
```

## Root Cause

Migration 0015 (`0015_update_turn_status.sql`) migrated all existing turns from `pending`/`in_progress` to `running`, but:
- Schema default was still `"pending"`
- Some code still created turns with `"pending"` status
- No transition logic from `pending` → `running` existed

## Changes

### Schema (`sessions.ts`)
- Change default status from `"pending"` to `"running"`
- Update status comment: `pending, in_progress` → `running, completed, failed, interrupted`
- Remove `startedAt` field (already dropped in migration, but schema wasn't updated)

### Code
- `initial-scan-executor.ts` - Create turns with `"running"` status
- `msw-handlers.ts` - Mock returns `"running"` instead of `"pending"`

### Tests
- `initial-scan-executor.test.ts` - Expect `"running"` status
- `blocks.test.ts` - Use `"running"` instead of `"in_progress"`
- `interrupt/route.test.ts` - Remove unnecessary pending turn test

## Impact

✅ Initial scans now execute correctly  
✅ Turn status model is consistent: `running` → `completed`/`failed`/`interrupted`  
✅ No intermediate states  
✅ Simpler state machine

## Test Plan

- [x] All existing tests pass (except 1 unrelated flaky test)
- [x] No `pending` or `in_progress` references in turn code
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)