### PR TITLE
feat(workspace): show all tool calls and results in turn block list

### DIFF
--- a/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
@@ -107,13 +107,14 @@ describe('block display', () => {
   })
 
   describe('tool_result blocks', () => {
-    it('renders result output as string', () => {
+    it('renders result field as string', () => {
       const block: Block = {
         id: 'block-7',
         turnId: 'turn-1',
         type: 'tool_result',
         content: {
-          output: 'Command executed successfully',
+          result: 'Command executed successfully',
+          error: null,
         },
         createdAt: new Date(),
       }
@@ -124,6 +125,23 @@ describe('block display', () => {
       ).toBeInTheDocument()
     })
 
+    it('renders output field for compatibility', () => {
+      const block: Block = {
+        id: 'block-7b',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          output: 'Alternative output format',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(
+        screen.getByText('Alternative output format'),
+      ).toBeInTheDocument()
+    })
+
     it('renders error message', () => {
       const block: Block = {
         id: 'block-8',
@@ -131,6 +149,7 @@ describe('block display', () => {
         type: 'tool_result',
         content: {
           error: 'File not found',
+          result: null,
         },
         createdAt: new Date(),
       }
@@ -139,13 +158,14 @@ describe('block display', () => {
       expect(screen.getByText('File not found')).toBeInTheDocument()
     })
 
-    it('renders multiline output', () => {
+    it('renders multiline result', () => {
       const block: Block = {
         id: 'block-9',
         turnId: 'turn-1',
         type: 'tool_result',
         content: {
-          output: 'Line 1\nLine 2\nLine 3',
+          result: 'Line 1\nLine 2\nLine 3',
+          error: null,
         },
         createdAt: new Date(),
       }
@@ -160,7 +180,8 @@ describe('block display', () => {
         turnId: 'turn-1',
         type: 'tool_result',
         content: {
-          output: '',
+          result: '',
+          error: null,
         },
         createdAt: new Date(),
       }

--- a/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen } from '@testing-library/react'
+import type { GetTurnResponse } from '@uspark/core'
+import { describe, expect, it } from 'vitest'
+import { BlockDisplay } from '../block-display'
+
+type Block = GetTurnResponse['blocks'][number]
+
+describe('block display', () => {
+  describe('text blocks', () => {
+    it('renders text content', () => {
+      const block: Block = {
+        id: 'block-1',
+        turnId: 'turn-1',
+        type: 'text',
+        content: 'Hello, world!',
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Hello, world!')).toBeInTheDocument()
+    })
+
+    it('renders text content from object with text property', () => {
+      const block: Block = {
+        id: 'block-2',
+        turnId: 'turn-1',
+        type: 'text',
+        content: { text: 'Nested text content' },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Nested text content')).toBeInTheDocument()
+    })
+  })
+
+  describe('thinking blocks', () => {
+    it('renders thinking content', () => {
+      const block: Block = {
+        id: 'block-3',
+        turnId: 'turn-1',
+        type: 'thinking',
+        content: 'Analyzing the request...',
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Analyzing the request...')).toBeInTheDocument()
+    })
+  })
+
+  describe('tool_use blocks', () => {
+    it('renders tool name and main parameter for Bash', () => {
+      const block: Block = {
+        id: 'block-4',
+        turnId: 'turn-1',
+        type: 'tool_use',
+        content: {
+          tool_name: 'Bash',
+          parameters: {
+            command: 'git status',
+            description: 'Check git status',
+          },
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Bash')).toBeInTheDocument()
+      expect(screen.getByText('git status')).toBeInTheDocument()
+    })
+
+    it('renders tool name and file path for Read', () => {
+      const block: Block = {
+        id: 'block-5',
+        turnId: 'turn-1',
+        type: 'tool_use',
+        content: {
+          tool_name: 'Read',
+          parameters: {
+            file_path: '/path/to/file.ts',
+          },
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Read')).toBeInTheDocument()
+      expect(screen.getByText('/path/to/file.ts')).toBeInTheDocument()
+    })
+
+    it('renders tool without parameters', () => {
+      const block: Block = {
+        id: 'block-6',
+        turnId: 'turn-1',
+        type: 'tool_use',
+        content: {
+          tool_name: 'ListFiles',
+          parameters: {},
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('ListFiles')).toBeInTheDocument()
+    })
+  })
+
+  describe('tool_result blocks', () => {
+    it('renders result output as string', () => {
+      const block: Block = {
+        id: 'block-7',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          output: 'Command executed successfully',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(
+        screen.getByText('Command executed successfully'),
+      ).toBeInTheDocument()
+    })
+
+    it('renders error message', () => {
+      const block: Block = {
+        id: 'block-8',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          error: 'File not found',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('File not found')).toBeInTheDocument()
+    })
+
+    it('renders multiline output', () => {
+      const block: Block = {
+        id: 'block-9',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          output: 'Line 1\nLine 2\nLine 3',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText(/Line 1.*Line 2.*Line 3/s)).toBeInTheDocument()
+    })
+
+    it('renders no output message when content is empty', () => {
+      const block: Block = {
+        id: 'block-10',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          output: '',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('(no output)')).toBeInTheDocument()
+    })
+
+    it('renders content from nested content property', () => {
+      const block: Block = {
+        id: 'block-11',
+        turnId: 'turn-1',
+        type: 'tool_result',
+        content: {
+          content: 'Nested result content',
+        },
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Nested result content')).toBeInTheDocument()
+    })
+  })
+
+  describe('code blocks', () => {
+    it('renders code content', () => {
+      const block: Block = {
+        id: 'block-12',
+        turnId: 'turn-1',
+        type: 'code',
+        content: 'const x = 42;',
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('const x = 42;')).toBeInTheDocument()
+    })
+  })
+
+  describe('error blocks', () => {
+    it('renders error content', () => {
+      const block: Block = {
+        id: 'block-13',
+        turnId: 'turn-1',
+        type: 'error',
+        content: 'Something went wrong',
+        createdAt: new Date(),
+      }
+
+      render(<BlockDisplay block={block} />)
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    })
+  })
+})

--- a/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/block-display.test.tsx
@@ -137,9 +137,7 @@ describe('block display', () => {
       }
 
       render(<BlockDisplay block={block} />)
-      expect(
-        screen.getByText('Alternative output format'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('Alternative output format')).toBeInTheDocument()
     })
 
     it('renders error message', () => {

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -643,11 +643,13 @@ describe('projectPage - turn and blocks rendering', () => {
       screen.findByText('Here are the files in your project'),
     ).resolves.toBeInTheDocument()
 
-    // Tool use blocks are now hidden by filterBlocksForDisplay()
-    // This improves UX by hiding implementation details
+    // Tool use block is now shown with compact format
+    await expect(screen.findByText('list_files')).resolves.toBeInTheDocument()
 
-    // Tool result block shows status label (only last tool_result is shown)
-    await expect(screen.findByText('Tool Result')).resolves.toBeInTheDocument()
+    // Tool result block displays the actual result content
+    await expect(
+      screen.findByText(/README\.md/),
+    ).resolves.toBeInTheDocument()
   })
 })
 

--- a/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
+++ b/turbo/apps/workspace/src/views/project/__tests__/project-page.test.tsx
@@ -647,9 +647,7 @@ describe('projectPage - turn and blocks rendering', () => {
     await expect(screen.findByText('list_files')).resolves.toBeInTheDocument()
 
     // Tool result block displays the actual result content
-    await expect(
-      screen.findByText(/README\.md/),
-    ).resolves.toBeInTheDocument()
+    await expect(screen.findByText(/README\.md/)).resolves.toBeInTheDocument()
   })
 })
 

--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -116,7 +116,14 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
             typeof content.error === 'string'
               ? content.error
               : JSON.stringify(content.error)
+        } else if ('result' in content) {
+          // Standard field used by BlockFactory
+          resultContent =
+            typeof content.result === 'string'
+              ? content.result
+              : JSON.stringify(content.result)
         } else if ('output' in content) {
+          // Alternative field for compatibility
           resultContent =
             typeof content.output === 'string'
               ? content.output

--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -65,37 +65,82 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
           ? toolData.parameters
           : {}
 
+      // Format parameters inline for compact display
+      let paramDisplay = ''
+      if (Object.keys(parameters).length > 0) {
+        // For common tools, extract the main parameter
+        if (toolName === 'Bash' && 'command' in parameters) {
+          paramDisplay = String(parameters.command)
+        } else if (toolName === 'Read' && 'file_path' in parameters) {
+          paramDisplay = String(parameters.file_path)
+        } else if (toolName === 'Edit' && 'file_path' in parameters) {
+          paramDisplay = String(parameters.file_path)
+        } else if (toolName === 'Write' && 'file_path' in parameters) {
+          paramDisplay = String(parameters.file_path)
+        } else if (toolName === 'Grep' && 'pattern' in parameters) {
+          paramDisplay = String(parameters.pattern)
+        } else {
+          // For other tools, show first parameter or count
+          const firstKey = Object.keys(parameters)[0]
+          if (firstKey && firstKey in parameters) {
+            const firstValue: unknown = parameters[firstKey]
+            paramDisplay =
+              typeof firstValue === 'string'
+                ? firstValue
+                : JSON.stringify(firstValue)
+          }
+        }
+      }
+
       return (
-        <div className="rounded border border-[#2d4f7c] bg-[#1e3a5f] p-2">
-          <div className="mb-1 text-[11px] font-medium text-[#569cd6]">
-            Tool: {toolName}
-          </div>
-          <details className="text-[13px]">
-            <summary className="cursor-pointer text-[#9cdcfe] transition-colors hover:text-[#569cd6]">
-              Parameters
-            </summary>
-            <pre className="mt-1.5 overflow-x-auto rounded border border-[#3e3e42] bg-[#1e1e1e] p-1.5 text-[11px] text-[#ce9178]">
-              {JSON.stringify(parameters, null, 2)}
-            </pre>
-          </details>
+        <div className="text-[11px] text-[#9cdcfe]">
+          {toolName}
+          {paramDisplay && (
+            <span className="ml-1 font-mono text-[#6a6a6a]">
+              {paramDisplay}
+            </span>
+          )}
         </div>
       )
     }
 
     case 'tool_result': {
       const content = block.content as BlockContent
-      const resultData = typeof content === 'object' ? content : {}
-      const hasError = 'error' in resultData && Boolean(resultData.error)
+      let resultContent = ''
+      let hasError = false
+
+      if (typeof content === 'object') {
+        if ('error' in content && content.error) {
+          hasError = true
+          resultContent =
+            typeof content.error === 'string'
+              ? content.error
+              : JSON.stringify(content.error)
+        } else if ('output' in content) {
+          resultContent =
+            typeof content.output === 'string'
+              ? content.output
+              : JSON.stringify(content.output)
+        } else if ('content' in content) {
+          resultContent = getTextContent(content.content)
+        } else {
+          resultContent = JSON.stringify(content)
+        }
+      } else {
+        resultContent = getTextContent(content)
+      }
 
       return (
         <div
-          className={`rounded border p-2 ${hasError ? 'border-[#6b3a3a] bg-[#4b2b2b]' : 'border-[#2d5f30] bg-[#1e4620]'}`}
+          className={`ml-2 max-h-[200px] overflow-hidden border-l-2 pl-2 font-mono text-[11px] leading-[1.4] ${
+            hasError
+              ? 'border-[#f48771] text-[#f48771]'
+              : 'border-[#3e3e42] text-[#d4d4d4]'
+          }`}
         >
-          <div
-            className={`text-[11px] font-medium ${hasError ? 'text-[#f48771]' : 'text-[#89d185]'}`}
-          >
-            {hasError ? 'Tool Error' : 'Tool Result'}
-          </div>
+          {resultContent || (
+            <span className="italic opacity-50">(no output)</span>
+          )}
         </div>
       )
     }

--- a/turbo/packages/core/src/utils/__tests__/blocks.test.ts
+++ b/turbo/packages/core/src/utils/__tests__/blocks.test.ts
@@ -21,7 +21,7 @@ describe("filterBlocksForDisplay", () => {
     expect(filterBlocksForDisplay([])).toEqual([]);
   });
 
-  it("should hide all tool_use blocks", () => {
+  it("should keep all tool_use blocks", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
       createBlock("tool_use", "block_2"),
@@ -32,36 +32,39 @@ describe("filterBlocksForDisplay", () => {
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(5);
     expect(result[0].id).toBe("block_1");
-    expect(result[1].id).toBe("block_3");
-    expect(result[2].id).toBe("block_5");
-    expect(result.every((block) => block.type !== "tool_use")).toBe(true);
+    expect(result[1].id).toBe("block_2");
+    expect(result[2].id).toBe("block_3");
+    expect(result[3].id).toBe("block_4");
+    expect(result[4].id).toBe("block_5");
   });
 
-  it("should keep only the last tool_result block", () => {
+  it("should keep all tool_result blocks", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
       createBlock("tool_use", "block_2"),
-      createBlock("tool_result", "block_3"), // First tool_result - should be hidden
+      createBlock("tool_result", "block_3"), // First tool_result - kept
       createBlock("tool_use", "block_4"),
-      createBlock("tool_result", "block_5"), // Second tool_result - should be kept
+      createBlock("tool_result", "block_5"), // Second tool_result - kept
       createBlock("text", "block_6"),
     ];
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(6);
     expect(result[0].id).toBe("block_1");
-    expect(result[1].id).toBe("block_5"); // Only the last tool_result
-    expect(result[2].id).toBe("block_6");
+    expect(result[1].id).toBe("block_2");
+    expect(result[2].id).toBe("block_3");
+    expect(result[3].id).toBe("block_4");
+    expect(result[4].id).toBe("block_5");
+    expect(result[5].id).toBe("block_6");
 
     const toolResults = result.filter((block) => block.type === "tool_result");
-    expect(toolResults).toHaveLength(1);
-    expect(toolResults[0].id).toBe("block_5");
+    expect(toolResults).toHaveLength(2);
   });
 
-  it("should keep all other block types", () => {
+  it("should keep all block types", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
       createBlock("code", "block_2"),
@@ -74,7 +77,7 @@ describe("filterBlocksForDisplay", () => {
     expect(result).toEqual(blocks);
   });
 
-  it("should handle blocks with only tool_use (all hidden)", () => {
+  it("should handle blocks with only tool_use", () => {
     const blocks: Block[] = [
       createBlock("tool_use", "block_1"),
       createBlock("tool_use", "block_2"),
@@ -82,48 +85,42 @@ describe("filterBlocksForDisplay", () => {
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(blocks);
   });
 
-  it("should handle blocks with only one tool_result (kept)", () => {
+  it("should handle blocks with multiple tool_results", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
       createBlock("tool_result", "block_2"),
-      createBlock("text", "block_3"),
+      createBlock("tool_result", "block_3"),
+      createBlock("text", "block_4"),
     ];
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(3);
-    expect(result[1].type).toBe("tool_result");
+    expect(result).toHaveLength(4);
+    expect(result).toEqual(blocks);
   });
 
   it("should handle complex scenario with multiple tool sequences", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
-      createBlock("tool_use", "block_2"), // Hidden
-      createBlock("tool_result", "block_3"), // Hidden (not last)
+      createBlock("tool_use", "block_2"),
+      createBlock("tool_result", "block_3"),
       createBlock("text", "block_4"),
-      createBlock("tool_use", "block_5"), // Hidden
-      createBlock("tool_result", "block_6"), // Hidden (not last)
-      createBlock("tool_use", "block_7"), // Hidden
-      createBlock("tool_result", "block_8"), // Kept (last)
+      createBlock("tool_use", "block_5"),
+      createBlock("tool_result", "block_6"),
+      createBlock("tool_use", "block_7"),
+      createBlock("tool_result", "block_8"),
       createBlock("text", "block_9"),
       createBlock("code", "block_10"),
     ];
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(5);
-    expect(result[0].id).toBe("block_1");
-    expect(result[1].id).toBe("block_4");
-    expect(result[2].id).toBe("block_8"); // Only the last tool_result
-    expect(result[3].id).toBe("block_9");
-    expect(result[4].id).toBe("block_10");
-
-    const toolResults = result.filter((block) => block.type === "tool_result");
-    expect(toolResults).toHaveLength(1);
-    expect(toolResults[0].id).toBe("block_8");
+    expect(result).toHaveLength(10);
+    expect(result).toEqual(blocks);
   });
 
   it("should handle blocks with no tool_use or tool_result", () => {
@@ -138,7 +135,7 @@ describe("filterBlocksForDisplay", () => {
     expect(result).toEqual(blocks);
   });
 
-  it("should preserve order of kept blocks", () => {
+  it("should preserve order of all blocks", () => {
     const blocks: Block[] = [
       createBlock("text", "block_1"),
       createBlock("tool_use", "block_2"),
@@ -150,10 +147,29 @@ describe("filterBlocksForDisplay", () => {
 
     const result = filterBlocksForDisplay(blocks);
 
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(6);
     expect(result[0].type).toBe("text");
-    expect(result[1].type).toBe("code");
-    expect(result[2].type).toBe("error");
-    expect(result[3].type).toBe("tool_result");
+    expect(result[1].type).toBe("tool_use");
+    expect(result[2].type).toBe("code");
+    expect(result[3].type).toBe("tool_use");
+    expect(result[4].type).toBe("error");
+    expect(result[5].type).toBe("tool_result");
+  });
+
+  it("should filter out null or undefined blocks", () => {
+    const blocks = [
+      createBlock("text", "block_1"),
+      null,
+      createBlock("tool_use", "block_2"),
+      undefined,
+      createBlock("text", "block_3"),
+    ] as unknown as Block[];
+
+    const result = filterBlocksForDisplay(blocks);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe("block_1");
+    expect(result[1].id).toBe("block_2");
+    expect(result[2].id).toBe("block_3");
   });
 });

--- a/turbo/packages/core/src/utils/blocks.ts
+++ b/turbo/packages/core/src/utils/blocks.ts
@@ -4,25 +4,25 @@ import type { Block } from "../contracts/turns.contract";
  * Filters blocks for display in the UI.
  *
  * Rules:
- * - Hide all tool_use blocks
- * - Keep only the last tool_result block (if multiple exist)
+ * - Keep all tool_use blocks (to show tool calls)
+ * - Keep all tool_result blocks (to show all tool outputs)
  * - Keep all other block types (text, thinking, content, code, error)
  *
  * @param blocks - Array of blocks to filter
- * @returns Filtered array of blocks
+ * @returns Filtered array of blocks (currently returns all blocks)
  *
  * @example
  * ```ts
  * const blocks = [
  *   { type: 'text', ... },
- *   { type: 'tool_use', ... },    // Hidden
- *   { type: 'tool_result', ... }, // Hidden (not last)
- *   { type: 'tool_use', ... },    // Hidden
- *   { type: 'tool_result', ... }, // Kept (last one)
+ *   { type: 'tool_use', ... },    // Kept
+ *   { type: 'tool_result', ... }, // Kept
+ *   { type: 'tool_use', ... },    // Kept
+ *   { type: 'tool_result', ... }, // Kept
  *   { type: 'text', ... },
  * ];
  * const filtered = filterBlocksForDisplay(blocks);
- * // Result: [text, tool_result (last), text]
+ * // Result: All blocks kept
  * ```
  */
 export function filterBlocksForDisplay(blocks: Block[]): Block[] {
@@ -30,40 +30,6 @@ export function filterBlocksForDisplay(blocks: Block[]): Block[] {
     return blocks;
   }
 
-  const filtered: Block[] = [];
-  let lastToolResultIndex = -1;
-
-  // First pass: Find the last tool_result index
-  for (let i = blocks.length - 1; i >= 0; i--) {
-    const block = blocks[i];
-    if (!block) continue;
-    if (block.type === "tool_result") {
-      lastToolResultIndex = i;
-      break;
-    }
-  }
-
-  // Second pass: Apply filtering rules
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i];
-    if (!block) continue;
-
-    // Hide all tool_use blocks
-    if (block.type === "tool_use") {
-      continue;
-    }
-
-    // Keep only the last tool_result
-    if (block.type === "tool_result") {
-      if (i === lastToolResultIndex) {
-        filtered.push(block);
-      }
-      continue;
-    }
-
-    // Keep all other block types
-    filtered.push(block);
-  }
-
-  return filtered;
+  // Keep all blocks - no filtering needed
+  return blocks.filter((block) => block != null);
 }


### PR DESCRIPTION
## Summary

- Show all `tool_use` and `tool_result` blocks instead of filtering them
- Simplify display with compact CSS-based styling
- Add comprehensive test coverage for block display component

## Changes

### Block Filtering (`packages/core/src/utils/blocks.ts`)
- **Before**: Filtered out all `tool_use` blocks and kept only the last `tool_result`
- **After**: Keep all blocks to show complete execution flow

### Block Display (`apps/workspace/src/views/project/block-display.tsx`)
- **tool_use**: Compact inline format showing tool name and main parameter
  - Example: `Bash git status` or `Read /path/to/file.ts`
- **tool_result**: CSS-based compact display with left border
  - Uses `max-h-[200px] overflow-hidden` for automatic height limiting
  - Red border/text for errors, gray border for normal output
  - Shows `(no output)` placeholder when empty

### Tests
- Added `apps/workspace/src/views/project/__tests__/block-display.test.tsx`
  - 13 tests covering all block types
  - Validates data extraction and rendering logic
  - No style/CSS testing (functional tests only)
- Updated `packages/core/src/utils/__tests__/blocks.test.ts`
  - Reflects new non-filtering behavior
  - All 10 tests passing

## Benefits

1. **Better visibility**: See complete tool execution flow
2. **Simpler code**: Pure CSS instead of JavaScript truncation logic
3. **More maintainable**: Removed 40+ lines of complex filtering logic
4. **Well tested**: 13 new functional tests

## Test Results

✅ All tests passing (13/13 new + 10/10 updated)
✅ Lint checks passing
✅ Type checks passing
✅ No bad smells detected (checked against `spec/bad-smell.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)