### PR TITLE
fix(e2b): correct shell redirection order for log capture

### DIFF
--- a/turbo/apps/web/src/lib/e2b-executor.ts
+++ b/turbo/apps/web/src/lib/e2b-executor.ts
@@ -324,7 +324,7 @@ export class E2BExecutor {
     // Environment variables set inline (TURN_ID and SESSION_ID)
     // Other vars (PROJECT_ID, USPARK_TOKEN, etc) are set at sandbox creation
     // All output (stdout and stderr) redirected to log file
-    const command = `TURN_ID="${effectiveTurnId}" SESSION_ID="${effectiveSessionId}" /usr/local/bin/execute-claude-turn.sh  2>&1 >> ${logFile}`;
+    const command = `TURN_ID="${effectiveTurnId}" SESSION_ID="${effectiveSessionId}" /usr/local/bin/execute-claude-turn.sh >> ${logFile} 2>&1`;
 
     // Run in background - command continues in sandbox even after client disconnects
     await sandbox.commands.run(command, {


### PR DESCRIPTION
## Summary
- Fixed the order of shell redirection operators in the execute-claude-turn.sh command
- Ensures both stdout and stderr are properly captured in the log file

## Technical Details
**Before:** `2>&1 >> logfile`
- stderr redirected to current stdout (console)
- stdout redirected to file
- **Result:** Only stdout captured in log file

**After:** `>> logfile 2>&1`
- stdout redirected to file
- stderr redirected to current stdout (file)
- **Result:** Both stdout and stderr captured in log file ✓

## Test Plan
- [ ] Verify log files in E2B sandboxes capture both stdout and stderr
- [ ] Check that error messages from execute-claude-turn.sh are logged
- [ ] Confirm background execution logs are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)