### PR TITLE
feat(workspace): replace share toast with popover for better clipboard support

### DIFF
--- a/turbo/apps/workspace/vitest.setup.ts
+++ b/turbo/apps/workspace/vitest.setup.ts
@@ -5,6 +5,22 @@ import { resetLoggerForTest } from './src/signals/log'
 import { resetMockAuth, setupMock } from './src/signals/test-utils'
 import { clearAllDetached } from './src/signals/utils'
 
+// Mock sonner globally
+vi.mock<typeof import('sonner')>('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    custom: vi.fn(),
+    message: vi.fn(),
+    dismiss: vi.fn(),
+  },
+  Toaster: () => null,
+}))
+
 setupMock()
 
 beforeAll(() => {


### PR DESCRIPTION
## Summary

Replaces the direct clipboard API usage with a popover UI to avoid browser permission issues across Chrome, Safari, and Firefox.

**Problem:** 
The previous implementation tried to copy the share link directly to clipboard after an async API call, which caused `NotAllowedError` in browsers (especially Safari) because the user gesture activation was lost during the async operation.

**Solution:**
- Show a popover when clicking the Share button
- Display the share link in the popover with a "Copy Link" button
- Clipboard operation happens synchronously on button click (no permission issues)

**Changes:**
- ✅ Replace auto-copy functionality with popover UI showing share link
- ✅ Add synchronous "Copy Link" button for reliable clipboard access
- ✅ Remove Safari-specific ClipboardItem workarounds (no longer needed)
- ✅ Simplify state management with computed signals
- ✅ Update tests to match new popover behavior
- ✅ Add global sonner mock in vitest.setup.ts

## Test plan

- [x] Unit tests pass (3 test cases for share functionality)
- [x] Lint checks pass
- [x] Type checks pass
- [x] Formatting checks pass
- [ ] Manual testing: Click Share button → popover appears with link
- [ ] Manual testing: Click "Copy Link" → link copied successfully
- [ ] Manual testing: Works in Chrome, Safari, and Firefox
- [ ] Manual testing: Popover closes after copying

## Screenshots

### Before (Toast with auto-copy)
Issues: Browser permission errors, Safari compatibility problems

### After (Popover with manual copy button)
Benefits: No permission errors, works across all browsers, better UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)