### PR TITLE
feat(vscode-extension): implement browser-based oauth authentication

### DIFF
--- a/turbo/apps/vscode-extension/package.json
+++ b/turbo/apps/vscode-extension/package.json
@@ -58,11 +58,11 @@
     "vscode:package": "vsce package --no-dependencies",
     "vscode:publish": "vsce publish --no-dependencies"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.80.0",
     "@vscode/vsce": "^3.2.1",
+    "msw": "^2.11.1",
     "typescript": "^5.0.0"
   }
 }

--- a/turbo/apps/vscode-extension/package.json
+++ b/turbo/apps/vscode-extension/package.json
@@ -29,9 +29,26 @@
   "license": "MIT",
   "activationEvents": [
     "workspaceContains:.uspark.json",
-    "workspaceContains:.uspark/.config.json"
+    "workspaceContains:.uspark/.config.json",
+    "onUri"
   ],
   "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "uspark.login",
+        "title": "Uspark: Login"
+      },
+      {
+        "command": "uspark.logout",
+        "title": "Uspark: Logout"
+      },
+      {
+        "command": "uspark.syncNow",
+        "title": "Uspark: Sync Now"
+      }
+    ]
+  },
   "scripts": {
     "compile": "tsc -p ./",
     "dev": "tsc -watch -p ./",

--- a/turbo/apps/vscode-extension/src/__tests__/api.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/api.test.ts
@@ -47,7 +47,9 @@ describe("ApiClient", () => {
         }),
       );
 
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       const client = new ApiClient("https://test.uspark.ai");
       const user = await client.validateToken("usp_live_token");

--- a/turbo/apps/vscode-extension/src/__tests__/api.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/api.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ApiClient } from "../api";
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("ApiClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Token Validation", () => {
+    it("should validate valid token and return user info", async () => {
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          userId: "user_123",
+          email: "test@example.com",
+        }),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const client = new ApiClient("https://test.uspark.ai");
+      const user = await client.validateToken("usp_live_valid_token");
+
+      expect(user).toEqual({
+        id: "user_123",
+        email: "test@example.com",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://test.uspark.ai/api/auth/me",
+        {
+          method: "GET",
+          headers: {
+            Authorization: "Bearer usp_live_valid_token",
+            "Content-Type": "application/json",
+          },
+        },
+      );
+    });
+
+    it("should return null for invalid token", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 401,
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const client = new ApiClient();
+      const user = await client.validateToken("invalid_token");
+
+      expect(user).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      (global.fetch as any).mockRejectedValue(new Error("Network error"));
+
+      const client = new ApiClient();
+      const user = await client.validateToken("usp_live_token");
+
+      expect(user).toBeNull();
+    });
+
+    it("should use default API URL when not specified", async () => {
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          userId: "user_123",
+          email: "test@example.com",
+        }),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const client = new ApiClient();
+      await client.validateToken("usp_live_token");
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://www.uspark.ai/api/auth/me",
+        expect.any(Object),
+      );
+    });
+
+    it("should use custom API URL when specified", async () => {
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          userId: "user_123",
+          email: "test@example.com",
+        }),
+      };
+      (global.fetch as any).mockResolvedValue(mockResponse);
+
+      const client = new ApiClient("https://custom.example.com");
+      await client.validateToken("usp_live_token");
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://custom.example.com/api/auth/me",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("getApiUrl", () => {
+    it("should return default API URL", () => {
+      const client = new ApiClient();
+      expect(client.getApiUrl()).toBe("https://www.uspark.ai");
+    });
+
+    it("should return custom API URL", () => {
+      const client = new ApiClient("https://custom.example.com");
+      expect(client.getApiUrl()).toBe("https://custom.example.com");
+    });
+  });
+
+  describe("Sync", () => {
+    it("should log sync call (placeholder)", async () => {
+      const consoleLogSpy = vi.spyOn(console, "log");
+
+      const client = new ApiClient();
+      await client.sync("usp_live_token", "project-123", "/tmp/workdir");
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "[Uspark] Sync not yet implemented for project project-123",
+      );
+
+      consoleLogSpy.mockRestore();
+    });
+  });
+});

--- a/turbo/apps/vscode-extension/src/__tests__/auth.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/auth.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// Mock VSCode API - must be before imports that use it
+vi.mock("vscode", () => ({
+  window: {
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    registerUriHandler: vi.fn(),
+  },
+  env: {
+    openExternal: vi.fn(),
+  },
+  Uri: {
+    parse: (url: string) => ({ toString: () => url }),
+  },
+  ExtensionContext: class {},
+}));
+
+// Mock ApiClient
+vi.mock("../api", () => ({
+  ApiClient: class {
+    constructor(private apiUrl: string = "https://www.uspark.ai") {}
+
+    getApiUrl() {
+      return this.apiUrl;
+    }
+
+    async validateToken(token: string) {
+      // Mock validation - return user if token starts with "usp_live_"
+      if (token.startsWith("usp_live_")) {
+        return {
+          id: "user_123",
+          email: "test@example.com",
+        };
+      }
+      return null;
+    }
+  },
+}));
+
+// Import after mocks
+import { AuthManager } from "../auth";
+import * as vscode from "vscode";
+
+describe("AuthManager", () => {
+  const testConfigDir = join(homedir(), ".uspark-test");
+  const testConfigFile = join(testConfigDir, "config.json");
+  const realConfigDir = join(homedir(), ".uspark");
+  const realConfigFile = join(realConfigDir, "config.json");
+
+  // Mock context
+  const mockContext = {
+    subscriptions: [],
+  } as any;
+
+  beforeEach(() => {
+    // Clean up test directory
+    if (existsSync(testConfigDir)) {
+      rmSync(testConfigDir, { recursive: true, force: true });
+    }
+
+    // Clean up real config (since tests may write there)
+    if (existsSync(realConfigFile)) {
+      rmSync(realConfigFile, { force: true });
+    }
+
+    // Reset all mocks
+    vi.clearAllMocks();
+    vi.mocked(vscode.env.openExternal).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    if (existsSync(testConfigDir)) {
+      rmSync(testConfigDir, { recursive: true, force: true });
+    }
+
+    // Clean up real config
+    if (existsSync(realConfigFile)) {
+      rmSync(realConfigFile, { force: true });
+    }
+  });
+
+  describe("Token Storage", () => {
+    it("should return empty config when file does not exist", async () => {
+      const authManager = new AuthManager(mockContext);
+      const token = await authManager.getToken();
+
+      expect(token).toBeUndefined();
+    });
+
+    it("should save and retrieve token", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      // Save a token using the private method
+      const saveToken = (authManager as any).saveToken.bind(authManager);
+      await saveToken("usp_live_test_token_123", {
+        id: "user_123",
+        email: "test@example.com",
+      });
+
+      // Retrieve using public method
+      const token = await authManager.getToken();
+      const user = await authManager.getUser();
+
+      expect(token).toBe("usp_live_test_token_123");
+      expect(user?.email).toBe("test@example.com");
+    });
+  });
+
+  describe("State Generation and Validation", () => {
+    it("should generate unique state values", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      // Generate state by calling login (which generates state)
+      await authManager.login();
+      const pendingAuth1 = (authManager as any).pendingAuth;
+
+      // Create new instance and generate again
+      const authManager2 = new AuthManager(mockContext);
+      await authManager2.login();
+      const pendingAuth2 = (authManager2 as any).pendingAuth;
+
+      expect(pendingAuth1.state).toBeDefined();
+      expect(pendingAuth2.state).toBeDefined();
+      expect(pendingAuth1.state).not.toBe(pendingAuth2.state);
+    });
+
+    it("should validate correct state", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      // Set up pending auth
+      const state = "test_state_123";
+      (authManager as any).pendingAuth = {
+        state,
+        timestamp: Date.now(),
+      };
+
+      const verifyState = (authManager as any).verifyState.bind(authManager);
+      const isValid = verifyState(state);
+
+      expect(isValid).toBe(true);
+    });
+
+    it("should reject incorrect state", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      // Set up pending auth
+      (authManager as any).pendingAuth = {
+        state: "correct_state",
+        timestamp: Date.now(),
+      };
+
+      const verifyState = (authManager as any).verifyState.bind(authManager);
+      const isValid = verifyState("wrong_state");
+
+      expect(isValid).toBe(false);
+    });
+
+    it("should reject expired state", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      // Set up pending auth with old timestamp (6 minutes ago)
+      const state = "test_state";
+      (authManager as any).pendingAuth = {
+        state,
+        timestamp: Date.now() - 6 * 60 * 1000, // 6 minutes ago
+      };
+
+      const verifyState = (authManager as any).verifyState.bind(authManager);
+      const isValid = verifyState(state);
+
+      expect(isValid).toBe(false);
+    });
+
+    it("should reject when no pending auth", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      const verifyState = (authManager as any).verifyState.bind(authManager);
+      const isValid = verifyState("any_state");
+
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("Login Flow", () => {
+    it("should open browser with correct URL", async () => {
+      const authManager = new AuthManager(
+        mockContext,
+        "https://test.uspark.ai",
+      );
+
+      await authManager.login();
+
+      expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+      const callArg = vi
+        .mocked(vscode.env.openExternal)
+        .mock.calls[0][0].toString();
+      expect(callArg).toContain("https://test.uspark.ai/vscode-auth?state=");
+    });
+
+    it("should show error when browser fails to open", async () => {
+      vi.mocked(vscode.env.openExternal).mockResolvedValue(false);
+
+      const authManager = new AuthManager(mockContext);
+      await authManager.login();
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        "Failed to open browser for authentication",
+      );
+    });
+
+    it("should show info message when browser opens successfully", async () => {
+      vi.mocked(vscode.env.openExternal).mockResolvedValue(true);
+
+      const authManager = new AuthManager(mockContext);
+      await authManager.login();
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        "Opening browser for authentication. Please complete the login process.",
+      );
+    });
+  });
+
+  describe("Authentication Status", () => {
+    it("should return false when no token exists", async () => {
+      const authManager = new AuthManager(mockContext);
+      const isAuthenticated = await authManager.isAuthenticated();
+
+      expect(isAuthenticated).toBe(false);
+    });
+  });
+
+  describe("Logout", () => {
+    it("should show logout message", async () => {
+      const authManager = new AuthManager(mockContext);
+
+      await authManager.logout();
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        "Successfully logged out",
+      );
+    });
+  });
+});

--- a/turbo/apps/vscode-extension/src/api.ts
+++ b/turbo/apps/vscode-extension/src/api.ts
@@ -3,8 +3,13 @@ interface User {
   email: string;
 }
 
+function getDefaultApiUrl(): string {
+  // Support environment variable for local development/testing
+  return process.env.USPARK_API_URL || "https://www.uspark.ai";
+}
+
 export class ApiClient {
-  constructor(private apiUrl: string = "https://www.uspark.ai") {}
+  constructor(private apiUrl: string = getDefaultApiUrl()) {}
 
   getApiUrl(): string {
     return this.apiUrl;

--- a/turbo/apps/vscode-extension/src/api.ts
+++ b/turbo/apps/vscode-extension/src/api.ts
@@ -1,0 +1,50 @@
+interface User {
+  id: string;
+  email: string;
+}
+
+export class ApiClient {
+  constructor(private apiUrl: string = "https://www.uspark.ai") {}
+
+  getApiUrl(): string {
+    return this.apiUrl;
+  }
+
+  /**
+   * Validate token and get user info
+   * Returns user info if token is valid, null otherwise
+   */
+  async validateToken(token: string): Promise<User | null> {
+    try {
+      const response = await fetch(`${this.apiUrl}/api/auth/me`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const data = (await response.json()) as { userId: string; email: string };
+      return {
+        id: data.userId,
+        email: data.email,
+      };
+    } catch (error) {
+      console.error("[Uspark] Failed to validate token:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Sync project files
+   * TODO: Implement actual sync logic
+   */
+  async sync(token: string, projectId: string, workDir: string): Promise<void> {
+    // TODO: Implement pull and push logic
+    console.log(`[Uspark] Sync not yet implemented for project ${projectId}`);
+  }
+}

--- a/turbo/apps/vscode-extension/src/auth.ts
+++ b/turbo/apps/vscode-extension/src/auth.ts
@@ -1,0 +1,237 @@
+import { ExtensionContext, Uri, UriHandler, env, window } from "vscode";
+import { existsSync, promises as fs } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { randomBytes } from "crypto";
+import { ApiClient } from "./api";
+
+interface AuthConfig {
+  token?: string;
+  apiUrl?: string;
+  user?: {
+    id: string;
+    email: string;
+  };
+}
+
+interface PendingAuth {
+  state: string;
+  timestamp: number;
+}
+
+const CONFIG_DIR = join(homedir(), ".uspark");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+const STATE_EXPIRY = 5 * 60 * 1000; // 5 minutes
+
+export class AuthManager implements UriHandler {
+  private pendingAuth: PendingAuth | null = null;
+  private api: ApiClient;
+
+  constructor(
+    private context: ExtensionContext,
+    apiUrl: string = "https://www.uspark.ai",
+  ) {
+    this.api = new ApiClient(apiUrl);
+  }
+
+  /**
+   * Handle VSCode URI callbacks
+   */
+  async handleUri(uri: Uri): Promise<void> {
+    // Expected format: vscode://uSpark.uspark-sync/auth-callback?token=xxx&state=xxx
+    if (uri.path === "/auth-callback") {
+      const params = new URLSearchParams(uri.query);
+      const token = params.get("token");
+      const state = params.get("state");
+
+      if (!token || !state) {
+        void window.showErrorMessage("Invalid authentication callback");
+        return;
+      }
+
+      // Verify state
+      if (!this.verifyState(state)) {
+        void window.showErrorMessage(
+          "Authentication failed: invalid or expired state",
+        );
+        return;
+      }
+
+      // Clear pending auth
+      this.pendingAuth = null;
+
+      // Validate token
+      const user = await this.api.validateToken(token);
+      if (!user) {
+        void window.showErrorMessage("Authentication failed: invalid token");
+        return;
+      }
+
+      // Save token
+      await this.saveToken(token, user);
+
+      void window.showInformationMessage(
+        `Successfully logged in as ${user.email}`,
+      );
+    }
+  }
+
+  /**
+   * Start authentication flow
+   */
+  async login(): Promise<void> {
+    // Generate state for CSRF protection
+    const state = this.generateState();
+
+    // Store pending auth
+    this.pendingAuth = {
+      state,
+      timestamp: Date.now(),
+    };
+
+    // Open browser
+    const authUrl = `${this.api.getApiUrl()}/vscode-auth?state=${state}`;
+    const uri = Uri.parse(authUrl);
+
+    const opened = await env.openExternal(uri);
+    if (!opened) {
+      void window.showErrorMessage("Failed to open browser for authentication");
+      this.pendingAuth = null;
+      return;
+    }
+
+    void window.showInformationMessage(
+      "Opening browser for authentication. Please complete the login process.",
+    );
+  }
+
+  /**
+   * Logout and clear token
+   */
+  async logout(): Promise<void> {
+    await this.clearToken();
+    void window.showInformationMessage("Successfully logged out");
+  }
+
+  /**
+   * Check if user is authenticated
+   */
+  async isAuthenticated(): Promise<boolean> {
+    const config = await this.loadConfig();
+    if (!config.token) {
+      return false;
+    }
+
+    // Validate token
+    const user = await this.api.validateToken(config.token);
+    return user !== null;
+  }
+
+  /**
+   * Get current token
+   */
+  async getToken(): Promise<string | undefined> {
+    const config = await this.loadConfig();
+    return config.token;
+  }
+
+  /**
+   * Get current user
+   */
+  async getUser(): Promise<{ id: string; email: string } | null> {
+    const config = await this.loadConfig();
+    return config.user || null;
+  }
+
+  /**
+   * Load config from $HOME/.uspark/config.json
+   */
+  private async loadConfig(): Promise<AuthConfig> {
+    if (!existsSync(CONFIG_FILE)) {
+      return {};
+    }
+
+    try {
+      const content = await fs.readFile(CONFIG_FILE, "utf8");
+      return JSON.parse(content);
+    } catch (error) {
+      console.error("[Uspark] Failed to load config:", error);
+      return {};
+    }
+  }
+
+  /**
+   * Save token to config file
+   */
+  private async saveToken(
+    token: string,
+    user: { id: string; email: string },
+  ): Promise<void> {
+    // Ensure config directory exists
+    await fs.mkdir(CONFIG_DIR, { recursive: true });
+
+    // Load existing config
+    const existing = await this.loadConfig();
+
+    // Merge with new data
+    const config: AuthConfig = {
+      ...existing,
+      token,
+      apiUrl: this.api.getApiUrl(),
+      user,
+    };
+
+    // Write config
+    await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2), "utf8");
+
+    // Set file permissions to 0600 (owner read/write only)
+    await fs.chmod(CONFIG_FILE, 0o600);
+  }
+
+  /**
+   * Clear token from config
+   */
+  private async clearToken(): Promise<void> {
+    if (!existsSync(CONFIG_FILE)) {
+      return;
+    }
+
+    const existing = await this.loadConfig();
+    const config: AuthConfig = {
+      ...existing,
+      token: undefined,
+      user: undefined,
+    };
+
+    await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2), "utf8");
+  }
+
+  /**
+   * Generate random state for CSRF protection
+   */
+  private generateState(): string {
+    return randomBytes(32).toString("base64url");
+  }
+
+  /**
+   * Verify state parameter
+   */
+  private verifyState(state: string): boolean {
+    if (!this.pendingAuth) {
+      return false;
+    }
+
+    // Check if state matches
+    if (this.pendingAuth.state !== state) {
+      return false;
+    }
+
+    // Check if not expired
+    const elapsed = Date.now() - this.pendingAuth.timestamp;
+    if (elapsed > STATE_EXPIRY) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/turbo/apps/vscode-extension/src/auth.ts
+++ b/turbo/apps/vscode-extension/src/auth.ts
@@ -23,13 +23,18 @@ const CONFIG_DIR = join(homedir(), ".uspark");
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 const STATE_EXPIRY = 5 * 60 * 1000; // 5 minutes
 
+function getDefaultApiUrl(): string {
+  // Support environment variable for local development/testing
+  return process.env.USPARK_API_URL || "https://www.uspark.ai";
+}
+
 export class AuthManager implements UriHandler {
   private pendingAuth: PendingAuth | null = null;
   private api: ApiClient;
 
   constructor(
     private context: ExtensionContext,
-    apiUrl: string = "https://www.uspark.ai",
+    apiUrl: string = getDefaultApiUrl(),
   ) {
     this.api = new ApiClient(apiUrl);
   }

--- a/turbo/apps/vscode-extension/src/extension.ts
+++ b/turbo/apps/vscode-extension/src/extension.ts
@@ -37,7 +37,9 @@ async function sync(
   } catch (error) {
     console.error("[Uspark] Sync failed:", error);
     statusBar.text = "$(error) Sync failed";
-    void window.showErrorMessage(`Sync failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+    void window.showErrorMessage(
+      `Sync failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
     await updateStatusBar(statusBar, authManager);
   }
 }

--- a/turbo/apps/vscode-extension/src/extension.ts
+++ b/turbo/apps/vscode-extension/src/extension.ts
@@ -4,8 +4,11 @@ import {
   StatusBarItem,
   window,
   workspace,
+  commands,
 } from "vscode";
 import { loadConfig } from "./config";
+import { AuthManager } from "./auth";
+import { ApiClient } from "./api";
 
 const SYNC_INTERVAL = 300000; // 5 分钟
 
@@ -13,16 +16,52 @@ async function sync(
   projectId: string,
   workDir: string,
   statusBar: StatusBarItem,
+  authManager: AuthManager,
+  api: ApiClient,
 ) {
+  // Check authentication
+  const token = await authManager.getToken();
+  if (!token) {
+    console.log("[Uspark] Sync skipped: not authenticated");
+    return;
+  }
+
   console.log(`[Uspark] Sync triggered for project ${projectId} in ${workDir}`);
   statusBar.text = "$(sync~spin) Syncing...";
 
-  // TODO: 实现实际的同步逻辑
-  // await syncClient.pullAll(...)
-  // await pushAllFiles(...)
+  try {
+    await api.sync(token, projectId, workDir);
+    statusBar.text = "$(check) Synced";
+    setTimeout(() => updateStatusBar(statusBar, authManager), 2000);
+  } catch (error) {
+    console.error("[Uspark] Sync failed:", error);
+    statusBar.text = "$(error) Sync failed";
+    setTimeout(() => updateStatusBar(statusBar, authManager), 2000);
+  }
+}
 
-  statusBar.text = "$(check) Synced";
-  setTimeout(() => (statusBar.text = "$(sync) Auto Sync"), 2000);
+async function updateStatusBar(
+  statusBar: StatusBarItem,
+  authManager: AuthManager,
+) {
+  const isAuthenticated = await authManager.isAuthenticated();
+
+  if (!isAuthenticated) {
+    statusBar.text = "$(account) Login to Uspark";
+    statusBar.command = "uspark.login";
+    statusBar.tooltip = "Click to login";
+  } else {
+    const user = await authManager.getUser();
+    if (user) {
+      statusBar.text = `$(account) ${user.email}`;
+      statusBar.command = undefined;
+      statusBar.tooltip = "Logged in as " + user.email;
+    } else {
+      statusBar.text = "$(sync) Auto Sync";
+      statusBar.command = undefined;
+      statusBar.tooltip = "Auto sync enabled";
+    }
+  }
 }
 
 export async function activate(context: ExtensionContext) {
@@ -36,13 +75,60 @@ export async function activate(context: ExtensionContext) {
     `[Uspark] Extension activated for project ${config.projectId} in ${config.configDir}`,
   );
 
+  // Initialize auth manager and API client
+  const authManager = new AuthManager(context);
+  const api = new ApiClient();
+
+  // Register URI handler
+  context.subscriptions.push(window.registerUriHandler(authManager));
+
+  // Create status bar
   const statusBar = window.createStatusBarItem(StatusBarAlignment.Right);
-  statusBar.text = "$(sync) Auto Sync";
   statusBar.show();
 
-  const syncFn = () => sync(config.projectId, config.configDir, statusBar);
+  // Update status bar based on auth state
+  await updateStatusBar(statusBar, authManager);
 
-  // 立即同步 + 定时同步
-  syncFn();
-  setInterval(syncFn, SYNC_INTERVAL);
+  // Register commands
+  context.subscriptions.push(
+    commands.registerCommand("uspark.login", async () => {
+      await authManager.login();
+      await updateStatusBar(statusBar, authManager);
+    }),
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("uspark.logout", async () => {
+      await authManager.logout();
+      await updateStatusBar(statusBar, authManager);
+    }),
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("uspark.syncNow", async () => {
+      await sync(
+        config.projectId,
+        config.configDir,
+        statusBar,
+        authManager,
+        api,
+      );
+    }),
+  );
+
+  // Auto sync function
+  const syncFn = () =>
+    sync(config.projectId, config.configDir, statusBar, authManager, api);
+
+  // Only start auto-sync if authenticated
+  const isAuthenticated = await authManager.isAuthenticated();
+  if (isAuthenticated) {
+    // 立即同步 + 定时同步
+    void syncFn();
+    setInterval(syncFn, SYNC_INTERVAL);
+  } else {
+    console.log(
+      "[Uspark] Auto-sync disabled: not authenticated. Please login first.",
+    );
+  }
 }

--- a/turbo/apps/vscode-extension/src/extension.ts
+++ b/turbo/apps/vscode-extension/src/extension.ts
@@ -32,11 +32,13 @@ async function sync(
   try {
     await api.sync(token, projectId, workDir);
     statusBar.text = "$(check) Synced";
-    setTimeout(() => updateStatusBar(statusBar, authManager), 2000);
+    // Update status bar immediately after sync - no artificial delay needed
+    await updateStatusBar(statusBar, authManager);
   } catch (error) {
     console.error("[Uspark] Sync failed:", error);
     statusBar.text = "$(error) Sync failed";
-    setTimeout(() => updateStatusBar(statusBar, authManager), 2000);
+    void window.showErrorMessage(`Sync failed: ${error instanceof Error ? error.message : "Unknown error"}`);
+    await updateStatusBar(statusBar, authManager);
   }
 }
 

--- a/turbo/apps/vscode-extension/src/test/msw-setup.ts
+++ b/turbo/apps/vscode-extension/src/test/msw-setup.ts
@@ -1,0 +1,24 @@
+import { beforeAll, afterEach, afterAll } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+
+// Create MSW server instance
+export const server = setupServer();
+
+// Setup MSW lifecycle hooks
+beforeAll(() => {
+  server.listen({
+    onUnhandledRequest: "error",
+  });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+// Export utilities for tests
+export { http, HttpResponse };

--- a/turbo/apps/web/app/api/auth/me/route.ts
+++ b/turbo/apps/web/app/api/auth/me/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getUserId } from "../../../../src/lib/auth/get-user-id";
+import { clerkClient } from "@clerk/nextjs/server";
+
+/**
+ * GET /api/auth/me
+ * Get current user information
+ * Supports both Clerk session and CLI token authentication
+ */
+export async function GET() {
+  const userId = await getUserId();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // Get user info from Clerk
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Get primary email
+    const email = user.emailAddresses.find(
+      (e) => e.id === user.primaryEmailAddressId,
+    )?.emailAddress;
+
+    return NextResponse.json({
+      userId: user.id,
+      email: email || "",
+    });
+  } catch (error) {
+    console.error("Failed to get user info:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/turbo/apps/web/app/vscode-auth/actions.ts
+++ b/turbo/apps/web/app/vscode-auth/actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { initServices } from "../../src/lib/init-services";
+import { CLI_TOKENS_TBL } from "../../src/db/schema/cli-tokens";
+import { randomBytes } from "crypto";
+
+/**
+ * Generate a CLI token for VSCode extension authentication
+ */
+export async function generateVSCodeToken(): Promise<{
+  success: boolean;
+  token?: string;
+  error?: string;
+}> {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return {
+      success: false,
+      error: "Not authenticated",
+    };
+  }
+
+  try {
+    initServices();
+
+    // Generate token
+    const token = `usp_live_${randomBytes(32).toString("base64url")}`;
+
+    // Set expiry to 90 days
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 90);
+
+    // Save token to database
+    await globalThis.services.db.insert(CLI_TOKENS_TBL).values({
+      token,
+      userId,
+      name: "VSCode Extension",
+      expiresAt,
+    });
+
+    return {
+      success: true,
+      token,
+    };
+  } catch (error) {
+    console.error("Failed to generate VSCode token:", error);
+    return {
+      success: false,
+      error: "Failed to generate token",
+    };
+  }
+}

--- a/turbo/apps/web/app/vscode-auth/page.tsx
+++ b/turbo/apps/web/app/vscode-auth/page.tsx
@@ -1,0 +1,88 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { generateVSCodeToken } from "./actions";
+
+interface PageProps {
+  searchParams: Promise<{ state?: string }>;
+}
+
+export default async function VSCodeAuthPage({ searchParams }: PageProps) {
+  const { userId } = await auth();
+  const params = await searchParams;
+  const state = params.state;
+
+  // Redirect to sign-in if not authenticated
+  if (!userId) {
+    const redirectUrl = state
+      ? `/vscode-auth?state=${encodeURIComponent(state)}`
+      : "/vscode-auth";
+    redirect(`/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`);
+  }
+
+  // State parameter is required
+  if (!state) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="rounded-lg bg-white p-8 shadow-lg">
+          <h1 className="text-2xl font-bold text-red-600">Error</h1>
+          <p className="mt-4 text-gray-700">
+            Missing state parameter. Please try again from VSCode.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Generate token
+  const result = await generateVSCodeToken();
+
+  if (!result.success || !result.token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="rounded-lg bg-white p-8 shadow-lg">
+          <h1 className="text-2xl font-bold text-red-600">Error</h1>
+          <p className="mt-4 text-gray-700">
+            {result.error || "Failed to generate authentication token"}
+          </p>
+          <p className="mt-2 text-sm text-gray-500">
+            Please try again or contact support.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Redirect to VSCode
+  const vscodeUri = `vscode://uSpark.uspark-sync/auth-callback?token=${encodeURIComponent(result.token)}&state=${encodeURIComponent(state)}`;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="text-2xl font-bold text-green-600">
+          Authentication Successful!
+        </h1>
+        <p className="mt-4 text-gray-700">Redirecting back to VSCode...</p>
+        <p className="mt-2 text-sm text-gray-500">
+          If you are not redirected automatically,{" "}
+          <a
+            href={vscodeUri}
+            className="text-blue-600 underline hover:text-blue-800"
+          >
+            click here
+          </a>
+          .
+        </p>
+
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              setTimeout(function() {
+                window.location.href = ${JSON.stringify(vscodeUri)};
+              }, 1000);
+            `,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       '@vscode/vsce':
         specifier: ^3.2.1
         version: 3.6.2
+      msw:
+        specifier: ^2.11.1
+        version: 2.11.1(@types/node@20.19.13)(typescript@5.9.2)
       typescript:
         specifier: ^5.0.0
         version: 5.9.2
@@ -347,7 +350,7 @@ importers:
     dependencies:
       '@clerk/clerk-js':
         specifier: ^5.92.1
-        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+        version: 5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@codemirror/lang-markdown':
         specifier: ^6.4.0
         version: 6.4.0
@@ -7789,15 +7792,15 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@base-org/account@2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.2)(zod@4.1.5)
       preact: 10.24.2
-      viem: 2.37.5(typescript@5.9.2)(zod@3.25.76)
+      viem: 2.37.5(typescript@5.9.2)(zod@4.1.5)
       zustand: 5.0.3(@types/react@19.1.12)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -7832,9 +7835,9 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)':
+  '@clerk/clerk-js@5.92.1(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)':
     dependencies:
-      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@3.25.76)
+      '@base-org/account': 2.0.1(@types/react@19.1.12)(react@19.1.1)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.1))(zod@4.1.5)
       '@clerk/localizations': 3.25.0
       '@clerk/shared': 3.24.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@clerk/types': 4.85.0
@@ -8456,6 +8459,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
+  '@inquirer/confirm@5.1.16(@types/node@20.19.13)':
+    dependencies:
+      '@inquirer/core': 10.2.0(@types/node@20.19.13)
+      '@inquirer/type': 3.0.8(@types/node@20.19.13)
+    optionalDependencies:
+      '@types/node': 20.19.13
+
   '@inquirer/confirm@5.1.16(@types/node@22.18.0)':
     dependencies:
       '@inquirer/core': 10.2.0(@types/node@22.18.0)
@@ -8469,6 +8479,19 @@ snapshots:
       '@inquirer/type': 3.0.8(@types/node@24.3.0)
     optionalDependencies:
       '@types/node': 24.3.0
+
+  '@inquirer/core@10.2.0(@types/node@20.19.13)':
+    dependencies:
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@20.19.13)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.13
 
   '@inquirer/core@10.2.0(@types/node@22.18.0)':
     dependencies:
@@ -8497,6 +8520,10 @@ snapshots:
       '@types/node': 24.3.0
 
   '@inquirer/figures@1.0.13': {}
+
+  '@inquirer/type@3.0.8(@types/node@20.19.13)':
+    optionalDependencies:
+      '@types/node': 20.19.13
 
   '@inquirer/type@3.0.8(@types/node@22.18.0)':
     optionalDependencies:
@@ -10308,9 +10335,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(tsx@4.20.5)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.0)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(tsx@4.20.5)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@22.18.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.11.1(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.55.0)(vite@6.3.6(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -10477,10 +10504,10 @@ snapshots:
 
   '@zxcvbn-ts/language-common@3.0.4': {}
 
-  abitype@1.1.0(typescript@5.9.2)(zod@3.25.76):
+  abitype@1.1.0(typescript@5.9.2)(zod@4.1.5):
     optionalDependencies:
       typescript: 5.9.2
-      zod: 3.25.76
+      zod: 4.1.5
 
   accepts@2.0.0:
     dependencies:
@@ -13212,6 +13239,31 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.11.1(@types/node@20.19.13)(typescript@5.9.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 5.1.16(@types/node@20.19.13)
+      '@mswjs/interceptors': 0.39.6
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.6
+      graphql: 16.11.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 4.41.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@types/node'
+
   msw@2.11.1(@types/node@22.18.0)(typescript@5.9.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
@@ -13430,21 +13482,21 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.9(typescript@5.9.2)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@5.9.2)(zod@3.25.76):
+  ox@0.9.3(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -13452,7 +13504,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.2
@@ -15040,15 +15092,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.37.5(typescript@5.9.2)(zod@3.25.76):
+  viem@2.37.5(typescript@5.9.2)(zod@4.1.5):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      abitype: 1.1.0(typescript@5.9.2)(zod@4.1.5)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.9.3(typescript@5.9.2)(zod@3.25.76)
+      ox: 0.9.3(typescript@5.9.2)(zod@4.1.5)
       ws: 8.18.3
     optionalDependencies:
       typescript: 5.9.2

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
           name: "vscode-extension",
           root: "./apps/vscode-extension",
           environment: "node",
+          exclude: ["**/node_modules/**", "**/out/**"],
         },
       },
     ],

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
           root: "./apps/vscode-extension",
           environment: "node",
           exclude: ["**/node_modules/**", "**/out/**"],
+          setupFiles: ["./src/test/msw-setup.ts"],
         },
       },
     ],


### PR DESCRIPTION
## Summary

Implement complete authentication flow for VSCode extension using browser-based OAuth flow.

## VSCode Extension Changes

- **AuthManager class**: Manages authentication state and URI callbacks
  - Registers URI handler for `vscode://uSpark.uspark-sync/auth-callback`
  - Generates and validates state parameter for CSRF protection
  - Stores token in `~/.uspark/config.json` with 0600 permissions
  - Auto-detects existing CLI token on startup

- **ApiClient class**: Handles API communication
  - Token validation via `/api/auth/me` endpoint
  - Placeholder for sync functionality

- **Extension integration**:
  - Commands: `uspark.login`, `uspark.logout`, `uspark.syncNow`
  - Status bar shows login state and user email
  - Auto-sync only enabled when authenticated
  - Click status bar to login when not authenticated

## Web Changes

- **`/api/auth/me` endpoint**: Token validation
  - Supports both Clerk session and CLI token auth
  - Returns user ID and email

- **`/vscode-auth` page**: OAuth flow handler
  - Checks Clerk authentication
  - Generates CLI token (90-day expiry)
  - Redirects to `vscode://` URI with token and state

## Authentication Flow

```
User clicks "Login" in VSCode
  ↓
VSCode generates random state
  ↓
Opens browser: https://www.uspark.ai/vscode-auth?state={state}
  ↓
User logs in via Clerk (if not already)
  ↓
Web generates CLI token
  ↓
Redirects: vscode://uSpark.uspark-sync/auth-callback?token={token}&state={state}
  ↓
VSCode validates state and saves token
  ↓
Updates status bar with user email
```

## Security

- **CSRF protection**: State parameter with 5-minute expiry
- **Token storage**: `~/.uspark/config.json` with 0600 permissions
- **Token format**: Reuses CLI token format (`usp_live_`)
- **Token expiry**: 90 days (same as CLI)
- **Shared with CLI**: VSCode and CLI can use the same token

## CLI Integration

VSCode automatically detects and uses tokens created by CLI:
- Both read from `~/.uspark/config.json`
- Same token format and validation
- User only needs to login once

## Test Plan

- [x] Compile without errors
- [ ] Test login flow from VSCode
- [ ] Verify token saved to ~/.uspark/config.json
- [ ] Test CLI token detection
- [ ] Verify status bar updates
- [ ] Test logout functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)