### PR TITLE
feat(core-node): add NodeFsDocStore minimal implementation

### DIFF
--- a/spec/polling-system.md
+++ b/spec/polling-system.md
@@ -302,3 +302,31 @@ function sleep(ms: number): Promise<void> {
 │    ↓                                                        │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+## NodeFsDocStore Implementation
+
+### Current Status
+✅ Minimal viable implementation complete:
+- [x] Basic class structure with DocStore integration
+- [x] Constructor accepts projectId, token, localDir, baseUrl
+- [x] sync(signal: AbortSignal) method that calls DocStore.sync()
+- [x] Basic test with MSW mocking
+- [x] Exported from @uspark/core-node package
+
+### Current Limitations
+- Only calls DocStore.sync() without any file system interaction
+- No local filesystem scanning or file operations
+- No blob upload/download implementation
+- No version tracking in local config file
+
+### Long-term Goal
+The `sync()` method should read version from a local config file and bidirectionally sync local filesystem changes with remote project:
+1. Read last synced version from local config file (e.g., `.uspark/config.json`)
+2. Scan local directory for file changes since last sync
+3. Pull remote changes from server (DocStore.sync)
+4. Upload new/modified local files as blobs
+5. Download new/modified remote files to local filesystem
+6. Handle file deletions (both local and remote)
+7. Update version in config file after successful sync
+
+This enables proper incremental sync based on version tracking.

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -95,6 +95,7 @@
     "./src/test/setup.ts",
     "./src/test/msw-setup.ts",
     "./src/test/db-setup.ts",
-    "./src/test/global-setup.ts"
+    "./src/test/global-setup.ts",
+    "../core/src/test/msw-setup.ts"
   ]
 }

--- a/turbo/packages/core-node/src/__tests__/node-fs-doc-store.test.ts
+++ b/turbo/packages/core-node/src/__tests__/node-fs-doc-store.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, beforeEach } from "vitest";
+import { NodeFsDocStore } from "../node-fs-doc-store";
+import { server, http, HttpResponse } from "@uspark/core/test/msw-setup";
+import * as Y from "yjs";
+
+describe("NodeFsDocStore", () => {
+  beforeEach(() => {
+    server.resetHandlers();
+  });
+
+  it("should construct and sync without error", async () => {
+    // Setup: Create empty server document
+    const serverDoc = new Y.Doc();
+    const serverState = Y.encodeStateAsUpdate(serverDoc);
+
+    // Mock API endpoint with MSW
+    server.use(
+      http.get("http://localhost/api/projects/:projectId", () => {
+        return new HttpResponse(serverState, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/octet-stream",
+            "X-Version": "1",
+          },
+        });
+      }),
+    );
+
+    // Test
+    const store = new NodeFsDocStore({
+      projectId: "my-project",
+      token: "auth-token",
+      localDir: "./my-files",
+      baseUrl: "http://localhost",
+    });
+
+    await store.sync(new AbortController().signal);
+
+    // If no error is thrown, test passes
+  });
+});

--- a/turbo/packages/core-node/src/index.ts
+++ b/turbo/packages/core-node/src/index.ts
@@ -1,6 +1,7 @@
 // Export Node.js-specific YJS filesystem utilities
 export { FileSystem } from "./filesystem";
 export { ProjectSync } from "./project-sync";
+export { NodeFsDocStore } from "./node-fs-doc-store";
 
 // Export Node.js-specific blob storage implementations
 export { VercelBlobStorage } from "./blob/vercel-blob-storage";

--- a/turbo/packages/core-node/src/node-fs-doc-store.ts
+++ b/turbo/packages/core-node/src/node-fs-doc-store.ts
@@ -1,0 +1,27 @@
+import { DocStore } from "@uspark/core";
+
+interface NodeFsDocStoreConfig {
+  projectId: string;
+  token: string;
+  localDir: string;
+  baseUrl?: string;
+}
+
+export class NodeFsDocStore {
+  private docStore: DocStore;
+  private localDir: string;
+
+  constructor(config: NodeFsDocStoreConfig) {
+    this.docStore = new DocStore({
+      projectId: config.projectId,
+      token: config.token,
+      baseUrl: config.baseUrl,
+    });
+    this.localDir = config.localDir;
+  }
+
+  async sync(signal: AbortSignal): Promise<void> {
+    // Minimal implementation: call DocStore's sync
+    await this.docStore.sync(signal);
+  }
+}

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
           name: "core-node",
           root: "./packages/core-node",
           environment: "node",
-          setupFiles: ["../core/src/test/msw-setup.ts"],
+          setupFiles: ["./packages/core/src/test/msw-setup.ts"],
         },
       },
 

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
           name: "core-node",
           root: "./packages/core-node",
           environment: "node",
-          setupFiles: ["./packages/core/src/test/msw-setup.ts"],
+          setupFiles: ["../core/src/test/msw-setup.ts"],
         },
       },
 

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
           name: "core-node",
           root: "./packages/core-node",
           environment: "node",
+          setupFiles: ["../core/src/test/msw-setup.ts"],
         },
       },
 


### PR DESCRIPTION
## Summary
Add initial NodeFsDocStore class for syncing local filesystem with remote projects.

## Changes
- Add NodeFsDocStore class with basic structure
- Constructor accepts `projectId`, `token`, `localDir`, `baseUrl`
- Implement `sync(signal: AbortSignal)` method using DocStore
- Add basic test with MSW mocking
- Export from `@uspark/core-node` package
- Configure vitest to use MSW setup for core-node tests
- Document implementation status and long-term goals in spec

## Current Implementation
Provides minimal viable structure with:
- Basic class that wraps DocStore
- Single `sync()` method that requires AbortSignal
- Test coverage using MSW

## Future Work
- Filesystem scanning and file operations
- Blob upload/download implementation
- Version tracking in local config file
- Full bidirectional sync between local and remote

## Test Plan
- [x] Unit test passes with MSW mocking
- [x] Exports correctly from package
- [x] TypeScript types are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)