### PR TITLE
fix(vscode-extension): resolve typescript compilation error in auth tests

### DIFF
--- a/turbo/apps/vscode-extension/src/__tests__/auth.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/auth.test.ts
@@ -49,10 +49,10 @@ describe("AuthManager", () => {
   const realConfigDir = join(homedir(), ".uspark");
   const realConfigFile = join(realConfigDir, "config.json");
 
-  // Type-safe mock context
-  const mockContext: vscode.ExtensionContext = {
+  // Minimal mock context - AuthManager doesn't actually use context properties
+  const mockContext = {
     subscriptions: [],
-  } as vscode.ExtensionContext;
+  } as unknown as vscode.ExtensionContext;
 
   beforeEach(() => {
     // Clean up real config


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error (TS2352) that was blocking the VSCode extension from publishing to the marketplace.

## Problem

The release workflow was failing at the "Build VSCode Extension" step with:
```
error TS2352: Conversion of type '{ subscriptions: never[]; }' to type 'ExtensionContext' may be a mistake
```

This error was introduced in PR #761 when replacing `as any` with `as vscode.ExtensionContext` to address code quality issues.

## Solution

- Changed mock context type assertion to use `as unknown as vscode.ExtensionContext`
- This is safe because `AuthManager` doesn't actually use any `ExtensionContext` properties
- Added comment explaining why the minimal mock is acceptable

## Testing

- ✅ TypeScript compilation passes: `pnpm -F uspark-sync compile`
- ✅ All 19 tests pass: `pnpm vitest run --project vscode-extension`
- ✅ No functionality changes - only type assertion fix

## Related

- Fixes the build failure in https://github.com/uspark-hq/uspark/actions/runs/18800025621/job/53646173021
- Follow-up to PR #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)