### PR TITLE
fix(cli): remove --continue flag from claude-worker execution

### DIFF
--- a/turbo/apps/cli/src/commands/claude-worker.test.ts
+++ b/turbo/apps/cli/src/commands/claude-worker.test.ts
@@ -174,7 +174,6 @@ describe("claude-worker", () => {
     // First iteration - Second call: claude
     expect(calls[1]?.[0]).toBe("claude");
     expect(calls[1]?.[1]).toEqual([
-      "--continue",
       "--print",
       "--verbose",
       "--output-format",

--- a/turbo/apps/cli/src/commands/claude-worker.ts
+++ b/turbo/apps/cli/src/commands/claude-worker.ts
@@ -153,7 +153,6 @@ async function executeClaude(
     const proc = spawn(
       "claude",
       [
-        "--continue",
         "--print",
         "--verbose",
         "--output-format",


### PR DESCRIPTION
## Summary

- Removed `--continue` flag from claude-worker command execution
- Each worker iteration now starts with a fresh Claude conversation instead of continuing from previous iterations
- Updated tests to match the new behavior

## Motivation

Previously, the claude-worker was using the `--continue` flag, which caused Claude to continue the previous conversation. This meant that context accumulated across iterations, which could lead to:
- Bloated conversation history
- Potential confusion when switching between tasks
- Difficulty in maintaining clean state between work cycles

## Changes

**Modified files:**
- `apps/cli/src/commands/claude-worker.ts` - Removed `--continue` flag from spawn arguments
- `apps/cli/src/commands/claude-worker.test.ts` - Updated test expectations

## Testing

All existing tests pass:
- ✓ should execute pull → claude → push cycle
- ✓ should detect sleep signal and continue to next iteration
- ✓ should continue immediately when no sleep signal
- ✓ should handle claude errors and retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)