### PR TITLE
chore: add .uspark.config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,4 @@ settings.local.json
 vitest-report.json
 
 .uspark
+.uspark.config


### PR DESCRIPTION
## Summary
- Add .uspark.config to .gitignore to exclude local uspark configuration file

## Changes
- **.gitignore**: Add single line `.uspark.config`

## Test plan
- [ ] Verify .uspark.config files are not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)