### PR TITLE
docs: correct false positive regarding workspace legacy code

### DIFF
--- a/spec/tech-debt.md
+++ b/spec/tech-debt.md
@@ -742,27 +742,49 @@ jobs:
 
 ---
 
-### 🟡 MEDIUM: Legacy Workspace Code (45 files)
-**Issue:** Unused files from old workspace app implementation
+### ✅ RESOLVED: Legacy Workspace Code (FALSE ALARM)
+**Issue:** Originally reported as unused files from old workspace app implementation
 **Location:** `/turbo/apps/workspace/`
-**Status:** 🟡 **NEW MEDIUM ISSUE**
+**Status:** ✅ **RESOLVED - NOT LEGACY CODE**
 **Discovery Date:** January 25, 2025
+**Resolution Date:** October 25, 2025
 
-**Files:**
+**Originally Reported Files:**
 - 12 custom ESLint rules (~3,109 lines)
 - 18 signal-related state management files
 - Mock handlers, vite configs, test utilities
 
+**Resolution:**
+After thorough investigation, these files are **actively used** and part of the core architecture:
+
+1. **Custom ESLint Rules** ✅ ACTIVELY USED
+   - Enabled in `eslint.config.ts` via `customPlugin`
+   - Enforce ccstate best practices (signal naming, async patterns, etc.)
+   - Rules like `custom/no-package-variable` and `custom/signal-check-await` are active
+
+2. **Signals Directory** ✅ ACTIVELY USED
+   - Core state management using ccstate pattern
+   - Used by all major components: `project-page.tsx`, `markdown-editor.tsx`, etc.
+   - Implements reactive state with `State`, `Computed`, `Command` primitives
+
+3. **ccstate Dependencies** ✅ PRODUCTION DEPENDENCIES
+   - `ccstate` and `ccstate-react` are production dependencies (not dev)
+   - Actively imported and used throughout the codebase
+
+4. **Knip Analysis** ✅ ZERO UNUSED FILES
+   ```bash
+   $ pnpm knip -W apps/workspace
+   # Output: (empty - no issues found)
+   ```
+
+**Root Cause of Misidentification:**
+- Audit tool misinterpreted ccstate architecture pattern as legacy code
+- High file count and unfamiliar state management pattern triggered false positive
+- No actual unused code analysis was performed
+
 **Impact:**
-- Increases repository size
-- Confuses new developers
-- Maintenance burden
-
-**Recommendation:**
-- Archive to legacy folder or delete
-- Run `pnpm knip --workspace apps/workspace --fix --allow-remove-files`
-
-**Priority:** MEDIUM - Can be done incrementally
+- No action needed - these are essential files
+- Removing them would break the workspace application
 
 ---
 
@@ -790,10 +812,10 @@ jobs:
 | Severity | Count | Category |
 |----------|-------|----------|
 | 🔴 Critical | 1 | CI/CD (1) |
-| 🟡 Medium | 3 | Configuration (1), Testing (1), Code Cleanup (1) |
+| 🟡 Medium | 2 | Configuration (1), Testing (1) |
 | 🟢 Low | 1 | CI/CD (1) |
-| ✅ Resolved | 2 | Performance (1), Error Handling (1) |
-| **Total** | **7** | **5 open issues, 2 resolved** |
+| ✅ Resolved | 3 | Performance (1), Error Handling (1), False Positive (1) |
+| **Total** | **7** | **4 open issues, 3 resolved** |
 
 ### Files Requiring Immediate Attention
 1. `.github/workflows/*.yml` (3 files) - Hardcoded image tags
@@ -823,10 +845,10 @@ jobs:
 7. **Refactor MSW mocking** - Replace global.fetch with MSW handlers
 
 ### Backlog (When Time Permits)
-8. **Clean up workspace legacy code** - Archive or delete 45 files
-9. **Optimize CI/CD** - Remove duplicate installations, add retry logic
+8. **Optimize CI/CD** - Remove duplicate installations, add retry logic
 
 ---
 
-*Last updated: 2025-01-25*
+*Last updated: 2025-10-25*
 *Comprehensive audit completed: 2025-01-25*
+*Latest revision: 2025-10-25 - Corrected false positive regarding workspace code*


### PR DESCRIPTION
## Summary

- Corrected false positive in technical debt audit from January 2025
- Verified workspace code (custom ESLint rules, signals) is actively used
- Updated issue statistics to reflect accurate state

## Details

The January 2025 comprehensive audit incorrectly identified 45 workspace files as "legacy code" that should be removed. After thorough investigation, these files are confirmed to be **actively used** and essential to the workspace application:

### Evidence of Active Usage

1. **Custom ESLint Rules** (12 files, ~3,109 lines)
   - Enabled in `eslint.config.ts` via `customPlugin`
   - Enforce ccstate best practices (signal naming, async patterns)
   - Rules like `custom/no-package-variable` and `custom/signal-check-await` are active

2. **Signals Directory** (18 files)
   - Core state management using ccstate pattern
   - Used by all major components: `project-page.tsx`, `markdown-editor.tsx`, etc.
   - Implements reactive state with `State`, `Computed`, `Command` primitives

3. **Production Dependencies**
   - `ccstate` and `ccstate-react` are production dependencies (not dev)
   - Actively imported throughout the codebase

4. **Knip Analysis**
   ```bash
   $ pnpm knip -W apps/workspace
   # Output: (empty - no issues found)
   ```

### Root Cause

The audit tool misinterpreted the ccstate architecture pattern as legacy code due to:
- High file count and unfamiliar state management pattern
- No actual unused code analysis was performed
- False positive from automated tooling

### Impact

- **Updated statistics**: Medium priority issues: 3 → 2, Resolved: 2 → 3
- **Removed from backlog**: "Clean up workspace legacy code" task
- **Prevented accidental deletion**: These files are essential to workspace app

## Test Plan

- [x] Verified custom ESLint rules are referenced in `eslint.config.ts`
- [x] Confirmed signals are imported by React components
- [x] Ran `pnpm knip -W apps/workspace` - zero unused files
- [x] Checked ccstate packages in production dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)