### PR TITLE
fix: remove all remaining any types from test code

### DIFF
--- a/spec/tech-debt.md
+++ b/spec/tech-debt.md
@@ -58,8 +58,8 @@ const userId = `test-user-{context}-${Date.now()}-${process.pid}`;
 ## TypeScript `any` Type Cleanup
 **Issue:** Several files still contain `any` types which compromise type safety and violate project standards.
 **Source:** Code review September 11-12, 2025
-**Status:** 🟡 **Partially Fixed** (3 violations remaining, down from 5)
-**Problem:** 
+**Status:** ✅ **RESOLVED** (October 25, 2025)
+**Problem:**
 - Project has zero tolerance for `any` types per design principles
 - `any` types disable TypeScript's type checking
 - Makes refactoring risky and error-prone
@@ -70,11 +70,11 @@ const userId = `test-user-{context}-${Date.now()}-${process.pid}`;
 **Production Code:** ✅ **FIXED** (September 12, 2025)
 - `/turbo/apps/web/app/projects/page.tsx` - Refactored to use standard fetch API instead of contractFetch with any
 
-**Test Code (3 violations remaining):**
+**Test Code:** ✅ **FIXED** (October 25, 2025)
 1. `/turbo/apps/workspace/custom-eslint/__tests__/rules.test.ts`
-   - Line 750: `type ToggleContext = { initContext$: any };`
-   - Line 833: `let context: any`
-   - Line 866: `let store: any, signal: any`
+   - ✅ Line 750: `type ToggleContext = { initContext$: any }` → `type ToggleContext = { initContext$: unknown }`
+   - ✅ Line 833: `let context: any` → `let context: ReturnType<typeof testContext>`
+   - ✅ Line 866: `let store: any, signal: any` → Proper type inference using `ReturnType<typeof testContext>['store']` and `ReturnType<typeof testContext>['signal']`
 
 **Solution:**
 1. **Use `unknown` for truly unknown types:**
@@ -442,7 +442,7 @@ beforeEach(async () => {
 ### Current State (October 2025)
 - Direct DB operations: **12 files** (down from 18+)
 - Test mock cleanup missing: **0 files** ✅ RESOLVED
-- TypeScript `any` violations: **3 test files** (down from 5, production code clean)
+- TypeScript `any` violations: **0** ✅ RESOLVED
 - Try-catch violations: **0** ✅ RESOLVED
 - Timer cleanup issues: **0** ✅ RESOLVED
 - Hardcoded URLs: **0** ✅ RESOLVED
@@ -452,9 +452,9 @@ beforeEach(async () => {
 
 ### Target State
 - Direct DB operations: **0 files**
-- Test mock cleanup: **100% coverage**
-- TypeScript `any` violations: **0**
-- MSW unhandled requests: **0 warnings** (all handlers properly configured)
+- ~~Test mock cleanup: **100% coverage**~~ ✅ ACHIEVED
+- ~~TypeScript `any` violations: **0**~~ ✅ ACHIEVED
+- ~~MSW unhandled requests: **0 warnings**~~ ✅ ACHIEVED (all handlers properly configured)
 - ~~Try-catch violations: **0 unnecessary blocks**~~ ✅ ACHIEVED
 - ~~Hardcoded URLs: **0**~~ ✅ ACHIEVED
 - ~~Database test isolation: **Transaction-based with rollback**~~ ✅ ACHIEVED (via unique IDs)
@@ -491,15 +491,15 @@ beforeEach(async () => {
 
 ### Major Achievements:
 1. **Database Test Isolation** ✅ - Implemented unique user IDs to prevent race conditions (PR #261)
-2. **Production Code Type Safety** ✅ - Removed all `any` types from production code
+2. **Production Code Type Safety** ✅ - Removed all `any` types from production code (September 12, 2025)
 3. **Hardcoded URLs** ✅ - All URLs now use centralized configuration (PR #259)
 4. **Try-Catch Cleanup** ✅ - Removed unnecessary defensive programming patterns
 5. **Test Mock Cleanup** ✅ - Added `vi.clearAllMocks()` to all 17 test files (PR #272)
 6. **MSW Unhandled Requests** ✅ - Standardized configuration to "error" mode across all packages (October 22, 2025)
 7. **Flaky E2E Tests** ✅ - Implemented proper deployment readiness checks in CI workflow (October 22, 2025)
+8. **Test Code Type Safety** ✅ - Removed all `any` types from test code (October 25, 2025)
 
 ### Remaining Work:
-- **Test Code `any` Types** - 3 violations in test files (low priority)
 - **Direct DB Operations in Tests** - 12 files need refactoring to use API endpoints
 
 ### Impact:
@@ -511,4 +511,4 @@ The most critical technical debt items have been resolved, significantly improvi
 
 ---
 
-*Last updated: 2025-10-22*
+*Last updated: 2025-10-25*

--- a/turbo/apps/workspace/custom-eslint/__tests__/rules.test.ts
+++ b/turbo/apps/workspace/custom-eslint/__tests__/rules.test.ts
@@ -747,7 +747,7 @@ ruleTester.run('no-get-signal', noGetSignal, {
       name: 'get nested AbortSignal in Map',
       code: `
             import { state, command } from 'ccstate';
-            type ToggleContext = { initContext$: any };
+            type ToggleContext = { initContext$: unknown };
             const contextMap$ = state(new Map<string, ToggleContext>());
             command(({get}) => {
                 const map = get(contextMap$)
@@ -830,7 +830,7 @@ ruleTester.run('test-context-in-hooks', testContextInHooks, {
       code: `
             import { testContext } from '../../__tests__/app-context'
             describe('test suite', () => {
-                let context: any
+                let context: ReturnType<typeof testContext>
                 beforeEach(() => {
                     context = testContext()
                 })
@@ -863,7 +863,8 @@ ruleTester.run('test-context-in-hooks', testContextInHooks, {
       code: `
             import { testContext } from '../../__tests__/app-context'
             describe('test suite', () => {
-                let store: any, signal: any
+                let store: ReturnType<typeof testContext>['store']
+                let signal: ReturnType<typeof testContext>['signal']
                 beforeEach(() => {
                     const { store: s, signal: sig } = testContext()
                     store = s


### PR DESCRIPTION
## Summary
- Eliminated the last 3 `any` type violations in custom-eslint test file
- Achieved zero-any-types goal across the entire codebase (production + test code)
- Updated tech debt documentation to reflect completion

## Changes Made
- **Line 750**: Replaced `type ToggleContext = { initContext$: any }` with `type ToggleContext = { initContext$: unknown }`
- **Line 833**: Replaced `let context: any` with `let context: ReturnType<typeof testContext>`
- **Line 866**: Replaced `let store: any, signal: any` with proper indexed access types using `ReturnType<typeof testContext>['store']` and `ReturnType<typeof testContext>['signal']`

## Impact
- ✅ Achieves project's zero-tolerance goal for `any` types
- ✅ Improves type safety in test code
- ✅ Better IDE support and autocomplete in test files
- ✅ Reduces maintenance burden by catching type errors at compile time

## Test Results
- All 106 tests in the modified file pass
- TypeScript type checking passes for entire monorepo
- Lint checks pass

## Related Documentation
- Updated `/spec/tech-debt.md` to mark TypeScript `any` Type Cleanup as ✅ RESOLVED
- This closes one of the remaining technical debt items from Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)