### PR TITLE
fix(workspace): improve workers count display format

### DIFF
--- a/turbo/apps/workspace/src/views/project/workers-popover.tsx
+++ b/turbo/apps/workspace/src/views/project/workers-popover.tsx
@@ -1,5 +1,4 @@
 import {
-  Badge,
   Button,
   HoverCard,
   HoverCardContent,
@@ -37,12 +36,9 @@ export function WorkersPopover() {
           aria-label="View active workers"
         >
           <Activity className="h-4 w-4" />
-          <span>workers</span>
-          {activeCount > 0 && (
-            <Badge variant="default" className="ml-1">
-              {activeCount}
-            </Badge>
-          )}
+          <span>
+            {activeCount} {activeCount === 1 ? 'worker' : 'workers'}
+          </span>
         </Button>
       </HoverCardTrigger>
       <HoverCardContent


### PR DESCRIPTION
## Summary

Improves the workers count display in the project details page header by changing from badge format to inline text format.

## Changes

- Modified `WorkersPopover` component to show count inline with text (e.g., "3 workers" instead of "workers [3]")
- Removed Badge component usage
- Added proper singular/plural handling ("1 worker" vs "N workers")
- Cleaned up unused Badge import

## Benefits

1. **More immediate visibility** - Count is always visible, even when 0
2. **Cleaner UI** - Simpler text presentation without badge wrapper
3. **Proper grammar** - Handles singular/plural forms correctly
4. **Consistent styling** - Matches other buttons in the header

## Test Plan

- [ ] Display shows "0 workers" when no workers are active
- [ ] Display shows "1 worker" (singular) when exactly one worker is active
- [ ] Display shows "N workers" (plural) when multiple workers are active
- [ ] Popover still works correctly when clicking the button
- [ ] Visual appearance is clean and matches other header buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)