### PR TITLE
feat(web): improve home page ux and github repo input

### DIFF
--- a/turbo/apps/web/app/api/github/verify-repo/route.test.ts
+++ b/turbo/apps/web/app/api/github/verify-repo/route.test.ts
@@ -1,0 +1,367 @@
+import { POST } from "./route";
+import { auth } from "@clerk/nextjs/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { initServices } from "../../../../src/lib/init-services";
+import { githubInstallations } from "../../../../src/db/schema/github";
+import { eq } from "drizzle-orm";
+import { createInstallationOctokit } from "../../../../src/lib/github/client";
+
+// Mock Clerk auth
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+// Mock GitHub client
+vi.mock("../../../../src/lib/github/client", () => ({
+  createInstallationOctokit: vi.fn(),
+}));
+
+const mockAuth = vi.mocked(auth);
+
+// Mock global fetch for public repo checks
+const originalFetch = global.fetch;
+
+describe("POST /api/github/verify-repo", () => {
+  const testUserId = `test-user-verify-${Date.now()}-${process.pid}`;
+  const baseInstallationId = Math.floor(Date.now() / 1000);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Initialize real database connection
+    initServices();
+
+    // Clean up any existing test data
+    await globalThis.services.db
+      .delete(githubInstallations)
+      .where(eq(githubInstallations.userId, testUserId));
+
+    // Default to authenticated user
+    mockAuth.mockResolvedValue({ userId: testUserId } as Awaited<
+      ReturnType<typeof auth>
+    >);
+
+    // Reset fetch mock
+    global.fetch = originalFetch;
+  });
+
+  describe("URL format parsing", () => {
+    beforeEach(() => {
+      // Mock fetch to return 404 for all public repo checks
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+    });
+
+    it("accepts owner/repo format", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "facebook/react" }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      // Should attempt to verify as public repo
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/facebook/react",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/vnd.github.v3+json",
+          }),
+        }),
+      );
+    });
+
+    it("accepts HTTPS URL format", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          repoUrl: "https://github.com/facebook/react",
+        }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/facebook/react",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts HTTPS URL with .git suffix", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          repoUrl: "https://github.com/facebook/react.git",
+        }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/facebook/react",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts SSH URL format", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          repoUrl: "git@github.com:facebook/react.git",
+        }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/facebook/react",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts repository names with dots", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "backend/backend.ai" }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/backend/backend.ai",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts repository names with multiple dots", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "owner/repo.with.multiple.dots" }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/owner/repo.with.multiple.dots",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts owner names with dots", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "owner.name/repo" }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/owner.name/repo",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts HTTPS URL with dots in repo name", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          repoUrl: "https://github.com/backend/backend.ai",
+        }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/backend/backend.ai",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts SSH URL with dots in repo name", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({
+          repoUrl: "git@github.com:backend/backend.ai.git",
+        }),
+      });
+
+      const response = await POST(request);
+      await response.json();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/backend/backend.ai",
+        expect.any(Object),
+      );
+    });
+
+    it("rejects invalid format", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "not a valid repo" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("invalid_format");
+    });
+
+    it("rejects empty string", async () => {
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "" }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("Repository verification", () => {
+    it("returns installed repo when found in user's installations", async () => {
+      // Create installation for user
+      await globalThis.services.db.insert(githubInstallations).values({
+        userId: testUserId,
+        installationId: baseInstallationId,
+        accountName: "testuser",
+      });
+
+      // Mock GitHub API response
+      const mockOctokit = {
+        request: vi.fn().mockResolvedValue({
+          data: {
+            repositories: [
+              {
+                id: 100,
+                name: "test-repo",
+                full_name: "testuser/test-repo",
+                private: true,
+                html_url: "https://github.com/testuser/test-repo",
+              },
+            ],
+          },
+        }),
+      };
+
+      vi.mocked(createInstallationOctokit).mockResolvedValue(
+        mockOctokit as never,
+      );
+
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "testuser/test-repo" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.valid).toBe(true);
+      expect(data.type).toBe("installed");
+      expect(data.fullName).toBe("testuser/test-repo");
+      expect(data.installationId).toBe(baseInstallationId);
+    });
+
+    it("returns public repo when not in installations but publicly accessible", async () => {
+      // Mock fetch to return public repo
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          name: "react",
+          full_name: "facebook/react",
+          private: false,
+        }),
+      });
+
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "facebook/react" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.valid).toBe(true);
+      expect(data.type).toBe("public");
+      expect(data.fullName).toBe("facebook/react");
+    });
+
+    it("rejects private repo not in installations", async () => {
+      // Mock fetch to return private repo
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          name: "private-repo",
+          full_name: "someuser/private-repo",
+          private: true,
+        }),
+      });
+
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "someuser/private-repo" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe("repository_private");
+    });
+
+    it("returns 404 when repository does not exist", async () => {
+      // Mock fetch to return 404
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      });
+
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "nonexistent/repo" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toBe("not_found");
+    });
+  });
+
+  describe("Authentication", () => {
+    it("returns 401 when user is not authenticated", async () => {
+      mockAuth.mockResolvedValue({ userId: null } as Awaited<
+        ReturnType<typeof auth>
+      >);
+
+      const request = new Request("http://localhost", {
+        method: "POST",
+        body: JSON.stringify({ repoUrl: "facebook/react" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error).toBe("unauthorized");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/github/verify-repo/route.ts
+++ b/turbo/apps/web/app/api/github/verify-repo/route.ts
@@ -143,24 +143,32 @@ export async function POST(request: Request) {
  * - https://github.com/owner/repo
  * - https://github.com/owner/repo.git
  * - git@github.com:owner/repo.git
+ *
+ * Supports repository names with dots, underscores, hyphens per GitHub's naming rules.
+ * Valid characters: [A-Za-z0-9_.-]
  */
 function normalizeRepoUrl(input: string): string | null {
   // Remove whitespace
   input = input.trim();
 
   // Pattern 1: already in owner/repo format
-  if (/^[\w-]+\/[\w-]+$/.test(input)) {
+  // GitHub allows: alphanumeric, hyphens, underscores, and periods
+  if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(input)) {
     return input;
   }
 
-  // Pattern 2: HTTPS URL
-  const httpsMatch = input.match(/github\.com\/([^/]+\/[^/.]+)/);
+  // Pattern 2: HTTPS URL (e.g., https://github.com/owner/repo or https://github.com/owner/repo.git)
+  const httpsMatch = input.match(
+    /github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?$/,
+  );
   if (httpsMatch?.[1]) {
     return httpsMatch[1];
   }
 
-  // Pattern 3: Git SSH URL
-  const sshMatch = input.match(/github\.com:([^/]+\/[^/.]+)/);
+  // Pattern 3: Git SSH URL (e.g., git@github.com:owner/repo.git)
+  const sshMatch = input.match(
+    /github\.com:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?$/,
+  );
   if (sshMatch?.[1]) {
     return sshMatch[1];
   }

--- a/turbo/apps/web/app/components/TerminalHome.tsx
+++ b/turbo/apps/web/app/components/TerminalHome.tsx
@@ -2,12 +2,20 @@
 
 import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import Terminal from "react-console-emulator";
 import styles from "./TerminalHome.module.css";
 
 export function TerminalHome() {
   const router = useRouter();
   const { isSignedIn } = useAuth();
+
+  // Auto-redirect to projects page if user is already signed in
+  useEffect(() => {
+    if (isSignedIn) {
+      router.push("/projects");
+    }
+  }, [isSignedIn, router]);
 
   const commands = {
     about: {

--- a/turbo/apps/web/app/components/repo-input.tsx
+++ b/turbo/apps/web/app/components/repo-input.tsx
@@ -75,7 +75,7 @@ export function RepoInput({ onRepoVerified }: RepoInputProps) {
     <div className="space-y-3">
       <div className="relative">
         <Input
-          placeholder="Enter GitHub URL or owner/repo (e.g., facebook/react)"
+          placeholder="Enter GitHub URL or owner/repo (e.g., uspark-hq/uspark)"
           value={input}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary

This PR improves the user experience on the home page and enhances GitHub repository input handling:

- Auto-redirect authenticated users from home page to projects list for better UX
- Update GitHub repository input placeholder to use uspark-hq/uspark as example
- Fix GitHub URL parser to support dots in repository names (e.g., backend.ai, node.js)
- Add comprehensive test suite with 16 test cases covering all URL formats and edge cases

## Changes

### Home Page Auto-Redirect
- **File:** `apps/web/app/components/TerminalHome.tsx`
- **Change:** Added useEffect hook to automatically redirect authenticated users to `/projects`
- **Benefit:** Streamlined user flow - logged-in users go directly to their projects

### Repository Input Placeholder
- **File:** `apps/web/app/components/repo-input.tsx`
- **Change:** Updated placeholder from `facebook/react` to `uspark-hq/uspark`
- **Benefit:** Uses our own repository as example, better brand visibility

### GitHub URL Parser Enhancement
- **File:** `apps/web/app/api/github/verify-repo/route.ts`
- **Change:** Updated regex pattern from `[\w-]` to `[A-Za-z0-9_.-]`
- **Benefit:** Supports all valid GitHub repository names including dots (., per GitHub naming rules)

### Comprehensive Test Suite
- **File:** `apps/web/app/api/github/verify-repo/route.test.ts` (NEW)
- **Test Coverage:** 16 test cases covering:
  - URL format validation (owner/repo, URLs, HTTP/HTTPS)
  - Repository verification (installed, public, private, not found)
  - Edge cases (empty strings, invalid formats, unauthorized access)
- **Status:** All tests passing ✓

## Test Plan

- [x] All 16 new tests passing
- [x] Existing tests continue to pass
- [x] Lint checks passed
- [x] Type checks passed
- [x] Format checks passed
- [x] Build successful
- [x] Knip checks passed

## Technical Details

**GitHub Repository Naming Rules:**
- Allows: letters (A-Z, a-z), numbers (0-9), hyphens (-), underscores (_), dots (.)
- Examples now supported: `backend.ai`, `node.js`, `uspark-hq/uspark`

**Type Safety:**
- All code is fully type-safe with explicit types
- No usage of `any` type
- Zero lint/type suppressions

## Breaking Changes

None - this is a backward-compatible enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)