### PR TITLE
chore: optimize knip configuration

### DIFF
--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -27,8 +27,7 @@
     },
     "apps/docs": {
       "entry": ["source.config.ts"],
-      "project": ["**/*.{ts,tsx,mdx,js,mjs}"],
-      "ignoreBinaries": ["fumadocs-mdx"]
+      "project": ["**/*.{ts,tsx,mdx,js,mjs}"]
     },
     "apps/workspace": {
       "entry": [


### PR DESCRIPTION
## Summary
- Remove `fumadocs-mdx` from `ignoreBinaries` in apps/docs workspace configuration
- Clean up unnecessary knip configuration as flagged by knip analysis

## Changes
- Modified `turbo/knip.json` to remove `ignoreBinaries` configuration for apps/docs

## Testing
- ✅ Verified `pnpm knip` runs successfully with no warnings
- ✅ Configuration optimized per knip's recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)