### PR TITLE
fix(web): use tool name for accurate result display and fix flaky tests

### DIFF
--- a/turbo/apps/web/app/api/github/installation-status/route.test.ts
+++ b/turbo/apps/web/app/api/github/installation-status/route.test.ts
@@ -14,7 +14,9 @@ const mockAuth = vi.mocked(auth);
 
 describe("GET /api/github/installation-status", () => {
   const testUserId = `test-user-gh-status-${Date.now()}-${process.pid}`;
-  const baseInstallationId = Math.floor(Date.now() / 1000); // Use timestamp as base for unique IDs
+  // Combine pid and timestamp to ensure uniqueness within PostgreSQL integer range (-2147483648 to 2147483647)
+  const baseInstallationId =
+    (process.pid % 10000) * 100000 + (Math.floor(Date.now() / 1000) % 100000);
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/turbo/apps/web/app/api/github/repositories/route.test.ts
+++ b/turbo/apps/web/app/api/github/repositories/route.test.ts
@@ -20,7 +20,9 @@ const mockAuth = vi.mocked(auth);
 
 describe("GET /api/github/repositories", () => {
   const testUserId = `test-user-repos-${Date.now()}-${process.pid}`;
-  const baseInstallationId = Math.floor(Date.now() / 1000);
+  // Combine pid and timestamp to ensure uniqueness within PostgreSQL integer range (-2147483648 to 2147483647)
+  const baseInstallationId =
+    (process.pid % 10000) * 100000 + (Math.floor(Date.now() / 1000) % 100000);
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/turbo/apps/web/app/api/github/verify-repo/route.test.ts
+++ b/turbo/apps/web/app/api/github/verify-repo/route.test.ts
@@ -23,7 +23,9 @@ const originalFetch = global.fetch;
 
 describe("POST /api/github/verify-repo", () => {
   const testUserId = `test-user-verify-${Date.now()}-${process.pid}`;
-  const baseInstallationId = Math.floor(Date.now() / 1000);
+  // Combine pid and timestamp to ensure uniqueness within PostgreSQL integer range (-2147483648 to 2147483647)
+  const baseInstallationId =
+    (process.pid % 10000) * 100000 + (Math.floor(Date.now() / 1000) % 100000);
 
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/turbo/apps/web/app/components/claude-chat/chat-interface.tsx
+++ b/turbo/apps/web/app/components/claude-chat/chat-interface.tsx
@@ -356,7 +356,11 @@ export function ChatInterface({ projectId }: ChatInterfaceProps) {
                     >
                       {turn.blocks && turn.blocks.length > 0 ? (
                         filterBlocksForDisplay(turn.blocks).map((block) => (
-                          <BlockDisplay key={block.id} block={block} />
+                          <BlockDisplay
+                            key={block.id}
+                            block={block}
+                            blocks={turn.blocks}
+                          />
                         ))
                       ) : turn.status === "in_progress" ? (
                         <div


### PR DESCRIPTION
## Summary
- Refactored BlockDisplay component to use explicit tool name identification instead of fragile format matching
- Read tool results now display "Read X Lines" summary instead of full content
- Other tool results display maximum 3 lines with truncation
- Fixed flaky GitHub API tests by generating unique installation IDs within PostgreSQL integer constraints

## Changes

### Block Display Improvements
- Added `blocks` prop to BlockDisplay component to access all blocks
- Implemented `findToolUse()` helper to locate tool_use block by tool_use_id
- Replaced regex-based format detection with explicit tool_name lookup
- Read tool results: Show "Read X Lines" summary for better UX
- Other tools: Display max 3 lines with "..." truncation

### Test Stability Fixes
Fixed flaky tests in three GitHub API test files by ensuring unique installation IDs:
- `apps/web/app/api/github/installation-status/route.test.ts`
- `apps/web/app/api/github/repositories/route.test.ts`
- `apps/web/app/api/github/verify-repo/route.test.ts`

Changed from:
```typescript
const baseInstallationId = Math.floor(Date.now() / 1000);
```

To:
```typescript
const baseInstallationId =
  (process.pid % 10000) * 100000 + (Math.floor(Date.now() / 1000) % 100000);
```

This ensures unique IDs when tests run in parallel while staying within PostgreSQL integer range.

## Technical Details
- Removed code smell: format-based tool detection (regex matching)
- Improved reliability: explicit tool identification via tool_use_id relationship
- Better test isolation: unique IDs prevent concurrent test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)