### PR TITLE
feat(core): add DocStore class for yjs document synchronization

### DIFF
--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -72,7 +72,8 @@
       "tsup": {
         "config": ["tsup.config.ts"]
       },
-      "ignoreDependencies": ["@vercel/blob"]
+      "ignoreDependencies": ["@vercel/blob"],
+      "ignoreBinaries": ["tsup"]
     },
     "apps/vscode-extension": {
       "entry": [],

--- a/turbo/packages/core/src/__tests__/doc-store.test.ts
+++ b/turbo/packages/core/src/__tests__/doc-store.test.ts
@@ -71,6 +71,88 @@ describe("DocStore", () => {
       expect(file).toBeDefined();
       expect(file?.hash).toBe("server-file-hash");
       expect(file?.mtime).toBe(1234567890);
+
+      // Assert: Should have version 42
+      expect(store.getVersion()).toBe(42);
+    });
+
+    it("should push local changes and update version", async () => {
+      // Step 1: First sync - GET to fetch initial state with version 42
+      const serverDoc = new Y.Doc();
+      const filesMap = serverDoc.getMap("files");
+      const blobsMap = serverDoc.getMap("blobs");
+
+      filesMap.set("src/app.ts", {
+        hash: "original-hash",
+        mtime: 1000000000,
+      });
+      blobsMap.set("original-hash", { size: 1024 });
+
+      server.use(
+        http.get("http://localhost/api/projects/:projectId", () => {
+          return new HttpResponse(Y.encodeStateAsUpdate(serverDoc), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "X-Version": "42",
+            },
+          });
+        }),
+      );
+
+      const store = new DocStore({
+        projectId: "test-project",
+        token: "test-token",
+        baseUrl: "http://localhost",
+      });
+
+      await store.sync(new AbortController().signal);
+
+      // Verify version 42
+      expect(store.getVersion()).toBe(42);
+      expect(store.getFile("src/app.ts")?.hash).toBe("original-hash");
+
+      // Step 2: Modify file locally
+      store.setFile("src/app.ts", "modified-hash", 2048);
+
+      // Step 3: Second sync - PATCH to push changes, get version 43
+      server.use(
+        http.patch(
+          "http://localhost/api/projects/:projectId",
+          async ({ request }) => {
+            // Verify headers
+            expect(request.headers.get("If-Match")).toBe("42");
+            expect(request.headers.get("Content-Type")).toBe(
+              "application/octet-stream",
+            );
+
+            // Read and apply the update to server doc
+            const updateBuffer = await request.arrayBuffer();
+            const update = new Uint8Array(updateBuffer);
+            Y.applyUpdate(serverDoc, update);
+
+            // Verify server doc now has the modified hash
+            const updatedFile = serverDoc.getMap("files").get("src/app.ts");
+            expect(updatedFile).toBeDefined();
+            expect((updatedFile as any).hash).toBe("modified-hash");
+
+            // Return updated state with new version
+            return new HttpResponse(Y.encodeStateAsUpdate(serverDoc), {
+              status: 200,
+              headers: {
+                "Content-Type": "application/octet-stream",
+                "X-Version": "43",
+              },
+            });
+          },
+        ),
+      );
+
+      await store.sync(new AbortController().signal);
+
+      // Step 4: Verify version is now 43
+      expect(store.getVersion()).toBe(43);
+      expect(store.getFile("src/app.ts")?.hash).toBe("modified-hash");
     });
   });
 });

--- a/turbo/packages/core/src/__tests__/doc-store.test.ts
+++ b/turbo/packages/core/src/__tests__/doc-store.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DocStore } from "../doc-store";
+import { server, http, HttpResponse } from "../test/msw-setup";
+import * as Y from "yjs";
+
+describe("DocStore", () => {
+  it("should get file after setFile", () => {
+    // Arrange
+    const store = new DocStore({
+      projectId: "test-project",
+      token: "test-token",
+    });
+
+    // Act
+    store.setFile("src/index.ts", "abc123hash", 1024);
+
+    // Assert
+    const file = store.getFile("src/index.ts");
+
+    expect(file).toBeDefined();
+    expect(file?.hash).toBe("abc123hash");
+    expect(file?.mtime).toBeGreaterThan(0);
+  });
+
+  describe("sync", () => {
+    beforeEach(() => {
+      server.resetHandlers();
+    });
+
+    it("should fetch file from server after sync", async () => {
+      // Arrange: Create a YJS document with a file
+      const serverDoc = new Y.Doc();
+      const filesMap = serverDoc.getMap("files");
+      const blobsMap = serverDoc.getMap("blobs");
+
+      filesMap.set("src/server.ts", {
+        hash: "server-file-hash",
+        mtime: 1234567890,
+      });
+      blobsMap.set("server-file-hash", { size: 2048 });
+
+      const serverState = Y.encodeStateAsUpdate(serverDoc);
+
+      // Mock the API endpoint
+      server.use(
+        http.get("http://localhost/api/projects/:projectId", ({ params }) => {
+          expect(params.projectId).toBe("test-project");
+
+          return new HttpResponse(serverState, {
+            status: 200,
+            headers: {
+              "Content-Type": "application/octet-stream",
+              "X-Version": "42",
+            },
+          });
+        }),
+      );
+
+      const store = new DocStore({
+        projectId: "test-project",
+        token: "test-token",
+        baseUrl: "http://localhost",
+      });
+
+      // Act: Sync with server
+      await store.sync(new AbortController().signal);
+
+      // Assert: Should have the file from server
+      const file = store.getFile("src/server.ts");
+
+      expect(file).toBeDefined();
+      expect(file?.hash).toBe("server-file-hash");
+      expect(file?.mtime).toBe(1234567890);
+    });
+  });
+});

--- a/turbo/packages/core/src/__tests__/doc-store.test.ts
+++ b/turbo/packages/core/src/__tests__/doc-store.test.ts
@@ -132,9 +132,11 @@ describe("DocStore", () => {
             Y.applyUpdate(serverDoc, update);
 
             // Verify server doc now has the modified hash
-            const updatedFile = serverDoc.getMap("files").get("src/app.ts");
+            const updatedFile = serverDoc
+              .getMap<{ hash: string; mtime: number }>("files")
+              .get("src/app.ts");
             expect(updatedFile).toBeDefined();
-            expect((updatedFile as any).hash).toBe("modified-hash");
+            expect(updatedFile?.hash).toBe("modified-hash");
 
             // Return updated state with new version
             return new HttpResponse(Y.encodeStateAsUpdate(serverDoc), {

--- a/turbo/packages/core/src/doc-store.ts
+++ b/turbo/packages/core/src/doc-store.ts
@@ -106,6 +106,8 @@ export class DocStore {
       // If diff is not empty, we have local changes
       if (diff.length > 0) {
         // PATCH: Push local changes to server
+        // Create a new Uint8Array to ensure we have an ArrayBuffer (not SharedArrayBuffer)
+        const body = new Uint8Array(diff);
         response = await fetch(url, {
           method: "PATCH",
           headers: {
@@ -113,7 +115,7 @@ export class DocStore {
             "Content-Type": "application/octet-stream",
             "If-Match": this.version.toString(),
           },
-          body: diff,
+          body,
           signal,
         });
       } else {

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -33,3 +33,5 @@ export type {
   YjsBlobConfig,
 } from "./yjs-filesystem/types";
 export * from "./utils/blocks";
+export { DocStore } from "./doc-store";
+export type { DocStoreConfig, FileNode, BlobInfo } from "./doc-store";

--- a/turbo/spec/tech-debt.md
+++ b/turbo/spec/tech-debt.md
@@ -1,0 +1,33 @@
+# Technical Debt
+
+This document tracks known technical debt in the codebase that should be addressed in future iterations.
+
+## ContractFetch Metadata Access
+
+**Created**: 2025-10-25
+
+**Problem**: The current `contractFetch` implementation only returns business data (response body) and doesn't expose response headers, status, or the Response object. This forces some call sites to use native `fetch` instead when they need access to response headers like `X-Version`.
+
+**Current Workaround**:
+- 3 call sites currently use native `fetch` to access response headers:
+  - `DocStore.sync()` - needs X-Version header
+  - `ProjectSync.syncFromRemote()` - needs X-Version header
+  - `ProjectSync.syncToRemote()` - needs X-Version header
+- 34+ other call sites use `contractFetch` successfully without needing headers
+
+**Proposed Solution**: Create a unified `withMeta` pattern for contractFetch that returns:
+```typescript
+{
+  data: T,
+  headers: Headers,
+  status: number
+}
+```
+
+**Migration Path**:
+1. Add new `contractFetchWithMeta` function (non-breaking)
+2. Gradually migrate the 3 call sites that need headers
+3. Consider whether to make metadata the default behavior
+4. Existing 34+ call sites can remain unchanged during migration
+
+**Impact**: Low urgency, but would improve API consistency and reduce the need for mixing `contractFetch` and native `fetch` in the codebase.

--- a/turbo/spec/tech-debt.md
+++ b/turbo/spec/tech-debt.md
@@ -9,6 +9,7 @@ This document tracks known technical debt in the codebase that should be address
 **Problem**: The current `contractFetch` implementation only returns business data (response body) and doesn't expose response headers, status, or the Response object. This forces some call sites to use native `fetch` instead when they need access to response headers like `X-Version`.
 
 **Current Workaround**:
+
 - 3 call sites currently use native `fetch` to access response headers:
   - `DocStore.sync()` - needs X-Version header
   - `ProjectSync.syncFromRemote()` - needs X-Version header
@@ -16,6 +17,7 @@ This document tracks known technical debt in the codebase that should be address
 - 34+ other call sites use `contractFetch` successfully without needing headers
 
 **Proposed Solution**: Create a unified `withMeta` pattern for contractFetch that returns:
+
 ```typescript
 {
   data: T,
@@ -25,6 +27,7 @@ This document tracks known technical debt in the codebase that should be address
 ```
 
 **Migration Path**:
+
 1. Add new `contractFetchWithMeta` function (non-breaking)
 2. Gradually migrate the 3 call sites that need headers
 3. Consider whether to make metadata the default behavior


### PR DESCRIPTION
## Summary

- Implement new `DocStore` class to manage YJS document and version state
- Add file operations: `setFile`, `getFile`, `deleteFile`, `getAllFiles`
- Add `getVersion()` method to expose current version number
- Implement bidirectional `sync()` method (pull + push)
- Add comprehensive tests with MSW mocking
- Document tech debt for unifying contractFetch metadata access

## Implementation Details

### DocStore Class
The `DocStore` class provides a simplified interface for managing YJS documents:

- **Constructor**: Takes `projectId`, `token`, and optional `baseUrl`
- **File operations**: Manage files in the YJS document's `files` map
- **Blob tracking**: Automatically updates the `blobs` map with file metadata
- **Version tracking**: `getVersion()` exposes the current version number
- **Sync method**: Bidirectional synchronization with server

### Sync Implementation (Bidirectional)

The sync method now supports both pull and push:

#### Pull (GET)
- First sync or when no local changes detected
- Calls GET `/api/projects/:projectId`
- Reads `X-Version` header to update local version
- Applies YJS update to local document

#### Push (PATCH)
- When local changes detected via YJS state vector diff
- Sends only the diff (incremental update) to server
- Includes `If-Match: <version>` header for optimistic locking
- Server returns updated document with new version

#### State Vector Tracking
- Saves `lastSyncStateVector` after each successful sync
- Uses YJS state vector diff to detect local changes efficiently
- No need to maintain separate `baseDoc` or `hasLocalChanges` flag

### Tech Debt Documentation
Added `spec/tech-debt.md` to track the need to unify contractFetch with a `withMeta` pattern that exposes headers and status.

## Test Plan

- ✅ Unit tests for file operations (setFile/getFile)
- ✅ Integration test for pull sync with version verification
- ✅ Integration test for bidirectional sync (pull → modify → push)
- ✅ Verify PATCH request includes correct headers (If-Match, Content-Type)
- ✅ Verify version updates from 42 to 43 after push
- ✅ All tests passing (3/3)

## Test Coverage

### Test 1: Basic file operations
```typescript
store.setFile("src/index.ts", "abc123hash", 1024);
expect(store.getFile("src/index.ts")?.hash).toBe("abc123hash");
```

### Test 2: Pull sync with version
```typescript
await store.sync(signal); // GET request
expect(store.getVersion()).toBe(42);
expect(store.getFile("src/server.ts")?.hash).toBe("server-file-hash");
```

### Test 3: Bidirectional sync
```typescript
// Step 1: First sync (GET)
await store.sync(signal);
expect(store.getVersion()).toBe(42);

// Step 2: Local modification
store.setFile("src/app.ts", "modified-hash", 2048);

// Step 3: Second sync (PATCH)
await store.sync(signal);
expect(store.getVersion()).toBe(43); // Version updated!
expect(store.getFile("src/app.ts")?.hash).toBe("modified-hash");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)