### PR TITLE
feat(vscode-extension): add output logs, status menu, and multi-root support

### DIFF
--- a/turbo/apps/vscode-extension/package.json
+++ b/turbo/apps/vscode-extension/package.json
@@ -34,6 +34,10 @@
   "contributes": {
     "commands": [
       {
+        "command": "uspark.showMenu",
+        "title": "uSpark: Show Menu"
+      },
+      {
         "command": "uspark.login",
         "title": "uSpark: Login"
       },

--- a/turbo/apps/vscode-extension/src/__tests__/api.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/api.test.ts
@@ -1,6 +1,32 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ApiClient } from "../api";
 import { http, HttpResponse, server } from "../test/msw-setup";
+
+// Mock vscode
+vi.mock("vscode", () => ({
+  window: {
+    createOutputChannel: vi.fn(() => ({
+      appendLine: vi.fn(),
+      show: vi.fn(),
+      dispose: vi.fn(),
+    })),
+  },
+}));
+
+// Mock logger
+vi.mock("../logger", () => ({
+  logger: {
+    init: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    show: vi.fn(),
+    dispose: vi.fn(),
+  },
+}));
+
+import { ApiClient } from "../api";
+import { logger } from "../logger";
 
 describe("ApiClient", () => {
   beforeEach(() => {
@@ -47,20 +73,14 @@ describe("ApiClient", () => {
         }),
       );
 
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
       const client = new ApiClient("https://test.uspark.ai");
       const user = await client.validateToken("usp_live_token");
 
       expect(user).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[uSpark] Failed to validate token:",
+      expect(logger.error).toHaveBeenCalledWith(
+        "Failed to validate token",
         expect.any(Error),
       );
-
-      consoleErrorSpy.mockRestore();
     });
 
     it("should use default API URL when not specified", async () => {
@@ -119,16 +139,12 @@ describe("ApiClient", () => {
 
   describe("Sync", () => {
     it("should log sync call (placeholder)", async () => {
-      const consoleLogSpy = vi.spyOn(console, "log");
-
       const client = new ApiClient();
       await client.sync("usp_live_token", "project-123", "/tmp/workdir");
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        "[uSpark] Sync not yet implemented for project project-123",
+      expect(logger.info).toHaveBeenCalledWith(
+        "Sync not yet implemented for project project-123",
       );
-
-      consoleLogSpy.mockRestore();
     });
   });
 });

--- a/turbo/apps/vscode-extension/src/__tests__/config.test.ts
+++ b/turbo/apps/vscode-extension/src/__tests__/config.test.ts
@@ -1,6 +1,31 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
+
+// Mock vscode
+vi.mock("vscode", () => ({
+  window: {
+    createOutputChannel: vi.fn(() => ({
+      appendLine: vi.fn(),
+      show: vi.fn(),
+      dispose: vi.fn(),
+    })),
+  },
+}));
+
+// Mock logger
+vi.mock("../logger", () => ({
+  logger: {
+    init: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    show: vi.fn(),
+    dispose: vi.fn(),
+  },
+}));
+
 import { loadConfig } from "../config";
 
 describe("loadConfig", () => {

--- a/turbo/apps/vscode-extension/src/api.ts
+++ b/turbo/apps/vscode-extension/src/api.ts
@@ -1,3 +1,5 @@
+import { logger } from "./logger";
+
 interface User {
   id: string;
   email: string;
@@ -39,7 +41,7 @@ export class ApiClient {
         email: data.email,
       };
     } catch (error) {
-      console.error("[uSpark] Failed to validate token:", error);
+      logger.error("Failed to validate token", error);
       return null;
     }
   }
@@ -50,6 +52,6 @@ export class ApiClient {
    */
   async sync(token: string, projectId: string, workDir: string): Promise<void> {
     // TODO: Implement pull and push logic
-    console.log(`[uSpark] Sync not yet implemented for project ${projectId}`);
+    logger.info(`Sync not yet implemented for project ${projectId}`);
   }
 }

--- a/turbo/apps/vscode-extension/src/auth.ts
+++ b/turbo/apps/vscode-extension/src/auth.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { randomBytes } from "crypto";
 import { ApiClient } from "./api";
+import { logger } from "./logger";
 
 interface AuthConfig {
   token?: string;
@@ -173,7 +174,7 @@ export class AuthManager implements UriHandler {
       const content = await fs.readFile(CONFIG_FILE, "utf8");
       return JSON.parse(content);
     } catch (error) {
-      console.error("[uSpark] Failed to load config:", error);
+      logger.error("Failed to load config", error);
       return {};
     }
   }

--- a/turbo/apps/vscode-extension/src/config.ts
+++ b/turbo/apps/vscode-extension/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { join, dirname } from "path";
+import { logger } from "./logger";
 
 interface Config {
   projectId: string;
@@ -15,8 +16,12 @@ export async function loadConfig(
     join(workspaceRoot, ".uspark", ".config.json"),
   ];
 
+  logger.info(`Looking for config files in: ${workspaceRoot}`);
+
   for (const configPath of paths) {
+    logger.info(`Checking: ${configPath}`);
     if (existsSync(configPath)) {
+      logger.info(`Found config file: ${configPath}`);
       const content = readFileSync(configPath, "utf8");
       const config = JSON.parse(content);
       return {
@@ -27,5 +32,6 @@ export async function loadConfig(
     }
   }
 
+  logger.info("No config file found in any of the checked paths");
   return null;
 }

--- a/turbo/apps/vscode-extension/src/extension.ts
+++ b/turbo/apps/vscode-extension/src/extension.ts
@@ -6,9 +6,11 @@ import {
   workspace,
   commands,
 } from "vscode";
+import { dirname } from "path";
 import { loadConfig } from "./config";
 import { AuthManager } from "./auth";
 import { ApiClient } from "./api";
+import { logger } from "./logger";
 
 const SYNC_INTERVAL = 300000; // 5 分钟
 
@@ -22,20 +24,21 @@ async function sync(
   // Check authentication
   const token = await authManager.getToken();
   if (!token) {
-    console.log("[uSpark] Sync skipped: not authenticated");
+    logger.info("Sync skipped: not authenticated");
     return;
   }
 
-  console.log(`[uSpark] Sync triggered for project ${projectId} in ${workDir}`);
+  logger.info(`Sync triggered for project ${projectId} in ${workDir}`);
   statusBar.text = "$(sync~spin) Syncing...";
 
   try {
     await api.sync(token, projectId, workDir);
     statusBar.text = "$(check) Synced";
+    logger.info("Sync completed successfully");
     // Update status bar immediately after sync - no artificial delay needed
     await updateStatusBar(statusBar, authManager);
   } catch (error) {
-    console.error("[uSpark] Sync failed:", error);
+    logger.error("Sync failed", error);
     statusBar.text = "$(error) Sync failed";
     void window.showErrorMessage(
       `Sync failed: ${error instanceof Error ? error.message : "Unknown error"}`,
@@ -50,36 +53,66 @@ async function updateStatusBar(
 ) {
   const isAuthenticated = await authManager.isAuthenticated();
 
+  // Always show icon only, click to open menu
+  statusBar.text = "$(sync)";
+  statusBar.command = "uspark.showMenu";
+
   if (!isAuthenticated) {
-    statusBar.text = "$(account) Login to uSpark";
-    statusBar.command = "uspark.login";
-    statusBar.tooltip = "Click to login";
+    statusBar.tooltip = "uSpark (not logged in) - Click for options";
   } else {
     const user = await authManager.getUser();
     if (user) {
-      statusBar.text = `$(account) ${user.email}`;
-      statusBar.command = undefined;
-      statusBar.tooltip = "Logged in as " + user.email;
+      statusBar.tooltip = `uSpark (${user.email}) - Click for options`;
     } else {
-      statusBar.text = "$(sync) Auto Sync";
-      statusBar.command = undefined;
-      statusBar.tooltip = "Auto sync enabled";
+      statusBar.tooltip = "uSpark - Click for options";
     }
   }
 }
 
 export async function activate(context: ExtensionContext) {
-  console.log("[uSpark] Extension activating...");
+  // Initialize logger
+  logger.init();
+  logger.info("Extension activating...");
 
-  const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
-  const config = workspaceRoot ? await loadConfig(workspaceRoot) : null;
+  let config: Awaited<ReturnType<typeof loadConfig>> = null;
 
-  if (config) {
-    console.log(
-      `[uSpark] Project configured: ${config.projectId} in ${config.configDir}`,
-    );
-  } else {
-    console.log("[uSpark] No project configuration found");
+  // First, try to find config in workspace file directory (for multi-root workspaces)
+  if (workspace.workspaceFile) {
+    const workspaceFilePath = workspace.workspaceFile.fsPath;
+    logger.info(`Workspace file: ${workspaceFilePath}`);
+
+    // Get the directory containing the .code-workspace file
+    const workspaceDir = dirname(workspaceFilePath);
+    logger.info(`Checking workspace directory: ${workspaceDir}`);
+
+    config = await loadConfig(workspaceDir);
+    if (config) {
+      logger.info(
+        `Project configured: ${config.projectId} in ${config.configDir}`,
+      );
+    }
+  }
+
+  // If not found, try all workspace folders
+  if (!config) {
+    const folders = workspace.workspaceFolders || [];
+    logger.info(`Found ${folders.length} workspace folder(s)`);
+
+    for (const folder of folders) {
+      const folderPath = folder.uri.fsPath;
+      logger.info(`Checking workspace folder: ${folderPath}`);
+      config = await loadConfig(folderPath);
+      if (config) {
+        logger.info(
+          `Project configured: ${config.projectId} in ${config.configDir}`,
+        );
+        break;
+      }
+    }
+  }
+
+  if (!config) {
+    logger.info("No project configuration found in workspace");
   }
 
   // Initialize auth manager and API client
@@ -100,6 +133,84 @@ export async function activate(context: ExtensionContext) {
   await updateStatusBar(statusBar, authManager);
 
   // Register commands (always available)
+  context.subscriptions.push(
+    commands.registerCommand("uspark.showMenu", async () => {
+      const isAuthenticated = await authManager.isAuthenticated();
+      const user = await authManager.getUser();
+
+      const items: { label: string; description?: string; action: string }[] =
+        [];
+
+      if (isAuthenticated && user) {
+        items.push({
+          label: "$(account) Logged in",
+          description: user.email,
+          action: "info",
+        });
+        items.push({
+          label: "$(sync) Sync Now",
+          description: "Manually trigger sync",
+          action: "sync",
+        });
+        items.push({
+          label: "$(sign-out) Logout",
+          description: "Sign out from uSpark",
+          action: "logout",
+        });
+      } else {
+        items.push({
+          label: "$(sign-in) Login",
+          description: "Sign in to uSpark",
+          action: "login",
+        });
+      }
+
+      items.push({
+        label: "$(output) Show Logs",
+        description: "Open uSpark output panel",
+        action: "showLogs",
+      });
+
+      const selected = await window.showQuickPick(items, {
+        placeHolder: "uSpark Actions",
+      });
+
+      if (selected) {
+        switch (selected.action) {
+          case "login":
+            await authManager.login();
+            await updateStatusBar(statusBar, authManager);
+            break;
+          case "logout":
+            await authManager.logout();
+            await updateStatusBar(statusBar, authManager);
+            break;
+          case "sync":
+            if (!config) {
+              void window.showErrorMessage(
+                "No uSpark project configured in this workspace. Create a .uspark.json file first.",
+              );
+            } else {
+              await sync(
+                config.projectId,
+                config.configDir,
+                statusBar,
+                authManager,
+                api,
+              );
+            }
+            break;
+          case "showLogs":
+            logger.show();
+            break;
+          case "info":
+            // Do nothing, just showing info
+            break;
+        }
+      }
+    }),
+  );
+
   context.subscriptions.push(
     commands.registerCommand("uspark.login", async () => {
       await authManager.login();
@@ -139,17 +250,20 @@ export async function activate(context: ExtensionContext) {
 
     const isAuthenticated = await authManager.isAuthenticated();
     if (isAuthenticated) {
-      console.log("[uSpark] Starting auto-sync...");
+      logger.info("Starting auto-sync...");
       void syncFn();
       setInterval(syncFn, SYNC_INTERVAL);
     } else {
-      console.log(
-        "[uSpark] Auto-sync disabled: not authenticated. Please login first.",
-      );
+      logger.info("Auto-sync disabled: not authenticated. Please login first.");
     }
   } else {
-    console.log("[uSpark] Auto-sync disabled: no project configuration.");
+    logger.info("Auto-sync disabled: no project configuration.");
   }
 
-  console.log("[uSpark] Extension activated successfully");
+  // Add logger cleanup on deactivation
+  context.subscriptions.push({
+    dispose: () => logger.dispose(),
+  });
+
+  logger.info("Extension activated successfully");
 }

--- a/turbo/apps/vscode-extension/src/logger.ts
+++ b/turbo/apps/vscode-extension/src/logger.ts
@@ -1,0 +1,76 @@
+import { window, OutputChannel } from "vscode";
+
+/**
+ * Logger for uSpark extension
+ * Outputs to VSCode Output panel under "uSpark" channel
+ */
+class Logger {
+  private channel: OutputChannel | null = null;
+
+  /**
+   * Initialize the logger (should be called once during activation)
+   */
+  init(): void {
+    if (!this.channel) {
+      this.channel = window.createOutputChannel("uSpark");
+    }
+  }
+
+  /**
+   * Show the output channel
+   */
+  show(): void {
+    this.channel?.show();
+  }
+
+  /**
+   * Log an info message
+   */
+  info(message: string): void {
+    const timestamp = new Date().toISOString();
+    this.channel?.appendLine(`[${timestamp}] [INFO] ${message}`);
+  }
+
+  /**
+   * Log an error message
+   */
+  error(message: string, error?: Error | unknown): void {
+    const timestamp = new Date().toISOString();
+    this.channel?.appendLine(`[${timestamp}] [ERROR] ${message}`);
+    if (error instanceof Error) {
+      this.channel?.appendLine(`  ${error.message}`);
+      if (error.stack) {
+        this.channel?.appendLine(`  ${error.stack}`);
+      }
+    } else if (error) {
+      this.channel?.appendLine(`  ${String(error)}`);
+    }
+  }
+
+  /**
+   * Log a warning message
+   */
+  warn(message: string): void {
+    const timestamp = new Date().toISOString();
+    this.channel?.appendLine(`[${timestamp}] [WARN] ${message}`);
+  }
+
+  /**
+   * Log a debug message
+   */
+  debug(message: string): void {
+    const timestamp = new Date().toISOString();
+    this.channel?.appendLine(`[${timestamp}] [DEBUG] ${message}`);
+  }
+
+  /**
+   * Dispose the output channel
+   */
+  dispose(): void {
+    this.channel?.dispose();
+    this.channel = null;
+  }
+}
+
+// Export singleton instance
+export const logger = new Logger();


### PR DESCRIPTION
## Summary

This PR improves the VSCode extension UX with three major enhancements:

### 1. Output Channel Logger 📋
- Created structured logger that outputs to VSCode Output panel
- Replaced all `console.log` with proper logger calls
- Users can now view extension logs under "uSpark" channel in Output panel
- Added timestamps and log levels (INFO, ERROR, WARN, DEBUG)

### 2. Interactive Status Bar Menu 🎯
- Optimized status bar to show only an icon (not text) for cleaner UI
- Clicking the icon opens a quick actions menu with:
  - Login/Logout
  - Sync Now (when logged in)
  - Show Logs
  - Current user info display
- Tooltip shows authentication status and user email

### 3. Multi-root Workspace Support 🗂️
- Extension now works correctly with VSCode multi-root workspaces
- Searches for config in workspace file directory first (highest priority)
- Falls back to searching all workspace folders
- Fixes issue where config wasn't found in `.code-workspace` projects

## Changes

**New Files:**
- `src/logger.ts` - Output channel logger implementation

**Modified Files:**
- `src/extension.ts` - Added menu, multi-root support, logger integration
- `src/config.ts` - Added debug logging for config discovery
- `src/auth.ts` - Replaced console.log with logger
- `src/api.ts` - Replaced console.log with logger
- `src/__tests__/api.test.ts` - Updated tests with logger mocks
- `src/__tests__/config.test.ts` - Added mocks for logger
- `package.json` - Added `uspark.showMenu` command

## Test Plan

- [x] All 19 unit tests pass
- [x] TypeScript compilation successful
- [x] Prettier and lint checks pass
- [x] Extension compiles and packages successfully
- [ ] Manual testing: Install VSIX and verify menu works
- [ ] Manual testing: Verify logs appear in Output panel
- [ ] Manual testing: Test in multi-root workspace
- [ ] Manual testing: Verify login/logout flow

## User Impact

**Before:**
- Status bar showed text like "Login to uSpark" or user email
- No way to see extension logs
- Config not found in multi-root workspaces

**After:**
- Clean icon-only status bar with tooltip
- Quick access menu for all actions
- Full debugging logs in Output panel
- Works in multi-root workspace configurations

## Screenshots

_TODO: Add screenshots of:_
- Status bar icon and tooltip
- Quick actions menu
- Output panel logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)