### PR TITLE
chore(e2b): update @uspark/cli to v0.13.0

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y git curl
 RUN npm install -g @anthropic-ai/claude-code@2.0.22
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.12.2
+RUN npm install -g @uspark/cli@0.13.0
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary
- Updated @uspark/cli from v0.12.2 to v0.13.0 in e2b.Dockerfile
- @anthropic-ai/claude-code remains at latest version 2.0.22

## Changes
- Modified `/workspaces/uspark1/e2b/e2b.Dockerfile` line 10 to use @uspark/cli@0.13.0

## Test Plan
- [x] CI checks passed locally (lint, format, build)
- [ ] GitHub Actions pipeline validation
- [ ] Docker image builds successfully with new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)