### PR TITLE
fix(vscode-extension): correct brand name capitalization to uspark

### DIFF
--- a/turbo/apps/vscode-extension/README.md
+++ b/turbo/apps/vscode-extension/README.md
@@ -1,6 +1,6 @@
-# Uspark VSCode Extension
+# uSpark VSCode Extension
 
-Automatically sync workspace files with Uspark cloud.
+Automatically sync workspace files with uSpark cloud.
 
 ## Features
 

--- a/turbo/apps/vscode-extension/package.json
+++ b/turbo/apps/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uspark-sync",
-  "displayName": "Uspark Auto Sync",
-  "description": "Automatically sync workspace with Uspark - seamless file synchronization for your projects",
+  "displayName": "uSpark Auto Sync",
+  "description": "Automatically sync workspace with uSpark - seamless file synchronization for your projects",
   "version": "0.2.1",
   "publisher": "uSpark",
   "engines": {
@@ -35,15 +35,15 @@
     "commands": [
       {
         "command": "uspark.login",
-        "title": "Uspark: Login"
+        "title": "uSpark: Login"
       },
       {
         "command": "uspark.logout",
-        "title": "Uspark: Logout"
+        "title": "uSpark: Logout"
       },
       {
         "command": "uspark.syncNow",
-        "title": "Uspark: Sync Now"
+        "title": "uSpark: Sync Now"
       }
     ]
   },

--- a/turbo/apps/vscode-extension/src/__tests__/api.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/api.test.ts
@@ -56,7 +56,7 @@ describe("ApiClient", () => {
 
       expect(user).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[Uspark] Failed to validate token:",
+        "[uSpark] Failed to validate token:",
         expect.any(Error),
       );
 
@@ -125,7 +125,7 @@ describe("ApiClient", () => {
       await client.sync("usp_live_token", "project-123", "/tmp/workdir");
 
       expect(consoleLogSpy).toHaveBeenCalledWith(
-        "[Uspark] Sync not yet implemented for project project-123",
+        "[uSpark] Sync not yet implemented for project project-123",
       );
 
       consoleLogSpy.mockRestore();

--- a/turbo/apps/vscode-extension/src/api.ts
+++ b/turbo/apps/vscode-extension/src/api.ts
@@ -39,7 +39,7 @@ export class ApiClient {
         email: data.email,
       };
     } catch (error) {
-      console.error("[Uspark] Failed to validate token:", error);
+      console.error("[uSpark] Failed to validate token:", error);
       return null;
     }
   }
@@ -50,6 +50,6 @@ export class ApiClient {
    */
   async sync(token: string, projectId: string, workDir: string): Promise<void> {
     // TODO: Implement pull and push logic
-    console.log(`[Uspark] Sync not yet implemented for project ${projectId}`);
+    console.log(`[uSpark] Sync not yet implemented for project ${projectId}`);
   }
 }

--- a/turbo/apps/vscode-extension/src/auth.ts
+++ b/turbo/apps/vscode-extension/src/auth.ts
@@ -160,7 +160,7 @@ export class AuthManager implements UriHandler {
       const content = await fs.readFile(CONFIG_FILE, "utf8");
       return JSON.parse(content);
     } catch (error) {
-      console.error("[Uspark] Failed to load config:", error);
+      console.error("[uSpark] Failed to load config:", error);
       return {};
     }
   }

--- a/turbo/apps/vscode-extension/src/extension.ts
+++ b/turbo/apps/vscode-extension/src/extension.ts
@@ -22,11 +22,11 @@ async function sync(
   // Check authentication
   const token = await authManager.getToken();
   if (!token) {
-    console.log("[Uspark] Sync skipped: not authenticated");
+    console.log("[uSpark] Sync skipped: not authenticated");
     return;
   }
 
-  console.log(`[Uspark] Sync triggered for project ${projectId} in ${workDir}`);
+  console.log(`[uSpark] Sync triggered for project ${projectId} in ${workDir}`);
   statusBar.text = "$(sync~spin) Syncing...";
 
   try {
@@ -35,7 +35,7 @@ async function sync(
     // Update status bar immediately after sync - no artificial delay needed
     await updateStatusBar(statusBar, authManager);
   } catch (error) {
-    console.error("[Uspark] Sync failed:", error);
+    console.error("[uSpark] Sync failed:", error);
     statusBar.text = "$(error) Sync failed";
     void window.showErrorMessage(
       `Sync failed: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -51,7 +51,7 @@ async function updateStatusBar(
   const isAuthenticated = await authManager.isAuthenticated();
 
   if (!isAuthenticated) {
-    statusBar.text = "$(account) Login to Uspark";
+    statusBar.text = "$(account) Login to uSpark";
     statusBar.command = "uspark.login";
     statusBar.tooltip = "Click to login";
   } else {
@@ -69,17 +69,17 @@ async function updateStatusBar(
 }
 
 export async function activate(context: ExtensionContext) {
-  console.log("[Uspark] Extension activating...");
+  console.log("[uSpark] Extension activating...");
 
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
   const config = workspaceRoot ? await loadConfig(workspaceRoot) : null;
 
   if (config) {
     console.log(
-      `[Uspark] Project configured: ${config.projectId} in ${config.configDir}`,
+      `[uSpark] Project configured: ${config.projectId} in ${config.configDir}`,
     );
   } else {
-    console.log("[Uspark] No project configuration found");
+    console.log("[uSpark] No project configuration found");
   }
 
   // Initialize auth manager and API client
@@ -115,7 +115,7 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("uspark.syncNow", async () => {
       if (!config) {
         void window.showErrorMessage(
-          "No Uspark project configured in this workspace. Create a .uspark.json file first.",
+          "No uSpark project configured in this workspace. Create a .uspark.json file first.",
         );
         return;
       }
@@ -136,17 +136,17 @@ export async function activate(context: ExtensionContext) {
 
     const isAuthenticated = await authManager.isAuthenticated();
     if (isAuthenticated) {
-      console.log("[Uspark] Starting auto-sync...");
+      console.log("[uSpark] Starting auto-sync...");
       void syncFn();
       setInterval(syncFn, SYNC_INTERVAL);
     } else {
       console.log(
-        "[Uspark] Auto-sync disabled: not authenticated. Please login first.",
+        "[uSpark] Auto-sync disabled: not authenticated. Please login first.",
       );
     }
   } else {
-    console.log("[Uspark] Auto-sync disabled: no project configuration.");
+    console.log("[uSpark] Auto-sync disabled: no project configuration.");
   }
 
-  console.log("[Uspark] Extension activated successfully");
+  console.log("[uSpark] Extension activated successfully");
 }


### PR DESCRIPTION
## Summary

Corrects brand name from "Uspark" to "uSpark" throughout the VSCode extension for consistency with company branding.

## Changes

✅ **Console logs**: `[Uspark]` → `[uSpark]`
✅ **Status bar**: "Login to Uspark" → "Login to uSpark"
✅ **Commands**: "Uspark: Login" → "uSpark: Login"
✅ **Package metadata**: Display name and description
✅ **README**: Title and description
✅ **Error messages**: All user-facing text

## Why

- Publisher is already "uSpark" (capital S)
- Inconsistent capitalization looks unprofessional
- Better brand identity and recognition

## Files Changed

- `src/extension.ts` - Console logs, status bar, error messages
- `src/api.ts` - Console logs
- `src/auth.ts` - Console logs  
- `src/__tests__/api.test.ts` - Test console output
- `package.json` - Display name, description, command titles
- `README.md` - Title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)