### PR TITLE
feat(ui): add block filtering to simplify turn display

### DIFF
--- a/turbo/apps/web/app/components/claude-chat/chat-interface.tsx
+++ b/turbo/apps/web/app/components/claude-chat/chat-interface.tsx
@@ -5,6 +5,63 @@ import { useSessionPolling } from "./use-session-polling";
 import { BlockDisplay } from "./block-display";
 import { SessionSelector } from "./session-selector";
 
+// Local Block type used by this component
+interface LocalBlock {
+  id: string;
+  type: string;
+  content: Record<string, unknown>;
+}
+
+/**
+ * Filters blocks for display in the UI.
+ * Rules:
+ * - Hide all tool_use blocks
+ * - Keep only the last tool_result block (if multiple exist)
+ * - Keep all other block types
+ */
+function filterBlocksForDisplay(blocks: LocalBlock[]): LocalBlock[] {
+  if (!blocks || blocks.length === 0) {
+    return blocks;
+  }
+
+  const filtered: LocalBlock[] = [];
+  let lastToolResultIndex = -1;
+
+  // First pass: Find the last tool_result index
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    if (!block) continue;
+    if (block.type === "tool_result") {
+      lastToolResultIndex = i;
+      break;
+    }
+  }
+
+  // Second pass: Apply filtering rules
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (!block) continue;
+
+    // Hide all tool_use blocks
+    if (block.type === "tool_use") {
+      continue;
+    }
+
+    // Keep only the last tool_result
+    if (block.type === "tool_result") {
+      if (i === lastToolResultIndex) {
+        filtered.push(block);
+      }
+      continue;
+    }
+
+    // Keep all other block types
+    filtered.push(block);
+  }
+
+  return filtered;
+}
+
 interface ChatInterfaceProps {
   projectId: string;
 }
@@ -349,7 +406,7 @@ export function ChatInterface({ projectId }: ChatInterfaceProps) {
                       }}
                     >
                       {turn.blocks && turn.blocks.length > 0 ? (
-                        turn.blocks.map((block) => (
+                        filterBlocksForDisplay(turn.blocks).map((block) => (
                           <BlockDisplay key={block.id} block={block} />
                         ))
                       ) : turn.status === "in_progress" ? (

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -643,12 +643,10 @@ describe('projectPage - turn and blocks rendering', () => {
       screen.findByText('Here are the files in your project'),
     ).resolves.toBeInTheDocument()
 
-    // Tool use block shows tool name
-    await expect(
-      screen.findByText('Tool: list_files'),
-    ).resolves.toBeInTheDocument()
+    // Tool use blocks are now hidden by filterBlocksForDisplay()
+    // This improves UX by hiding implementation details
 
-    // Tool result block shows status label (content is now hidden)
+    // Tool result block shows status label (only last tool_result is shown)
     await expect(screen.findByText('Tool Result')).resolves.toBeInTheDocument()
   })
 })

--- a/turbo/apps/workspace/src/views/project/turn-display.tsx
+++ b/turbo/apps/workspace/src/views/project/turn-display.tsx
@@ -1,4 +1,4 @@
-import type { GetTurnResponse } from '@uspark/core'
+import { filterBlocksForDisplay, type GetTurnResponse } from '@uspark/core'
 import { BlockDisplay } from './block-display'
 
 interface TurnDisplayProps {
@@ -34,7 +34,7 @@ export function TurnDisplay({ turn, isLastTurn = false }: TurnDisplayProps) {
       {/* Assistant blocks */}
       {hasBlocks ? (
         <div className="space-y-1.5 pl-3">
-          {turn.blocks.map((block) => (
+          {filterBlocksForDisplay(turn.blocks).map((block) => (
             <BlockDisplay key={block.id} block={block} />
           ))}
         </div>

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./contracts";
 export * from "./types";
 export * from "./blob";
 export * from "./yjs-filesystem";
+export * from "./utils/blocks";

--- a/turbo/packages/core/src/utils/__tests__/blocks.test.ts
+++ b/turbo/packages/core/src/utils/__tests__/blocks.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { filterBlocksForDisplay } from "../blocks";
+import type { Block } from "../../contracts/turns.contract";
+
+// Helper to create a mock block
+function createBlock(
+  type: Block["type"],
+  id: string = `block_${Math.random()}`,
+): Block {
+  return {
+    id,
+    turnId: "turn_test",
+    type,
+    content: `Content for ${type}`,
+    createdAt: new Date(),
+  };
+}
+
+describe("filterBlocksForDisplay", () => {
+  it("should return empty array for empty input", () => {
+    expect(filterBlocksForDisplay([])).toEqual([]);
+  });
+
+  it("should hide all tool_use blocks", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("tool_use", "block_2"),
+      createBlock("text", "block_3"),
+      createBlock("tool_use", "block_4"),
+      createBlock("text", "block_5"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe("block_1");
+    expect(result[1].id).toBe("block_3");
+    expect(result[2].id).toBe("block_5");
+    expect(result.every((block) => block.type !== "tool_use")).toBe(true);
+  });
+
+  it("should keep only the last tool_result block", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("tool_use", "block_2"),
+      createBlock("tool_result", "block_3"), // First tool_result - should be hidden
+      createBlock("tool_use", "block_4"),
+      createBlock("tool_result", "block_5"), // Second tool_result - should be kept
+      createBlock("text", "block_6"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe("block_1");
+    expect(result[1].id).toBe("block_5"); // Only the last tool_result
+    expect(result[2].id).toBe("block_6");
+
+    const toolResults = result.filter((block) => block.type === "tool_result");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].id).toBe("block_5");
+  });
+
+  it("should keep all other block types", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("code", "block_2"),
+      createBlock("error", "block_3"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(blocks);
+  });
+
+  it("should handle blocks with only tool_use (all hidden)", () => {
+    const blocks: Block[] = [
+      createBlock("tool_use", "block_1"),
+      createBlock("tool_use", "block_2"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle blocks with only one tool_result (kept)", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("tool_result", "block_2"),
+      createBlock("text", "block_3"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(3);
+    expect(result[1].type).toBe("tool_result");
+  });
+
+  it("should handle complex scenario with multiple tool sequences", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("tool_use", "block_2"), // Hidden
+      createBlock("tool_result", "block_3"), // Hidden (not last)
+      createBlock("text", "block_4"),
+      createBlock("tool_use", "block_5"), // Hidden
+      createBlock("tool_result", "block_6"), // Hidden (not last)
+      createBlock("tool_use", "block_7"), // Hidden
+      createBlock("tool_result", "block_8"), // Kept (last)
+      createBlock("text", "block_9"),
+      createBlock("code", "block_10"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(5);
+    expect(result[0].id).toBe("block_1");
+    expect(result[1].id).toBe("block_4");
+    expect(result[2].id).toBe("block_8"); // Only the last tool_result
+    expect(result[3].id).toBe("block_9");
+    expect(result[4].id).toBe("block_10");
+
+    const toolResults = result.filter((block) => block.type === "tool_result");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].id).toBe("block_8");
+  });
+
+  it("should handle blocks with no tool_use or tool_result", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("code", "block_2"),
+      createBlock("error", "block_3"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toEqual(blocks);
+  });
+
+  it("should preserve order of kept blocks", () => {
+    const blocks: Block[] = [
+      createBlock("text", "block_1"),
+      createBlock("tool_use", "block_2"),
+      createBlock("code", "block_3"),
+      createBlock("tool_use", "block_4"),
+      createBlock("error", "block_5"),
+      createBlock("tool_result", "block_6"),
+    ];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(4);
+    expect(result[0].type).toBe("text");
+    expect(result[1].type).toBe("code");
+    expect(result[2].type).toBe("error");
+    expect(result[3].type).toBe("tool_result");
+  });
+});

--- a/turbo/packages/core/src/utils/blocks.ts
+++ b/turbo/packages/core/src/utils/blocks.ts
@@ -1,0 +1,69 @@
+import type { Block } from "../contracts/turns.contract";
+
+/**
+ * Filters blocks for display in the UI.
+ *
+ * Rules:
+ * - Hide all tool_use blocks
+ * - Keep only the last tool_result block (if multiple exist)
+ * - Keep all other block types (text, thinking, content, code, error)
+ *
+ * @param blocks - Array of blocks to filter
+ * @returns Filtered array of blocks
+ *
+ * @example
+ * ```ts
+ * const blocks = [
+ *   { type: 'text', ... },
+ *   { type: 'tool_use', ... },    // Hidden
+ *   { type: 'tool_result', ... }, // Hidden (not last)
+ *   { type: 'tool_use', ... },    // Hidden
+ *   { type: 'tool_result', ... }, // Kept (last one)
+ *   { type: 'text', ... },
+ * ];
+ * const filtered = filterBlocksForDisplay(blocks);
+ * // Result: [text, tool_result (last), text]
+ * ```
+ */
+export function filterBlocksForDisplay(blocks: Block[]): Block[] {
+  if (!blocks || blocks.length === 0) {
+    return blocks;
+  }
+
+  const filtered: Block[] = [];
+  let lastToolResultIndex = -1;
+
+  // First pass: Find the last tool_result index
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const block = blocks[i];
+    if (!block) continue;
+    if (block.type === "tool_result") {
+      lastToolResultIndex = i;
+      break;
+    }
+  }
+
+  // Second pass: Apply filtering rules
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (!block) continue;
+
+    // Hide all tool_use blocks
+    if (block.type === "tool_use") {
+      continue;
+    }
+
+    // Keep only the last tool_result
+    if (block.type === "tool_result") {
+      if (i === lastToolResultIndex) {
+        filtered.push(block);
+      }
+      continue;
+    }
+
+    // Keep all other block types
+    filtered.push(block);
+  }
+
+  return filtered;
+}


### PR DESCRIPTION
## Summary

- Implemented frontend filtering to hide tool execution details in Claude chat UI
- Hide all `tool_use` blocks and keep only the last `tool_result` block per turn
- Improves UX by showing users clean conversation flow without implementation details

## Changes

### Core Package (`@uspark/core`)
- Added `filterBlocksForDisplay()` utility function in `packages/core/src/utils/blocks.ts`
- Comprehensive unit tests with 9 test cases covering all scenarios
- Exported from package index for reuse across applications

### Workspace App
- Applied filtering in `turn-display.tsx` component
- Uses core package's filtering function for consistency

### Web App
- Applied filtering in `chat-interface.tsx` component
- Local implementation due to type incompatibility (maintains same filtering rules)

## Technical Details

- **Algorithm**: O(n) time complexity with two-pass filtering
- **Type Safety**: Fully TypeScript typed with proper null/undefined checks
- **Testing**: 9 comprehensive unit tests covering edge cases
- **Quality**: All lint, type-check, and test suites passing

## Test Plan

- [x] Unit tests: All 9 new tests passing
- [x] Type checks: TypeScript compilation successful
- [x] Linting: ESLint and Prettier checks passing
- [x] Integration: Verified filtering works in both web and workspace apps
- [x] Edge cases: Tested empty arrays, single results, multiple results

## Before/After

**Before**: Users see all `tool_use` blocks and all `tool_result` blocks, cluttering the conversation view

**After**: Users see clean conversation flow with only the final tool result (if any), hiding implementation details

🤖 Generated with [Claude Code](https://claude.com/claude-code)