### PR TITLE
fix(workspace): prevent infinite refresh of workers api

### DIFF
--- a/turbo/apps/workspace/src/signals/project/project.ts
+++ b/turbo/apps/workspace/src/signals/project/project.ts
@@ -14,6 +14,7 @@ import {
   projectDetail,
   projectFiles,
   projectSessions,
+  projectWorkers,
   sendMessage$,
   sessionTurns,
   turnDetail,
@@ -75,6 +76,15 @@ export const currentGitHubRepository$ = computed((get) => {
   }
 
   return get(githubRepository(projectId))
+})
+
+export const currentProjectWorkers$ = computed((get) => {
+  const projectId = get(projectId$)
+  if (!projectId) {
+    return undefined
+  }
+
+  return get(projectWorkers(projectId))
 })
 
 export const projectFiles$ = computed((get) => {

--- a/turbo/apps/workspace/src/views/project/workers-popover.tsx
+++ b/turbo/apps/workspace/src/views/project/workers-popover.tsx
@@ -7,8 +7,7 @@ import {
 } from '@uspark/ui'
 import { useLastResolved } from 'ccstate-react'
 import { Activity } from 'lucide-react'
-import { projectWorkers } from '../../signals/external/project-detail'
-import { currentProject$ } from '../../signals/project/project'
+import { currentProjectWorkers$ } from '../../signals/project/project'
 
 const WORKER_TIMEOUT_MS = 60_000 // 60 seconds
 
@@ -20,13 +19,7 @@ function isWorkerActive(lastHeartbeatAt: string): boolean {
 }
 
 export function WorkersPopover() {
-  const project = useLastResolved(currentProject$)
-  const projectId = project?.id
-
-  // Always call the hook, but pass undefined when no project
-  const workersData = useLastResolved(
-    projectId ? projectWorkers(projectId) : undefined,
-  )
+  const workersData = useLastResolved(currentProjectWorkers$)
 
   const activeWorkers = workersData?.workers.filter((w) =>
     isWorkerActive(w.last_heartbeat_at),


### PR DESCRIPTION
## Summary
- Fixed infinite refresh issue in workers API endpoint
- Created stable singleton signal `currentProjectWorkers$` 
- Updated WorkersPopover to use the new signal pattern

## Details

The workers API endpoint (`/api/projects/:projectId/workers`) was being called infinitely because:
- The `WorkersPopover` component called `projectWorkers(projectId)` on every render
- This created a new computed signal instance each time
- `useLastResolved` detected the reference change and re-subscribed
- This triggered a new API call, causing a re-render, creating an infinite loop

**Solution:**
Created a stable `currentProjectWorkers$` signal in `project.ts` (similar to `currentProject$` and `currentGitHubRepository$`) that:
- Is a singleton signal (single instance across the app)
- Automatically reacts to `projectId` changes internally
- Prevents unnecessary re-subscriptions and API calls

## Test plan
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] Tests pass
- [x] Code formatting passes
- [ ] Verify in browser that workers API is called only when necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)