### PR TITLE
feat(workspace): scroll file content to top when switching files

### DIFF
--- a/turbo/apps/workspace/src/views/project/file-content.tsx
+++ b/turbo/apps/workspace/src/views/project/file-content.tsx
@@ -40,12 +40,10 @@ export function FileContent() {
     navigator.clipboard
       .writeText(shareUrl)
       .then(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         toast.success('Link copied to clipboard')
         closeSharePopover()
       })
       .catch(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         toast.error('Failed to copy link')
       })
   }

--- a/turbo/apps/workspace/src/views/project/file-tree.tsx
+++ b/turbo/apps/workspace/src/views/project/file-tree.tsx
@@ -1,10 +1,12 @@
 import type { FileItem } from '@uspark/core/yjs-filesystem'
-import { useLastResolved, useLoadable, useSet } from 'ccstate-react'
+import { useGet, useLastResolved, useLoadable, useSet } from 'ccstate-react'
+import { pageSignal$ } from '../../signals/page-signal'
 import {
   projectFiles$,
   selectedFileItem$,
   selectFile$,
 } from '../../signals/project/project'
+import { detach, Reason } from '../../signals/utils'
 
 interface FileTreeItemProps {
   item: FileItem
@@ -16,10 +18,11 @@ function FileTreeItem({ item, level }: FileTreeItemProps) {
   const selectFile = useSet(selectFile$)
   const selectedFile = useLastResolved(selectedFileItem$)
   const isSelected = selectedFile?.path === item.path
+  const signal = useGet(pageSignal$)
 
   const handleClick = () => {
     if (item.type === 'file') {
-      selectFile(item.path)
+      detach(selectFile(item.path, signal), Reason.DomCallback)
     }
   }
 

--- a/turbo/apps/workspace/src/views/project/markdown-preview.tsx
+++ b/turbo/apps/workspace/src/views/project/markdown-preview.tsx
@@ -1,17 +1,21 @@
-import { useLastResolved } from 'ccstate-react'
-import { selectedFileContentHtml$ } from '../../signals/project/project'
+import { useLastResolved, useSet } from 'ccstate-react'
+import {
+  mountFileContentContainer$,
+  selectedFileContentHtml$,
+} from '../../signals/project/project'
 
 export function MarkdownPreview() {
   const sanitizedHtml: string | undefined = useLastResolved(
     selectedFileContentHtml$,
   )
+  const mountContainer = useSet(mountFileContentContainer$)
 
   if (!sanitizedHtml) {
     return null
   }
 
   return (
-    <div className="h-full overflow-auto bg-[#1e1e1e] p-4">
+    <div className="h-full overflow-auto bg-[#1e1e1e] p-4" ref={mountContainer}>
       <div
         className="markdown-preview"
         dangerouslySetInnerHTML={{ __html: sanitizedHtml }}


### PR DESCRIPTION
## Summary
- Implements automatic scroll-to-top when switching files in project details page
- Uses ref pattern similar to session turn list scrolling
- Ensures users always see the beginning of newly opened files

## Changes
- **project.ts**: Added file content container ref management (`mountFileContentContainer$`)
- **project.ts**: Updated `selectFile$` command to be async and scroll to top after content loads
- **file-tree.tsx**: Changed to use `detach` pattern for async command handling
- **markdown-preview.tsx**: Added container ref using `mountFileContentContainer$`
- **file-content.tsx**: Removed unused eslint-disable comments (cleanup)

## Technical Details
The implementation follows the same pattern used for turn list scrolling:
1. Create a state to hold the DOM element reference
2. Use `onRef` to create a ref command
3. Wait for content to load before scrolling
4. Use `detach(command(signal), Reason.DomCallback)` for event handlers

## Test Plan
- [x] Verify file content scrolls to top when switching between files
- [x] Lint and type checks pass
- [x] Code follows existing patterns in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)