### PR TITLE
fix(vscode-extension): activate extension on startup instead of config file presence

### DIFF
--- a/turbo/apps/vscode-extension/package.json
+++ b/turbo/apps/vscode-extension/package.json
@@ -28,9 +28,7 @@
   "homepage": "https://github.com/uspark-hq/uspark#readme",
   "license": "MIT",
   "activationEvents": [
-    "workspaceContains:.uspark.json",
-    "workspaceContains:.uspark/.config.json",
-    "onUri"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
## Problem

The VSCode extension wasn't activating for users after installation because it required workspace to contain `.uspark.json` or `.uspark/.config.json` files:

```json
"activationEvents": [
  "workspaceContains:.uspark.json",
  "workspaceContains:.uspark/.config.json",
  "onUri"
]
```

This created a chicken-and-egg problem:
- ❌ Users couldn't see the extension or login without config files
- ❌ Status bar didn't appear
- ❌ No way to initialize a project without manually creating config files
- ❌ Commands like "Uspark: Login" were inaccessible

## Solution

Changed activation to `onStartupFinished`:

```json
"activationEvents": [
  "onStartupFinished"
]
```

## Benefits

✅ **Extension activates immediately** - Works right after installation
✅ **Status bar always visible** - Shows authentication status
✅ **Login available** - Users can authenticate before creating projects
✅ **Better UX** - Natural workflow: Install → Login → Initialize Project
✅ **Follows best practices** - Standard for always-on VSCode extensions

## User Impact

**Before**: Install extension → See nothing → Confused
**After**: Install extension → See status bar → Click to login → Start using

## Testing

- Install extension in clean workspace (no .uspark files)
- Extension should activate and show status bar
- "Uspark: Login" command should be available in command palette
- Status bar should show "Not logged in" state

## Related

- Fixes user report: "vscode 插件安装了 0.2.1，但是 output 中没有，状态栏也没出现"
- This will require a new release (v0.2.2) to reach users

🤖 Generated with [Claude Code](https://claude.com/claude-code)