### PR TITLE
feat(cli): auto-generate worker id for claude-worker command

### DIFF
--- a/turbo/apps/cli/src/commands/claude-worker.test.ts
+++ b/turbo/apps/cli/src/commands/claude-worker.test.ts
@@ -12,6 +12,11 @@ vi.mock("./shared", () => ({
   }),
 }));
 
+// Mock project-config
+vi.mock("../project-config", () => ({
+  getOrCreateWorkerId: vi.fn().mockResolvedValue("test-worker-id-12345"),
+}));
+
 // Mock chalk
 vi.mock("chalk", () => ({
   default: {
@@ -20,12 +25,20 @@ vi.mock("chalk", () => ({
     yellow: (str: string) => str,
     green: (str: string) => str,
     red: (str: string) => str,
+    gray: (str: string) => str,
   },
 }));
 
 // Mock child_process
 vi.mock("child_process", () => ({
   spawn: vi.fn(),
+}));
+
+// Mock WorkerApiClient
+vi.mock("../worker-api", () => ({
+  WorkerApiClient: vi.fn().mockImplementation(() => ({
+    sendHeartbeat: vi.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 // Helper to create a mock child process
@@ -143,7 +156,6 @@ describe("claude-worker", () => {
 
   it("should execute pull -> claude -> push cycle", async () => {
     await claudeWorkerCommand({
-      id: "1",
       projectId: "test-project",
     });
 
@@ -178,7 +190,6 @@ describe("claude-worker", () => {
 
   it("should detect sleep signal and continue to next iteration", async () => {
     await claudeWorkerCommand({
-      id: "1",
       projectId: "test-project",
     });
 
@@ -233,7 +244,6 @@ describe("claude-worker", () => {
     });
 
     await claudeWorkerCommand({
-      id: "1",
       projectId: "test-project",
     });
 
@@ -278,7 +288,6 @@ describe("claude-worker", () => {
     });
 
     await claudeWorkerCommand({
-      id: "1",
       projectId: "test-project",
     });
 

--- a/turbo/apps/cli/src/commands/claude-worker.ts
+++ b/turbo/apps/cli/src/commands/claude-worker.ts
@@ -3,19 +3,19 @@ import { createInterface } from "readline";
 import chalk from "chalk";
 import { requireAuth } from "./shared";
 import { WorkerApiClient } from "../worker-api";
+import { getOrCreateWorkerId } from "../project-config";
 
 const SLEEP_SIGNAL = "###USPARK_WORKER_SLEEP###";
 const DEFAULT_SLEEP_DURATION_MS = 60000; // 60 seconds
 const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
 
 export async function claudeWorkerCommand(options: {
-  id: string;
   projectId: string;
   verbose?: boolean;
 }): Promise<void> {
   const context = await requireAuth();
 
-  const { id, projectId, verbose = false } = options;
+  const { projectId, verbose = false } = options;
 
   // Support max iterations for testing (via environment variable)
   const maxIterations = process.env.MAX_ITERATIONS
@@ -27,7 +27,11 @@ export async function claudeWorkerCommand(options: {
     ? parseInt(process.env.SLEEP_DURATION_MS, 10)
     : DEFAULT_SLEEP_DURATION_MS;
 
-  console.log(chalk.cyan(`[uspark] Starting Claude Worker #${id}`));
+  // Initialize workerId in .uspark/.config.json
+  const workerId = await getOrCreateWorkerId(".uspark");
+
+  console.log(chalk.cyan(`[uspark] Starting Claude Worker`));
+  console.log(chalk.cyan(`[uspark] Worker ID: ${workerId}`));
   console.log(chalk.cyan(`[uspark] Project ID: ${projectId}`));
   console.log(chalk.cyan(`[uspark] Press Ctrl+C to stop\n`));
 
@@ -38,7 +42,7 @@ export async function claudeWorkerCommand(options: {
   const heartbeatTimer = setInterval(async () => {
     try {
       await workerApi.sendHeartbeat(projectId, {
-        name: `worker-${id}`,
+        name: `worker-${workerId}`,
       });
       console.log(chalk.gray("[uspark] Heartbeat sent"));
     } catch (error) {
@@ -64,7 +68,7 @@ export async function claudeWorkerCommand(options: {
 
         // Phase 2: Execute Claude
         console.log(chalk.blue("[uspark] Phase 2: Executing Claude..."));
-        const shouldSleep = await executeClaude(id, verbose);
+        const shouldSleep = await executeClaude(workerId, verbose);
 
         // Phase 3: Push files to remote
         console.log(chalk.blue("[uspark] Phase 3: Pushing files..."));
@@ -135,10 +139,10 @@ async function syncFiles(
  * Returns true if sleep signal was detected
  */
 async function executeClaude(
-  taskId: string,
+  workerId: string,
   verbose: boolean,
 ): Promise<boolean> {
-  const prompt = buildWorkerPrompt(taskId);
+  const prompt = buildWorkerPrompt(workerId);
 
   return new Promise((resolve, reject) => {
     const proc = spawn(
@@ -208,9 +212,9 @@ async function executeClaude(
 /**
  * Build the worker prompt
  */
-function buildWorkerPrompt(taskId: string): string {
+function buildWorkerPrompt(workerId: string): string {
   return `You are a uSpark Worker. Your tasks:
-1. Read the task from .uspark/tasks/task-${taskId}.md
+1. Read the task from .uspark/tasks/task-${workerId}.md
 2. Understand the current progress and execute the next step
 3. Update the task file to record your progress
 4. If the task is completed or cannot continue, output: ${SLEEP_SIGNAL}

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -108,14 +108,11 @@ program
 program
   .command("claude-worker")
   .description("Run Claude as a continuous worker to process tasks")
-  .requiredOption("--id <taskId>", "Task ID to process")
   .requiredOption("--project-id <projectId>", "Project ID to sync changes to")
   .option("--verbose", "Show full JSON output instead of just result field")
-  .action(
-    async (options: { id: string; projectId: string; verbose?: boolean }) => {
-      await claudeWorkerCommand(options);
-    },
-  );
+  .action(async (options: { projectId: string; verbose?: boolean }) => {
+    await claudeWorkerCommand(options);
+  });
 
 export { program };
 

--- a/turbo/apps/cli/src/project-config.ts
+++ b/turbo/apps/cli/src/project-config.ts
@@ -1,10 +1,12 @@
 import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
+import { randomUUID } from "crypto";
 
 interface ProjectConfig {
   projectId: string;
   version?: string;
+  workerId?: string;
 }
 
 const CONFIG_FILENAME = ".config.json";
@@ -77,4 +79,22 @@ export async function updateProjectVersion(
     );
   }
   await saveProjectConfig({ ...config, version }, dir);
+}
+
+export async function getOrCreateWorkerId(
+  dir: string = process.cwd(),
+): Promise<string> {
+  const config = await loadProjectConfig(dir);
+
+  // If config doesn't exist or doesn't have a workerId, generate a new one
+  if (!config?.workerId) {
+    const workerId = randomUUID();
+    await saveProjectConfig(
+      { ...(config || {}), workerId } as ProjectConfig,
+      dir,
+    );
+    return workerId;
+  }
+
+  return config.workerId;
 }


### PR DESCRIPTION
## Summary
- Remove the `--id` parameter from `claude-worker` command
- Auto-generate a UUID-based `workerId` that persists in `.uspark/.config.json`
- Simplify command usage - users no longer need to provide a worker ID manually
- Ensure each worker has a consistent identifier across runs

## Changes
- Remove `--id` parameter from `claude-worker` command
- Add `workerId` field to `ProjectConfig` interface
- Implement `getOrCreateWorkerId()` to generate/retrieve workerId
- Update worker prompt to use workerId for task file path (`.uspark/tasks/task-{workerId}.md`)
- Update heartbeat to use workerId for worker name (`worker-{workerId}`)
- Update all tests to reflect new parameter structure

## Test plan
- [x] Run CLI unit tests - all 4 tests passing
- [x] Type checking passes
- [x] Linting passes
- [x] Formatting verified
- [ ] Manual testing: Run `uspark claude-worker --project-id <projectId>` and verify workerId is generated in `.uspark/.config.json`
- [ ] Manual testing: Run command again and verify same workerId is reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)