### PR TITLE
chore(workspace): add e2b folder to vs code workspace

### DIFF
--- a/uspark.code-workspace
+++ b/uspark.code-workspace
@@ -7,6 +7,9 @@
       "path": "e2e"
     },
     {
+      "path": "e2b"
+    },
+    {
       "path": "spec"
     },
     {


### PR DESCRIPTION
## Summary
- Add the e2b directory to the VS Code workspace configuration

## Context
The e2b folder was missing from the workspace configuration, making it less discoverable when working in VS Code. This change adds it to the workspace for better navigation.

## Test plan
- [x] Verify workspace file syntax is valid
- [x] Confirm e2b folder appears in VS Code workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)