### PR TITLE
fix(turbo): prevent knip from blocking commits in pre-commit hook

### DIFF
--- a/turbo/lefthook.yml
+++ b/turbo/lefthook.yml
@@ -11,5 +11,10 @@ pre-commit:
       glob: "turbo/**/*"
     knip:
       root: turbo/
-      run: pnpm knip
+      run: pnpm knip --cache --no-exit-code
       glob: "turbo/**/*.{js,ts,tsx,jsx,json}"
+      skip:
+        - merge
+        - rebase
+      fail_text: "Knip found unused code. Run 'cd turbo && pnpm knip' to see details."
+      timeout: 60


### PR DESCRIPTION
Add --no-exit-code flag to knip command in lefthook configuration to prevent pre-commit hook failures when unused code is detected. Also add performance and usability improvements:
- Add --cache flag for faster subsequent runs
- Add 60-second timeout to prevent indefinite hangs
- Skip knip during merge and rebase operations
- Add helpful fail_text message

This resolves the issue where knip would fail the pre-commit hook (appearing as a "hang") when finding unused dependencies or exports, blocking commits. Developers can still see knip warnings but can proceed with commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)