### PR TITLE
feat(cli): add verbose flag to claude-worker command

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -110,9 +110,12 @@ program
   .description("Run Claude as a continuous worker to process tasks")
   .requiredOption("--id <taskId>", "Task ID to process")
   .requiredOption("--project-id <projectId>", "Project ID to sync changes to")
-  .action(async (options: { id: string; projectId: string }) => {
-    await claudeWorkerCommand(options);
-  });
+  .option("--verbose", "Show full JSON output instead of just result field")
+  .action(
+    async (options: { id: string; projectId: string; verbose?: boolean }) => {
+      await claudeWorkerCommand(options);
+    },
+  );
 
 export { program };
 


### PR DESCRIPTION
## Summary
- Add `--verbose` option to `claude-worker` command to control output verbosity
- By default, only shows the `result` field from result blocks for cleaner output
- When `--verbose` is enabled, shows full JSON stream output including all blocks

## Changes
- Modified `turbo/apps/cli/src/index.ts` to add `--verbose` option to command definition
- Updated `claudeWorkerCommand` function to accept and pass `verbose` parameter
- Implemented output filtering logic in `executeClaude` function to parse and filter JSON blocks based on verbose flag

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Format passes
- [ ] Manual test: Run `uspark claude-worker --id test --project-id abc123` (should show only result)
- [ ] Manual test: Run `uspark claude-worker --id test --project-id abc123 --verbose` (should show full JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)