### PR TITLE
test: standardize msw configuration to error mode across all packages

### DIFF
--- a/spec/tech-debt.md
+++ b/spec/tech-debt.md
@@ -210,9 +210,19 @@ useEffect(() => {
 ## MSW Unhandled Requests in Tests
 **Issue:** Tests using MSW (Mock Service Worker) have unhandled HTTP requests that pass through without being intercepted.
 **Source:** Code review October 2025
-**Status:** 🔴 **ACTIVE**
+**Status:** ✅ **RESOLVED** (October 22, 2025)
 **Severity:** MEDIUM
-**Problem:**
+**Resolution:** Standardized MSW configuration across all packages to use `onUnhandledRequest: "error"` and fixed all unhandled requests
+
+**Changes Made:**
+- Updated `/turbo/packages/core/src/test/msw-setup.ts` to use "error" mode
+- Updated `/turbo/apps/web/src/test/msw-setup.ts` to use "error" mode (removed custom warning logging)
+- Updated `/turbo/apps/workspace/vitest.setup.browser.ts` to use "error" mode
+- Added missing handler for `/api/github/repositories` in global MSW handlers
+- Fixed `contract-fetch-simple.test.ts` to use proper MSW handlers instead of expecting network failures
+- Removed duplicate MSW server setup from `github-repo-selector.test.tsx`
+
+**Problem (Previously):**
 - MSW warns about unhandled requests but tests still pass
 - Indicates missing or incorrect request handlers
 - Tests may be making real network calls instead of using mocks
@@ -465,7 +475,7 @@ beforeEach(async () => {
 - Timer cleanup issues: **0** ✅ RESOLVED
 - Hardcoded URLs: **0** ✅ RESOLVED
 - Database test isolation: **Unique IDs implemented** ✅ RESOLVED
-- MSW unhandled requests: **Needs investigation** 🔴 ACTIVE
+- MSW unhandled requests: **0 warnings** ✅ RESOLVED (standardized to "error" mode)
 - Flaky E2E tests: **Temporarily mitigated with retries** 🟡 NEEDS PROPER FIX
 
 ### Target State
@@ -512,11 +522,10 @@ beforeEach(async () => {
 3. **Hardcoded URLs** ✅ - All URLs now use centralized configuration (PR #259)
 4. **Try-Catch Cleanup** ✅ - Removed unnecessary defensive programming patterns
 5. **Test Mock Cleanup** ✅ - Added `vi.clearAllMocks()` to all 17 test files (PR #272)
-6. **MSW Integration** 🟡 - Started migrating from fetch mocking to MSW (October 2025)
+6. **MSW Unhandled Requests** ✅ - Standardized configuration to "error" mode across all packages (October 22, 2025)
 
 ### Remaining Work:
 - **Flaky E2E Tests** 🟡 - Remove retry band-aid and implement proper deployment readiness checks
-- **MSW Unhandled Requests** 🔴 - Need to fix handler patterns to eliminate warnings
 - **Test Code `any` Types** - 3 violations in test files (low priority)
 - **Direct DB Operations in Tests** - 12 files need refactoring to use API endpoints
 
@@ -529,4 +538,4 @@ The most critical technical debt items have been resolved, significantly improvi
 
 ---
 
-*Last updated: 2025-10-21*
+*Last updated: 2025-10-22*

--- a/turbo/apps/web/app/components/__tests__/github-repo-selector.test.tsx
+++ b/turbo/apps/web/app/components/__tests__/github-repo-selector.test.tsx
@@ -1,69 +1,11 @@
 /**
  * @vitest-environment jsdom
  */
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  beforeAll,
-  afterAll,
-  afterEach,
-} from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GitHubRepoSelector } from "../github-repo-selector";
-import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
-
-const mockRepositories = [
-  {
-    id: 1,
-    name: "repo-1",
-    fullName: "owner1/repo-1",
-    installationId: 123,
-    private: false,
-    url: "https://github.com/owner1/repo-1",
-  },
-  {
-    id: 2,
-    name: "repo-2",
-    fullName: "owner1/repo-2",
-    installationId: 123,
-    private: true,
-    url: "https://github.com/owner1/repo-2",
-  },
-  {
-    id: 3,
-    name: "repo-3",
-    fullName: "owner2/repo-3",
-    installationId: 456,
-    private: false,
-    url: "https://github.com/owner2/repo-3",
-  },
-];
-
-// Setup MSW server
-const server = setupServer(
-  http.get("*/api/github/repositories", () => {
-    return HttpResponse.json({ repositories: mockRepositories });
-  }),
-);
-
-beforeAll(() => {
-  server.listen({ onUnhandledRequest: "error" });
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-  server.resetHandlers();
-});
-
-afterAll(() => {
-  server.close();
-});
 
 describe("GitHubRepoSelector", () => {
   beforeEach(() => {

--- a/turbo/apps/web/src/test/msw-handlers.ts
+++ b/turbo/apps/web/src/test/msw-handlers.ts
@@ -301,6 +301,38 @@ const projectsHandlers = [
     });
   }),
 
+  // GitHub repositories endpoint
+  http.get("*/api/github/repositories", () => {
+    return HttpResponse.json({
+      repositories: [
+        {
+          id: 1,
+          name: "repo-1",
+          fullName: "owner1/repo-1",
+          installationId: 123,
+          private: false,
+          url: "https://github.com/owner1/repo-1",
+        },
+        {
+          id: 2,
+          name: "repo-2",
+          fullName: "owner1/repo-2",
+          installationId: 123,
+          private: true,
+          url: "https://github.com/owner1/repo-2",
+        },
+        {
+          id: 3,
+          name: "repo-3",
+          fullName: "owner2/repo-3",
+          installationId: 456,
+          private: false,
+          url: "https://github.com/owner2/repo-3",
+        },
+      ],
+    });
+  }),
+
   // GET /api/projects/:projectId - Get project YJS data
   http.get("*/api/projects/:projectId", () => {
     // Mock empty YJS document (for testing)

--- a/turbo/apps/web/src/test/msw-setup.ts
+++ b/turbo/apps/web/src/test/msw-setup.ts
@@ -6,15 +6,10 @@ import { handlers } from "./msw-handlers";
 // Create MSW server instance with default handlers
 export const server = setupServer(...handlers);
 
-// Configure MSW to log all unhandled requests
-server.events.on("request:unhandled", ({ request }) => {
-  console.warn(`[MSW] Unhandled ${request.method} request to ${request.url}`);
-});
-
 // Setup MSW lifecycle hooks
 beforeAll(() => {
   server.listen({
-    onUnhandledRequest: "bypass", // Let unhandled requests pass through
+    onUnhandledRequest: "error",
   });
 });
 

--- a/turbo/apps/workspace/vitest.setup.browser.ts
+++ b/turbo/apps/workspace/vitest.setup.browser.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
   })
   await worker.start({
     quiet: true,
-    onUnhandledRequest: 'bypass',
+    onUnhandledRequest: 'error',
   })
   controller.signal.throwIfAborted()
 

--- a/turbo/packages/core/src/test/msw-setup.ts
+++ b/turbo/packages/core/src/test/msw-setup.ts
@@ -8,7 +8,7 @@ export const server = setupServer();
 // Setup MSW lifecycle hooks
 beforeAll(() => {
   server.listen({
-    onUnhandledRequest: "warn",
+    onUnhandledRequest: "error",
   });
 });
 


### PR DESCRIPTION
## Summary
Standardized Mock Service Worker (MSW) configuration to use strict `onUnhandledRequest: error` mode across all packages for consistent test behavior and early detection of missing request handlers.

## Changes
- ✅ Updated `packages/core` MSW setup from 'warn' to 'error' mode
- ✅ Updated `apps/web` MSW setup from 'bypass' to 'error' mode
- ✅ Updated `apps/workspace` browser setup from 'bypass' to 'error' mode
- ✅ Added missing `/api/github/repositories` handler to global MSW handlers
- ✅ Fixed `contract-fetch-simple.test.ts` to use proper MSW mocking instead of expecting network failures
- ✅ Removed duplicate MSW server setup from `github-repo-selector.test.tsx`
- ✅ Updated `tech-debt.md` to mark MSW issue as resolved

## Impact
- ✅ All 425 tests pass with zero MSW warnings
- ✅ Tests now fail immediately if handlers are missing
- ✅ Prevents accidental real network calls in tests
- ✅ Consistent strict behavior across all packages

## Test Plan
- [x] Run all tests: `pnpm vitest --run` ✅ 425 tests passed
- [x] Run lint: `pnpm turbo run lint` ✅ All passed
- [x] Run type check: `pnpm check-types` ✅ All passed
- [x] Run format: `pnpm format` ✅ All formatted

## Related
- Resolves tech debt item: MSW Unhandled Requests
- See `spec/tech-debt.md` for full details

🤖 Generated with [Claude Code](https://claude.com/claude-code)