### PR TITLE
feat(workspace): default to wiki/00-README.md on project page

### DIFF
--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -99,11 +99,19 @@ export const selectedFileItem$ = computed(async (get) => {
 
   const filePath = get(selectedFile$)
 
-  const file = filePath
-    ? findFileInTree(files.files, filePath)
-    : findFirstFile(files.files)
+  if (filePath) {
+    // If a file is explicitly specified in the URL, use it
+    return findFileInTree(files.files, filePath)
+  }
 
-  return file
+  // Default to wiki/00-README.md if it exists
+  const defaultFile = findFileInTree(files.files, 'wiki/00-README.md')
+  if (defaultFile) {
+    return defaultFile
+  }
+
+  // Fall back to the first file in the tree
+  return findFirstFile(files.files)
 })
 
 export const selectedFileContent$ = computed(async (get) => {


### PR DESCRIPTION
## Summary
- Modified the `selectedFileItem$` computed property to default to `wiki/00-README.md` when no file is specified in the URL
- Provides a consistent and predictable entry point for users when viewing project details
- Falls back to the first available file if `wiki/00-README.md` doesn't exist

## Changes
- Updated file selection logic in `turbo/apps/workspace/src/signals/project/project.ts:94-115`
- Now checks for `wiki/00-README.md` before falling back to `findFirstFile()`

## Test plan
- [ ] Verify that accessing a project page without a file parameter shows `wiki/00-README.md` when it exists
- [ ] Verify that projects without `wiki/00-README.md` still show the first available file
- [ ] Verify that explicitly specifying a file in the URL still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)