### PR TITLE
test(core): remove timeout test in contract-fetch-simple

### DIFF
--- a/turbo/packages/core/src/__tests__/contract-fetch-simple.test.ts
+++ b/turbo/packages/core/src/__tests__/contract-fetch-simple.test.ts
@@ -6,6 +6,7 @@ import { contractFetch, ContractFetchError } from "../contract-fetch";
 // 创建一个简单的测试合约
 const c = initContract();
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const simpleContract = c.router({
   getUser: {
     method: "GET",
@@ -64,20 +65,6 @@ describe("contractFetch simple test", () => {
 
     expect(assertGetUserType).toBeDefined();
     expect(assertCreateUserType).toBeDefined();
-  });
-
-  it("should build correct request URL with path params", async () => {
-    // 使用实际的 fetch API 测试 URL 构建
-    // 这会失败但我们可以捕获错误来验证 URL
-    try {
-      await contractFetch(simpleContract.getUser, {
-        baseUrl: "https://api.example.com",
-        params: { id: "user123" },
-      });
-    } catch (error) {
-      // 由于没有实际的服务器，会失败，但我们可以检查错误
-      expect(error).toBeDefined();
-    }
   });
 
   it("should handle ContractFetchError type", () => {


### PR DESCRIPTION
## Summary
- Removed test that was timing out in CI environment
- Test was attempting real HTTP requests to external API (https://api.example.com)
- Added eslint-disable-next-line for simpleContract variable to fix lint warning

## Test plan
- [x] Run `pnpm vitest run packages/core/src/__tests__/contract-fetch-simple.test.ts` - passes with 2 tests
- [x] Verify pre-commit hooks pass (prettier, knip, lint)
- [x] Wait for CI to pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)