### PR TITLE
fix(cli): prevent version increment when no files changed

### DIFF
--- a/e2e/tests/03-push-pull/t03-push-pull.bats
+++ b/e2e/tests/03-push-pull/t03-push-pull.bats
@@ -149,7 +149,7 @@ teardown() {
     # Push should indicate no files found
     run cli_with_host push --project-id "$PROJECT_ID"
     assert_success
-    assert_output --partial "No files found to push"
+    assert_output --partial "No changes to push"
 }
 
 @test "CLI version increments after each push" {

--- a/turbo/apps/cli/src/commands/shared.ts
+++ b/turbo/apps/cli/src/commands/shared.ts
@@ -101,10 +101,10 @@ export async function pushAllFiles(
   });
 
   // Use batch push with fail-fast
-  await context.sync.pushFiles(projectId, filesToPush, {
+  const changedCount = await context.sync.pushFiles(projectId, filesToPush, {
     token: context.token,
     apiUrl: context.apiUrl,
   });
 
-  return files.length;
+  return changedCount;
 }

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -84,14 +84,16 @@ export async function pushCommand(options: {
 
   console.log(chalk.blue(`Pushing all files to project ${projectId}...`));
 
-  const count = await pushAllFiles(
+  const changedCount = await pushAllFiles(
     { token, apiUrl, sync },
     projectId,
     ".", // Always push from current directory
   );
 
-  if (count === 0) {
-    console.log(chalk.yellow("No files found to push"));
+  if (changedCount === 0) {
+    console.log(
+      chalk.gray("ℹ️  No changes to push (all files are up to date)"),
+    );
     return;
   }
 
@@ -101,6 +103,8 @@ export async function pushCommand(options: {
   await updateProjectVersion(newVersion);
 
   console.log(
-    chalk.green(`✓ Successfully pushed ${count} files (version ${newVersion})`),
+    chalk.green(
+      `✓ Successfully pushed ${changedCount} files (version ${newVersion})`,
+    ),
   );
 }

--- a/turbo/apps/cli/src/commands/sync.ts
+++ b/turbo/apps/cli/src/commands/sync.ts
@@ -91,9 +91,7 @@ export async function pushCommand(options: {
   );
 
   if (changedCount === 0) {
-    console.log(
-      chalk.gray("ℹ️  No changes to push (all files are up to date)"),
-    );
+    console.log(chalk.gray("No changes to push (all files are up to date)"));
     return;
   }
 

--- a/turbo/packages/core-node/src/project-sync.ts
+++ b/turbo/packages/core-node/src/project-sync.ts
@@ -336,7 +336,7 @@ export class ProjectSync {
     projectId: string,
     files: Array<{ filePath: string; localPath?: string }>,
     options: SyncOptions,
-  ): Promise<void> {
+  ): Promise<number> {
     const apiUrl = options.apiUrl;
     const token = options.token;
 
@@ -477,6 +477,9 @@ export class ProjectSync {
 
     // 7. Sync everything to remote in one PATCH request
     await this.syncToRemote(projectId, options);
+
+    // Return the number of files that were actually changed
+    return toAdd.size + toUpdate.size + toDelete.size;
   }
 
   async pullAll(


### PR DESCRIPTION
## Summary
- Modified `pushFiles()` to return the actual number of changed files (added, updated, or deleted) instead of total file count
- Updated CLI to only increment version when `changedCount > 0`
- Added user-friendly message when no changes are detected

## Problem
Previously, running `uspark push` multiple times without any file changes would increment the version number on every push. This was because:
1. `pushFiles()` always returned the total number of files being pushed
2. The CLI incremented the version whenever the count was > 0, regardless of whether files actually changed

Example of the bug:
```bash
➜ uspark push
✓ Successfully pushed 46 files (version 24)
➜ uspark push  # No changes made
✓ Successfully pushed 46 files (version 25)  # Version incremented!
➜ uspark push  # Still no changes
✓ Successfully pushed 46 files (version 26)  # Version incremented again!
```

## Solution
Now `pushFiles()` returns the count of files that were actually added, updated, or deleted. The CLI only increments the version when actual changes are pushed.

New behavior:
```bash
➜ uspark push
✓ Successfully pushed 46 files (version 24)
➜ uspark push  # No changes made
ℹ️  No changes to push (all files are up to date)  # Version stays 24
➜ uspark push  # Still no changes
ℹ️  No changes to push (all files are up to date)  # Version stays 24
```

## Changes Made
- `project-sync.ts`: Modified `pushFiles()` return type from `Promise<void>` to `Promise<number>` and return `toAdd.size + toUpdate.size + toDelete.size`
- `shared.ts`: Updated `pushAllFiles()` to return the changed count from `pushFiles()`
- `sync.ts`: CLI now only increments version when `changedCount > 0`, and shows appropriate message when no changes detected

## Test Plan
- [x] Run `uspark push` with actual file changes - version should increment
- [x] Run `uspark push` again without changes - should show "No changes to push" and not increment version
- [x] Verify all pre-commit checks pass (prettier, lint, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)