### PR TITLE
feat(workspace): improve turn block display with smart truncation

### DIFF
--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -4,6 +4,7 @@ type Block = GetTurnResponse['blocks'][number]
 
 interface BlockDisplayProps {
   block: Block
+  toolName?: string
 }
 
 // Runtime type for block content (schema is incorrect - content can be object)
@@ -24,7 +25,7 @@ function getTextContent(content: unknown): string {
   return JSON.stringify(content)
 }
 
-export function BlockDisplay({ block }: BlockDisplayProps) {
+export function BlockDisplay({ block, toolName }: BlockDisplayProps) {
   switch (block.type) {
     case 'text':
     case 'content': {
@@ -93,7 +94,7 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
       }
 
       return (
-        <div className="text-[11px] text-[#9cdcfe]">
+        <div className="truncate text-[11px] text-[#9cdcfe]">
           {toolName}
           {paramDisplay && (
             <span className="ml-1 font-mono text-[#6a6a6a]">
@@ -137,17 +138,52 @@ export function BlockDisplay({ block }: BlockDisplayProps) {
         resultContent = getTextContent(content)
       }
 
+      // Special handling for Read tool
+      if (toolName === 'Read' && !hasError && resultContent) {
+        const lines = resultContent.split('\n')
+        return (
+          <div className="ml-2 border-l-2 border-[#3e3e42] pl-2 font-mono text-[11px] text-[#6a6a6a]">
+            Read {lines.length} {lines.length === 1 ? 'line' : 'lines'}
+          </div>
+        )
+      }
+
+      // For other tools, limit to 3 lines
+      if (!resultContent) {
+        return (
+          <div
+            className={`ml-2 border-l-2 pl-2 font-mono text-[11px] leading-[1.4] ${
+              hasError
+                ? 'border-[#f48771] text-[#f48771]'
+                : 'border-[#3e3e42] text-[#d4d4d4]'
+            }`}
+          >
+            <pre className="font-mono whitespace-pre-wrap">
+              <span className="italic opacity-50">(no output)</span>
+            </pre>
+          </div>
+        )
+      }
+
+      const lines = resultContent.split('\n')
+      const displayLines = lines.slice(0, 3)
+      const remainingLines = lines.length - 3
+
       return (
         <div
-          className={`ml-2 max-h-[200px] overflow-hidden border-l-2 pl-2 font-mono text-[11px] leading-[1.4] ${
+          className={`ml-2 border-l-2 pl-2 font-mono text-[11px] leading-[1.4] ${
             hasError
               ? 'border-[#f48771] text-[#f48771]'
               : 'border-[#3e3e42] text-[#d4d4d4]'
           }`}
         >
           <pre className="font-mono whitespace-pre-wrap">
-            {resultContent || (
-              <span className="italic opacity-50">(no output)</span>
+            {displayLines.join('\n')}
+            {remainingLines > 0 && (
+              <span className="text-[#6a6a6a]">
+                {'\n'}+{remainingLines}{' '}
+                {remainingLines === 1 ? 'line' : 'lines'}
+              </span>
             )}
           </pre>
         </div>


### PR DESCRIPTION
## Summary

- Implement CSS-based single-line truncation for tool_use blocks
- Add JS-controlled 3-line limit for tool_result blocks with "+XX lines" indicator
- Special handling for Read tool results showing "Read XX lines" instead of content
- Pass tool name from turn-display to block-display component via props

## Changes

### UI Improvements
- **tool_use blocks**: Added `truncate` CSS class for automatic ellipsis on overflow
- **tool_result blocks**: JavaScript-controlled display limiting to first 3 lines
- **Read tool**: Shows compact "Read XX lines" summary instead of file contents
- **Overflow indicator**: Shows "+XX lines" for truncated tool results

### Technical Implementation
- Created tool name mapping system using `tool_use_id` → `tool_name` lookup
- Enhanced BlockDisplay component to accept `toolName` prop
- Modified turn-display to build and pass tool name mappings
- Proper singular/plural handling ("1 line" vs "2 lines")

## Benefits

1. **Cleaner UI**: tool_use blocks never wrap, maintaining compact list layout
2. **Predictable height**: tool_result blocks limited to maximum 3 lines
3. **Better UX**: Read results show line count instead of overwhelming file content
4. **Consistent display**: All blocks follow predictable, uniform formatting rules

## Test Coverage

- Added 4 new comprehensive tests:
  - 3-line content display without truncation indicator
  - Content exceeding 3 lines with "+XX lines" indicator
  - Read tool showing line count summary
  - Singular/plural form handling
- All 17 tests passing ✅
- Lint checks passing ✅  
- TypeScript type checks passing ✅

## Before/After

**Before**: 
- tool_use blocks could wrap to multiple lines
- tool_result blocks used CSS max-height (unpredictable display)
- Read tool showed full file contents

**After**:
- tool_use blocks always single line with ellipsis
- tool_result blocks show exactly first 3 lines + indicator
- Read tool shows compact "Read XX lines"

🤖 Generated with [Claude Code](https://claude.com/claude-code)