### PR TITLE
feat(workspace): implement 1:1 split layout for project detail page

### DIFF
--- a/turbo/apps/workspace/src/views/project/left-panel.tsx
+++ b/turbo/apps/workspace/src/views/project/left-panel.tsx
@@ -5,13 +5,13 @@ import { SessionList } from './session-list'
 
 /**
  * Left panel containing the new session input and session list.
- * Fixed width of 320px with VS Code dark theme styling.
+ * Takes up 50% of screen width (1:1 split with right panel).
  */
 export function LeftPanel() {
   const handleSelectSession = useSet(selectSession$)
 
   return (
-    <div className="flex h-full w-[320px] flex-col border-r border-[#3e3e42] bg-[#252526]">
+    <div className="flex h-full w-1/2 flex-col border-r border-[#3e3e42] bg-[#252526]">
       <NewSessionChatInput />
       <SessionList onSelectSession={handleSelectSession} />
     </div>

--- a/turbo/apps/workspace/src/views/project/project-page.tsx
+++ b/turbo/apps/workspace/src/views/project/project-page.tsx
@@ -64,13 +64,13 @@ export function ProjectPage() {
         </div>
       </div>
 
-      {/* Main content area - fixed two-column layout */}
+      {/* Main content area - 1:1 split two-column layout */}
       <div className="flex min-h-0 flex-1">
-        {/* Left panel: Session list (320px fixed) */}
+        {/* Left panel: Session list (50% width) */}
         <LeftPanel />
 
-        {/* Right panel: Session chat OR file content */}
-        <div className="flex-1">
+        {/* Right panel: Session chat OR file content (50% width) */}
+        <div className="w-1/2">
           {isFileContentVisible ? <FileContent /> : <SessionChatArea />}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Changed project detail page layout from fixed 320px left panel to strict 50/50 split
- Left panel (session list): now `w-1/2` instead of `w-[320px]`
- Right panel (content area): now `w-1/2` instead of `flex-1`

This provides a more balanced viewing experience with equal space for sessions and content.

## Test plan
- [ ] Verify the layout displays correctly with 1:1 split on different screen sizes
- [ ] Test session list functionality in the new layout
- [ ] Verify content area displays properly in the new layout
- [ ] Check responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)