### PR TITLE
fix(workspace): fix truncate not working in tool_use block display

### DIFF
--- a/turbo/apps/workspace/src/views/project/block-display.tsx
+++ b/turbo/apps/workspace/src/views/project/block-display.tsx
@@ -94,10 +94,10 @@ export function BlockDisplay({ block, toolName }: BlockDisplayProps) {
       }
 
       return (
-        <div className="truncate text-[11px] text-[#9cdcfe]">
-          {toolName}
+        <div className="flex items-center gap-1 overflow-hidden text-[11px] text-[#9cdcfe]">
+          <span className="shrink-0">{toolName}</span>
           {paramDisplay && (
-            <span className="ml-1 font-mono text-[#6a6a6a]">
+            <span className="truncate font-mono text-[#6a6a6a]">
               {paramDisplay}
             </span>
           )}


### PR DESCRIPTION
## Summary
- Fixed CSS truncate not working in tool_use block display
- Long parameter values (like TodoWrite with large JSON arrays) now show ellipsis correctly

## Changes
- Convert outer div to flexbox layout with overflow-hidden
- Wrap toolName in shrink-0 span to prevent it from being truncated
- Apply truncate class only to paramDisplay span where truncation should occur

## Test plan
- [x] All existing tests pass (17/17 in block-display.test.tsx)
- [x] Tool names always display fully
- [x] Long parameters show ellipsis correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)