### PR TITLE
chore(e2b): update dependencies to latest versions

### DIFF
--- a/e2b/e2b.Dockerfile
+++ b/e2b/e2b.Dockerfile
@@ -4,10 +4,10 @@ FROM node:22-slim
 RUN apt-get update && apt-get install -y git curl
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code@2.0.22
+RUN npm install -g @anthropic-ai/claude-code@2.0.24
 
 # Install uspark CLI globally
-RUN npm install -g @uspark/cli@0.13.0
+RUN npm install -g @uspark/cli@0.16.0
 
 # Verify installations
 RUN claude --version


### PR DESCRIPTION
## Summary

- Update `@anthropic-ai/claude-code` from 2.0.22 to 2.0.24
- Update `@uspark/cli` from 0.13.0 to 0.16.0

These updates ensure the E2B Docker image uses the latest stable releases with bug fixes and improvements.

## Test plan

- [ ] Verify Docker image builds successfully
- [ ] Verify `claude --version` shows 2.0.24
- [ ] Verify `uspark --version` shows 0.16.0
- [ ] Test basic Claude Code functionality in E2B environment
- [ ] Test basic uspark CLI functionality in E2B environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)