### PR TITLE
refactor(vscode-extension): exclude test files from build compilation

### DIFF
--- a/turbo/apps/vscode-extension/tsconfig.json
+++ b/turbo/apps/vscode-extension/tsconfig.json
@@ -12,5 +12,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "out"]
+  "exclude": ["node_modules", "out", "src/__tests__", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Improves build configuration by excluding test files from TypeScript compilation.

## Problem

Currently, `tsconfig.json` includes all files under `src/**/*`, which means test files are compiled during the build process (`pnpm compile`). This:
- Slows down builds unnecessarily
- Can cause type errors in test-specific code to block builds
- Includes test code in build validation when it shouldn't be

## Solution

Added test files to `tsconfig.json` exclude:
```json
"exclude": ["node_modules", "out", "src/__tests__", "src/**/*.test.ts"]
```

## Benefits

✅ **Faster builds** - Test files not compiled during `pnpm compile`
✅ **Tests still work** - vitest has its own configuration
✅ **Cleaner separation** - Test code doesn't affect production builds
✅ **Better solution** - Makes PR #766 workaround unnecessary in hindsight

## Testing

- ✅ `pnpm -F uspark-sync compile` - Passes without compiling tests
- ✅ `pnpm vitest run --project vscode-extension` - All 19 tests still pass
- ✅ Test files are properly excluded from build output

## Related

- Follow-up improvement to PR #766
- This is the standard practice for VSCode extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)